### PR TITLE
fix: finalize pi-gremlins child runs on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `pi-gremlins` now finalizes child runs on process exit even if `close` never arrives, preserving terminal tool results and parent-session completion for exit-complete gremlin work.
+
 ### Changed
 - **Immersive Viewer UX and Theming** (PRD-0001, ADR-0001): Overhauled embedded and popup `pi-gremlins` presentation with shared status semantics, `viewerEntries`-driven summaries, clearer source/trust badges, compact live activity rows, narrow-layout hardening, and differentiated tool/result rendering.
 - README now leads with gremlin artwork and refreshed package presentation for the updated viewer experience.

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -750,6 +750,61 @@ describe("pi-gremlins execute streaming characterization", () => {
 		]);
 	});
 
+	test("single mode resolves buffered terminal output after child exit when close never arrives", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					JSON.stringify({
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: [{ type: "text", text: "final answer after exit" }],
+							usage: {
+								input: 3,
+								output: 2,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: { total: 0.01 },
+								totalTokens: 5,
+							},
+						},
+					}),
+				],
+				exitCode: 0,
+				exitDelay: 5,
+				omitClose: true,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const result = await Promise.race([
+			tool.execute(
+				"single-exit-without-close",
+				{ agent: "tars", task: "Finish and exit cleanly" },
+				undefined,
+				undefined,
+				createExecutionContext(workspace.repoRoot),
+			),
+			new Promise((_, reject) => {
+				setTimeout(() => {
+					reject(new Error("timed out waiting for child exit fallback"));
+				}, 250);
+			}),
+		]);
+
+		expect(result.content[0].text).toBe("final answer after exit");
+		expect(result.details.status).toBe("Completed");
+		expect(result.details.results[0]).toMatchObject({
+			agent: "tars",
+			exitCode: 0,
+		});
+	});
+
 	test("chain mode emits pending snapshots, previous substitution, and stops on error", async () => {
 		const workspace = createWorkspace();
 		workspaceRoot = workspace.root;

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -106,6 +106,7 @@ import {
 
 const MAX_PARALLEL_TASKS = 8;
 const MAX_CONCURRENCY = 4;
+const CHILD_PROCESS_EXIT_GRACE_MS = 50;
 const NO_INVOCATION_TEXT = "No pi-gremlins run available in this session.";
 const VIEWER_TITLE = "pi-gremlins mission control";
 
@@ -1578,6 +1579,21 @@ async function runSingleAgent(
 				}
 			};
 
+			let settled = false;
+			let observedExitCode: number | undefined;
+			let exitFallbackTimer: ReturnType<typeof setTimeout> | undefined;
+			let removeAbortListener: (() => void) | undefined;
+
+			const finalize = (code: number) => {
+				if (settled) return;
+				settled = true;
+				if (exitFallbackTimer) clearTimeout(exitFallbackTimer);
+				if (buffer.trim()) processLine(buffer);
+				buffer = "";
+				removeAbortListener?.();
+				resolve(code);
+			};
+
 			proc.stdout.on("data", (data) => {
 				buffer += data.toString();
 				const lines = buffer.split("\n");
@@ -1589,13 +1605,21 @@ async function runSingleAgent(
 				currentResult.stderr += data.toString();
 			});
 
+			proc.on("exit", (code) => {
+				if (settled) return;
+				observedExitCode = code ?? observedExitCode ?? 0;
+				if (exitFallbackTimer) clearTimeout(exitFallbackTimer);
+				exitFallbackTimer = setTimeout(() => {
+					finalize(observedExitCode ?? 0);
+				}, CHILD_PROCESS_EXIT_GRACE_MS);
+			});
+
 			proc.on("close", (code) => {
-				if (buffer.trim()) processLine(buffer);
-				resolve(code ?? 0);
+				finalize(code ?? observedExitCode ?? 0);
 			});
 
 			proc.on("error", () => {
-				resolve(1);
+				finalize(1);
 			});
 
 			if (signal) {
@@ -1606,8 +1630,14 @@ async function runSingleAgent(
 						if (!proc.killed) proc.kill("SIGKILL");
 					}, 5000);
 				};
-				if (signal.aborted) killProc();
-				else signal.addEventListener("abort", killProc, { once: true });
+				if (signal.aborted) {
+					killProc();
+				} else {
+					signal.addEventListener("abort", killProc, { once: true });
+					removeAbortListener = () => {
+						signal.removeEventListener("abort", killProc);
+					};
+				}
 			}
 		});
 

--- a/extensions/pi-gremlins/test-helpers.js
+++ b/extensions/pi-gremlins/test-helpers.js
@@ -34,7 +34,10 @@ export function createMockProcess({
 	stdoutChunks = [],
 	stderrChunks = [],
 	closeCode = 0,
+	exitCode = closeCode,
 	closeDelay,
+	exitDelay,
+	omitClose = false,
 	errorAt,
 } = {}) {
 	const proc = new EventEmitter();
@@ -54,6 +57,7 @@ export function createMockProcess({
 		];
 		const finalCloseDelay =
 			closeDelay ?? (allDelays.length > 0 ? Math.max(...allDelays) + 1 : 0);
+		const finalExitDelay = exitDelay ?? finalCloseDelay;
 
 		for (const event of stdoutEvents) {
 			setTimeout(() => {
@@ -71,8 +75,13 @@ export function createMockProcess({
 			}, errorAt);
 		}
 		setTimeout(() => {
-			proc.emit("close", closeCode);
-		}, finalCloseDelay);
+			proc.emit("exit", exitCode);
+		}, finalExitDelay);
+		if (!omitClose) {
+			setTimeout(() => {
+				proc.emit("close", closeCode);
+			}, finalCloseDelay);
+		}
 	});
 
 	return proc;


### PR DESCRIPTION
## Summary
- finalize gremlin child runs from `exit` with short grace period fallback when `close` never arrives
- flush buffered terminal output before resolving so parent session still records terminal tool results
- add regression coverage for exit-without-close behavior and document fix in changelog

## Root cause
`runSingleAgent()` only resolved on child process `close`. If child work completed and process exited but stdio `close` never arrived, `pi-gremlins` never returned a terminal tool result to parent session.

## Verification
- bun test extensions/pi-gremlins/index.execute.test.js -t "single mode resolves buffered terminal output after child exit when close never arrives"
- pnpm test
- pnpm typecheck
- pnpm check
- pnpm build *(fails: Command "build" not found)*
- pnpm lint *(fails: Command "lint" not found)*

Closes #1