### PR TITLE
fix: preserve scroll position when expanding inline view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `pi-gremlins` now finalizes child runs on process exit even if `close` never arrives, preserving terminal tool results and parent-session completion for exit-complete gremlin work.
+- Embedded `pi-gremlins` inline expansion now reuses its rendered text component so newly revealed content keeps viewport anchoring stable instead of forcing a jump to bottom.
 
 ### Changed
 - Inline `pi-gremlins` expand hints now advertise `Alt+O`, and lair scroll-to-start/end aliases now use `Alt+↑` / `Alt+↓` while preserving `Home` / `End` support.

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -333,6 +333,44 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("viewer · /pi-gremlins:view opens mission control.");
 	});
 
+	test("reuses inline result component when expanding so viewport anchoring can stay stable", () => {
+		const tool = createRegisteredTool();
+		const result = {
+			content: [{ type: "text", text: "unused" }],
+			details: createDetails("single", [
+				createSingleResult({
+					messages: [
+						{
+							role: "assistant",
+							content: Array.from({ length: 6 }, (_value, index) => ({
+								type: "text",
+								text: `line ${index + 1}`,
+							})),
+						},
+					],
+				}),
+			]),
+		};
+		const collapsed = tool.renderResult(
+			result,
+			{ expanded: false },
+			createTheme(),
+			{ toolCallId: "render-stability" },
+		);
+		const expanded = tool.renderResult(
+			result,
+			{ expanded: true },
+			createTheme(),
+			{ toolCallId: "render-stability", lastComponent: collapsed },
+		);
+
+		expect(expanded).toBe(collapsed);
+		expect(expanded.text).toContain("digest · line 6");
+		expect(expanded.text).not.toContain("Alt+O expands embedded view.");
+		const lineCount = expanded.text.split("\n").length;
+		expect(lineCount).toBeGreaterThan(6);
+	});
+
 	test("renders themed single quiet state when no output captured", () => {
 		const tool = createRegisteredTool();
 		const text = renderToText(tool, {

--- a/extensions/pi-gremlins/result-rendering.ts
+++ b/extensions/pi-gremlins/result-rendering.ts
@@ -59,6 +59,7 @@ interface RenderContext {
 	toolCallId?: string;
 	width?: number;
 	columns?: number;
+	lastComponent?: unknown;
 }
 
 interface RenderResultLike {
@@ -76,15 +77,14 @@ interface RenderDependencies {
 }
 
 function getRenderWidth(context: RenderContext): number | null {
-	const candidate =
-		typeof context.width === "number"
-			? context.width
-			: typeof context.columns === "number"
-				? context.columns
-				: null;
-	return candidate && Number.isFinite(candidate)
-		? Math.max(12, Math.floor(candidate))
-		: null;
+	let candidate: number | null = null;
+	if (typeof context.width === "number") {
+		candidate = context.width;
+	} else if (typeof context.columns === "number") {
+		candidate = context.columns;
+	}
+	if (!candidate || !Number.isFinite(candidate)) return null;
+	return Math.max(12, Math.floor(candidate));
 }
 
 function fitsWidth(text: string, width: number | null): boolean {
@@ -417,15 +417,16 @@ function describeDigestEntry(
 	}
 	if (entry.kind === "toolCall") {
 		if (status !== "Running") {
+			let tone: "error" | "warning" | "dim" = "dim";
+			if (status === "Failed") {
+				tone = "error";
+			} else if (status === "Canceled") {
+				tone = "warning";
+			}
 			return {
 				label: "tool call",
 				text: entry.text,
-				tone:
-					status === "Failed"
-						? "error"
-						: status === "Canceled"
-							? "warning"
-							: "dim",
+				tone,
 			};
 		}
 		return {
@@ -574,11 +575,20 @@ function buildUsageLine(
 	return formatLabelLine(theme, label, usageText, "dim", width);
 }
 
+function renderTextResult(context: RenderContext, text: string): Text {
+	if (context.lastComponent instanceof Text) {
+		context.lastComponent.setText(text);
+		return context.lastComponent;
+	}
+	return new Text(text, 0, 0);
+}
+
 function buildSingleView(
 	result: SingleResult,
 	theme: RenderTheme,
 	viewerHint: string | null,
 	formatToolCall: RenderDependencies["formatToolCall"],
+	context: RenderContext,
 	{ expanded, width }: { expanded: boolean; width: number | null },
 ): Text {
 	const status = getSingleResultSemantics(result);
@@ -654,7 +664,10 @@ function buildSingleView(
 	);
 	if (usageLine) lines.push(usageLine);
 
-	return new Text(appendHintText(lines.join("\n"), viewerHint), 0, 0);
+	return renderTextResult(
+		context,
+		appendHintText(lines.join("\n"), viewerHint),
+	);
 }
 
 function buildModeSummary(results: SingleResult[]): string {
@@ -738,12 +751,12 @@ function buildChildRow(
 	const summary = getResultSummaryLine(result, formatToolCall);
 	const liveStage = getLiveStage(result);
 	const sourceBadge = getSourceBadge(theme, result);
-	const marker =
-		liveStage === "active"
-			? theme.fg("warning", "▶")
-			: liveStage === "pending"
-				? theme.fg("muted", "○")
-				: theme.fg(status.isError ? "error" : "muted", "•");
+	let marker = theme.fg(status.isError ? "error" : "muted", "•");
+	if (liveStage === "active") {
+		marker = theme.fg("warning", "▶");
+	} else if (liveStage === "pending") {
+		marker = theme.fg("muted", "○");
+	}
 	const identity =
 		kind === "step"
 			? `step ${result.step ?? "?"} · ${result.agent}`
@@ -797,6 +810,7 @@ function buildCollectionView(
 	theme: RenderTheme,
 	viewerHint: string | null,
 	formatToolCall: RenderDependencies["formatToolCall"],
+	context: RenderContext,
 	{ expanded, width }: { expanded: boolean; width: number | null },
 ): Text {
 	const invocationStatus = getInvocationSemantics(mode, results);
@@ -858,7 +872,10 @@ function buildCollectionView(
 		lines.push(usageLine);
 	}
 
-	return new Text(appendHintText(lines.join("\n"), viewerHint), 0, 0);
+	return renderTextResult(
+		context,
+		appendHintText(lines.join("\n"), viewerHint),
+	);
 }
 
 export function renderPiGremlinsResult(
@@ -873,11 +890,9 @@ export function renderPiGremlinsResult(
 		: undefined;
 	if (!details || details.results.length === 0) {
 		const text = result.content[0];
-		return new Text(
-			text?.type === "text" ? (text.text ?? "(no output)") : "(no output)",
-			0,
-			0,
-		);
+		const output =
+			text?.type === "text" ? (text.text ?? "(no output)") : "(no output)";
+		return renderTextResult(context, output);
 	}
 
 	const width = getRenderWidth(context);
@@ -889,6 +904,7 @@ export function renderPiGremlinsResult(
 			theme,
 			viewerHint,
 			formatToolCall,
+			context,
 			{ expanded, width },
 		);
 	}
@@ -900,6 +916,7 @@ export function renderPiGremlinsResult(
 			theme,
 			viewerHint,
 			formatToolCall,
+			context,
 			{ expanded, width },
 		);
 	}
@@ -911,14 +928,13 @@ export function renderPiGremlinsResult(
 			theme,
 			viewerHint,
 			formatToolCall,
+			context,
 			{ expanded, width },
 		);
 	}
 
 	const text = result.content[0];
-	return new Text(
-		text?.type === "text" ? (text.text ?? "(no output)") : "(no output)",
-		0,
-		0,
-	);
+	const output =
+		text?.type === "text" ? (text.text ?? "(no output)") : "(no output)";
+	return renderTextResult(context, output);
 }

--- a/extensions/pi-gremlins/test-helpers.js
+++ b/extensions/pi-gremlins/test-helpers.js
@@ -129,6 +129,10 @@ export class MockText {
 	constructor(text) {
 		this.text = text;
 	}
+
+	setText(text) {
+		this.text = text;
+	}
 }
 
 export class MockSpacer {


### PR DESCRIPTION
## Summary
- reuse embedded render `Text` instances via `lastComponent` so inline expansion updates existing node instead of re-anchoring viewport at bottom
- add characterization coverage proving expanded render reuses component identity and keeps revealed content intact
- record issue #3 under `CHANGELOG.md`

## Issue Context
Issue #3 reported that expanding embedded `pi-gremlins` inline results auto-scrolled viewport to bottom, breaking reading flow and hiding surrounding context. This change preserves viewport anchoring while still revealing additional inline content during expansion.

## Verification
- `npm run check`

Closes #3
