### PR TITLE
fix: remap pi-gremlins shortcut affordances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pi-gremlins` now finalizes child runs on process exit even if `close` never arrives, preserving terminal tool results and parent-session completion for exit-complete gremlin work.
 
 ### Changed
+- Inline `pi-gremlins` expand hints now advertise `Alt+O`, and lair scroll-to-start/end aliases now use `Alt+↑` / `Alt+↓` while preserving `Home` / `End` support.
 - **Immersive Viewer UX and Theming** (PRD-0001, ADR-0001): Overhauled embedded and popup `pi-gremlins` presentation with shared status semantics, `viewerEntries`-driven summaries, clearer source/trust badges, compact live activity rows, narrow-layout hardening, and differentiated tool/result rendering.
 - README now leads with gremlin artwork and refreshed package presentation for the updated viewer experience.
 

--- a/extensions/pi-gremlins/agents.test.js
+++ b/extensions/pi-gremlins/agents.test.js
@@ -99,6 +99,7 @@ mock.module("@mariozechner/pi-tui", () => ({
 		up: "up",
 		down: "down",
 		ctrl: (key) => `ctrl-${key}`,
+		alt: (key) => `alt-${key}`,
 	},
 	Markdown: class {},
 	Spacer: class {},

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -89,6 +89,7 @@ mock.module("@mariozechner/pi-tui", () => ({
 		up: "up",
 		down: "down",
 		ctrl: (key) => `ctrl-${key}`,
+		alt: (key) => `alt-${key}`,
 	},
 	Markdown: class {
 		constructor(text) {

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -64,6 +64,7 @@ mock.module("@mariozechner/pi-tui", () => ({
 		up: "up",
 		down: "down",
 		ctrl: (key) => `ctrl-${key}`,
+		alt: (key) => `alt-${key}`,
 	},
 	Markdown: MockMarkdown,
 	Spacer: MockSpacer,
@@ -267,7 +268,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Completed] tars · single · [user]");
 		expect(text).toContain("digest · line 11");
 		expect(text).toContain("… 8 earlier events");
-		expect(text).toContain("Ctrl+O expands embedded view.");
+		expect(text).toContain("Alt+O expands embedded view.");
 		expect(text).toContain("usage · turns:2 · input:10 · output:20");
 		expect(text).not.toContain(
 			"viewer · /pi-gremlins:view opens mission control.",
@@ -703,7 +704,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Failed] step 2 · reviewer [user]");
 		expect(text).toContain("quiet · No output captured.");
 		expect(text).toContain("usage total · turns:3 · input:15 · output:12");
-		expect(text).toContain("Ctrl+O expands embedded view.");
+		expect(text).toContain("Alt+O expands embedded view.");
 	});
 
 	test("renders chain running and canceled states with semantic badges instead of failure markers", () => {
@@ -824,7 +825,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Completed] beta [user]");
 		expect(text).toContain("digest · beta complete");
 		expect(text).toContain("usage total · turns:1 · input:9 · output:3");
-		expect(text).toContain("Ctrl+O expands embedded view.");
+		expect(text).toContain("Alt+O expands embedded view.");
 	});
 
 	test("renders parallel completed collapsed state with explicit failure count and totals", () => {
@@ -862,7 +863,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("digest · alpha collapsed");
 		expect(text).toContain("digest · beta collapsed");
 		expect(text).toContain("usage total · turns:3 · input:10 · output:6");
-		expect(text).toContain("Ctrl+O expands embedded view.");
+		expect(text).toContain("Alt+O expands embedded view.");
 	});
 
 	test("reuses derived render cache for same revision and invalidates when messages append", () => {

--- a/extensions/pi-gremlins/index.viewer.test.js
+++ b/extensions/pi-gremlins/index.viewer.test.js
@@ -66,6 +66,7 @@ mock.module("@mariozechner/pi-tui", () => ({
 		up: "up",
 		down: "down",
 		ctrl: (key) => `ctrl-${key}`,
+		alt: (key) => `alt-${key}`,
 	},
 	Markdown: class {
 		constructor(text) {

--- a/extensions/pi-gremlins/result-rendering.ts
+++ b/extensions/pi-gremlins/result-rendering.ts
@@ -24,10 +24,10 @@ const VIEWER_HINT_VARIANTS = [
 	"viewer · /pi-gremlins:view",
 ] as const;
 const EXPAND_HINT_VARIANTS = [
-	"Ctrl+O expands embedded view.",
-	"Ctrl+O expands view.",
-	"Ctrl+O expands.",
-	"Ctrl+O",
+	"Alt+O expands embedded view.",
+	"Alt+O expands view.",
+	"Alt+O expands.",
+	"Alt+O",
 ] as const;
 const WAITING_TEXT = "Waiting for first event.";
 const NO_OUTPUT_TEXT = "No output captured.";
@@ -392,10 +392,10 @@ function createOverflowHint(
 	return theme.fg(
 		"muted",
 		pickLineVariant(width, [
-			`… ${remaining} more ${kind} · Ctrl+O to expand`,
-			`… ${remaining} more ${kind} · Ctrl+O`,
-			`… +${remaining} ${kind} · Ctrl+O`,
-			`… +${remaining} · Ctrl+O`,
+			`… ${remaining} more ${kind} · Alt+O to expand`,
+			`… ${remaining} more ${kind} · Alt+O`,
+			`… +${remaining} ${kind} · Alt+O`,
+			`… +${remaining} · Alt+O`,
 		]),
 	);
 }

--- a/extensions/pi-gremlins/viewer-result-navigation.test.js
+++ b/extensions/pi-gremlins/viewer-result-navigation.test.js
@@ -7,14 +7,15 @@ mock.module("@mariozechner/pi-tui", () => {
 		up: "up",
 		down: "down",
 		ctrl: (key) => `ctrl-${key}`,
+		alt: (key) => `alt-${key}`,
 	};
 	const keyMap = new Map([
 		["\x1b[H", Key.home],
-		["\x1bOa", Key.ctrl(Key.up)],
-		["\x1b[57419;5u", Key.ctrl(Key.up)],
+		["\x1b[1;3A", Key.alt(Key.up)],
+		["\x1b[57419;3u", Key.alt(Key.up)],
 		["\x1b[F", Key.end],
-		["\x1bOb", Key.ctrl(Key.down)],
-		["\x1b[57420;5u", Key.ctrl(Key.down)],
+		["\x1b[1;3B", Key.alt(Key.down)],
+		["\x1b[57420;3u", Key.alt(Key.down)],
 	]);
 	return {
 		Key,
@@ -205,6 +206,9 @@ describe("viewer result navigation", () => {
 		expect(getViewerNavigationHint(3)).toBe(
 			"←/→ result · ↑/↓ scroll · PgUp/PgDn · Home/End · Esc close",
 		);
+		expect(getViewerNavigationHint(3, 80)).toBe(
+			"←/→ result · ↑/↓ scroll · PgUp/PgDn page · Home/End/Alt+↑/Alt+↓ · Esc close",
+		);
 		expect(getViewerNavigationHint(3, 40)).toBe(
 			"←/→ result · ↑/↓ scroll · Esc close",
 		);
@@ -218,14 +222,18 @@ describe("viewer result navigation", () => {
 		});
 	});
 
-	test("treats legacy and CSI-u ctrl+up/down as home/end viewer aliases", () => {
+	test("treats alt+up/down and CSI-u variants as home/end viewer aliases", () => {
 		expect(isViewerScrollToStartKey("\x1b[H")).toBe(true);
-		expect(isViewerScrollToStartKey("\x1bOa")).toBe(true);
-		expect(isViewerScrollToStartKey("\x1b[57419;5u")).toBe(true);
+		expect(isViewerScrollToStartKey("\x1b[1;3A")).toBe(true);
+		expect(isViewerScrollToStartKey("\x1b[57419;3u")).toBe(true);
+		expect(isViewerScrollToStartKey("\x1bOa")).toBe(false);
+		expect(isViewerScrollToStartKey("\x1b[57419;5u")).toBe(false);
 		expect(isViewerScrollToStartKey("\x1b[A")).toBe(false);
 		expect(isViewerScrollToEndKey("\x1b[F")).toBe(true);
-		expect(isViewerScrollToEndKey("\x1bOb")).toBe(true);
-		expect(isViewerScrollToEndKey("\x1b[57420;5u")).toBe(true);
+		expect(isViewerScrollToEndKey("\x1b[1;3B")).toBe(true);
+		expect(isViewerScrollToEndKey("\x1b[57420;3u")).toBe(true);
+		expect(isViewerScrollToEndKey("\x1bOb")).toBe(false);
+		expect(isViewerScrollToEndKey("\x1b[57420;5u")).toBe(false);
 		expect(isViewerScrollToEndKey("\x1b[B")).toBe(false);
 	});
 

--- a/extensions/pi-gremlins/viewer-result-navigation.ts
+++ b/extensions/pi-gremlins/viewer-result-navigation.ts
@@ -60,13 +60,13 @@ export const VIEWER_SCROLL_LINE_STEP = 3;
 const VIEWER_SCROLL_TO_START_KEYS: string[] = [
 	Key.home,
 	Key.ctrl(Key.home),
-	Key.ctrl(Key.up),
+	Key.alt(Key.up),
 ];
 
 const VIEWER_SCROLL_TO_END_KEYS: string[] = [
 	Key.end,
 	Key.ctrl(Key.end),
-	Key.ctrl(Key.down),
+	Key.alt(Key.down),
 ];
 
 function clampLine(text: string, width: number): string {
@@ -260,7 +260,7 @@ export function getViewerNavigationHint(
 ): string | null {
 	if (!hasMultiResultNavigation(resultCount)) return null;
 	return pickLineVariant(dialogWidth, [
-		"←/→ result · ↑/↓ scroll · PgUp/PgDn page · Home/End/Ctrl+↑/Ctrl+↓ · Esc close",
+		"←/→ result · ↑/↓ scroll · PgUp/PgDn page · Home/End/Alt+↑/Alt+↓ · Esc close",
 		"←/→ result · ↑/↓ scroll · PgUp/PgDn · Home/End · Esc close",
 		"←/→ result · ↑/↓ scroll · Esc close",
 	]);


### PR DESCRIPTION
## Summary
- remap embedded pi-gremlins expand hint copy from Ctrl+O to Alt+O
- remap lair Home/End arrow aliases from Ctrl+↑/Ctrl+↓ to Alt+↑/Alt+↓
- update regression coverage and changelog for new shortcut affordances

## Verification
- npm run typecheck
- npm test

## Notes
- Lair alias behavior is owned in this repo and covered here.
- Embedded expand toggle keybinding itself is provided by Pi core (`app.tools.expand`); this package updates pi-gremlins-owned affordance copy and tests in repo scope.

Closes #2