### PR TITLE
fix: emit terminal single-child gremlin updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `pi-gremlins` now emits explicit terminal completion updates for single-child `single` and one-step `chain` runs after child exit, so parent flows receive terminal status snapshots before final tool results land.
 - `pi-gremlins` now finalizes child runs on process exit even if `close` never arrives, preserving terminal tool results and parent-session completion for exit-complete gremlin work.
 - Embedded `pi-gremlins` inline expansion now reuses its rendered text component so newly revealed content keeps viewport anchoring stable instead of forcing a jump to bottom.
 - `pi-gremlins` now surfaces child spawn failures, malformed child JSON protocol output, and package gremlin discovery failures with actionable diagnostics instead of degrading into silent or `(no output)` failure states.

--- a/extensions/pi-gremlins/execution-modes.ts
+++ b/extensions/pi-gremlins/execution-modes.ts
@@ -3,7 +3,6 @@ import type { AgentConfig } from "./agents.js";
 import {
 	createPendingResult,
 	getFinalOutput,
-	getInvocationStatus,
 	getSingleResultErrorText,
 	getSingleResultStatus,
 	type InvocationMode,
@@ -41,7 +40,6 @@ export type OnUpdateCallback = (
 ) => void;
 
 interface ExecutionModeDependencies {
-	toolCallId: string;
 	ctxCwd: string;
 	agents: AgentConfig[];
 	signal: AbortSignal | undefined;
@@ -50,11 +48,6 @@ interface ExecutionModeDependencies {
 	makeDetails: (
 		mode: InvocationMode,
 	) => (results: SingleResult[]) => PiGremlinsDetails;
-	updateInvocation: (
-		toolCallId: string,
-		details: PiGremlinsDetails,
-		status: ReturnType<typeof getInvocationStatus>,
-	) => void;
 	packageDiscoveryWarning?: string;
 }
 
@@ -124,7 +117,6 @@ function applyPreviousOutputToChainTask(
 }
 
 export async function executeChainMode({
-	toolCallId,
 	chain,
 	ctxCwd,
 	agents,
@@ -132,7 +124,6 @@ export async function executeChainMode({
 	runSingleAgent,
 	handleInvocationUpdate,
 	makeDetails,
-	updateInvocation,
 	packageDiscoveryWarning,
 }: ChainExecutionDependencies): Promise<PiGremlinsToolResult> {
 	const results: SingleResult[] = [];
@@ -180,30 +171,31 @@ export async function executeChainMode({
 		const resultStatus = getSingleResultStatus(result);
 		if (resultStatus === "Failed" || resultStatus === "Canceled") {
 			const details = makeDetails("chain")(results);
-			updateInvocation(
-				toolCallId,
-				details,
-				getInvocationStatus("chain", results),
-			);
 			if (resultStatus === "Canceled") {
-				return {
+				const terminalPartial = {
 					content: [
 						{
-							type: "text",
+							type: "text" as const,
 							text: `Chain canceled at step ${i + 1} (${step.agent}): ${getSingleResultErrorText(result)}`,
 						},
 					],
 					details,
 				};
+				handleInvocationUpdate(terminalPartial);
+				return terminalPartial;
 			}
-			return {
+			const terminalPartial = {
 				content: [
 					{
-						type: "text",
+						type: "text" as const,
 						text: `Chain stopped at step ${i + 1} (${step.agent}): ${getSingleResultErrorText(result)}`,
 					},
 				],
 				details,
+			};
+			handleInvocationUpdate(terminalPartial);
+			return {
+				...terminalPartial,
 				isError: true,
 			};
 		}
@@ -212,11 +204,10 @@ export async function executeChainMode({
 
 	const details = makeDetails("chain")(results);
 	const finalResult = results.at(-1);
-	updateInvocation(toolCallId, details, getInvocationStatus("chain", results));
-	return {
+	const terminalPartial = {
 		content: [
 			{
-				type: "text",
+				type: "text" as const,
 				text:
 					getFinalOutput(
 						finalResult?.messages ?? [],
@@ -226,10 +217,11 @@ export async function executeChainMode({
 		],
 		details,
 	};
+	handleInvocationUpdate(terminalPartial);
+	return terminalPartial;
 }
 
 export async function executeParallelMode({
-	toolCallId,
 	tasks,
 	ctxCwd,
 	agents,
@@ -237,7 +229,6 @@ export async function executeParallelMode({
 	runSingleAgent,
 	handleInvocationUpdate,
 	makeDetails,
-	updateInvocation,
 	maxConcurrency,
 	mapWithConcurrencyLimit,
 	packageDiscoveryWarning,
@@ -319,11 +310,6 @@ export async function executeParallelMode({
 		return `[${result.agent}] ${statuses[index].toLowerCase()}: ${output || "(no output)"}`;
 	});
 	const details = makeDetails("parallel")(results);
-	updateInvocation(
-		toolCallId,
-		details,
-		getInvocationStatus("parallel", results),
-	);
 	return {
 		content: [
 			{
@@ -336,7 +322,6 @@ export async function executeParallelMode({
 }
 
 export async function executeSingleMode({
-	toolCallId,
 	agent,
 	task,
 	cwd,
@@ -346,7 +331,6 @@ export async function executeSingleMode({
 	runSingleAgent,
 	handleInvocationUpdate,
 	makeDetails,
-	updateInvocation,
 	packageDiscoveryWarning,
 }: SingleExecutionDependencies): Promise<PiGremlinsToolResult> {
 	const result = await runSingleAgent(
@@ -362,41 +346,41 @@ export async function executeSingleMode({
 		packageDiscoveryWarning,
 	);
 	const details = makeDetails("single")([result]);
-	updateInvocation(
-		toolCallId,
-		details,
-		getInvocationStatus("single", [result]),
-	);
-
 	const resultStatus = getSingleResultStatus(result);
 	if (resultStatus === "Failed") {
-		return {
+		const terminalPartial = {
 			content: [
 				{
-					type: "text",
+					type: "text" as const,
 					text: `Agent ${result.stopReason || "failed"}: ${getSingleResultErrorText(result)}`,
 				},
 			],
 			details,
+		};
+		handleInvocationUpdate(terminalPartial);
+		return {
+			...terminalPartial,
 			isError: true,
 		};
 	}
 	if (resultStatus === "Canceled") {
-		return {
+		const terminalPartial = {
 			content: [
 				{
-					type: "text",
+					type: "text" as const,
 					text: `Canceled: ${getSingleResultErrorText(result)}`,
 				},
 			],
 			details,
 		};
+		handleInvocationUpdate(terminalPartial);
+		return terminalPartial;
 	}
 
-	return {
+	const terminalPartial = {
 		content: [
 			{
-				type: "text",
+				type: "text" as const,
 				text:
 					getFinalOutput(result.messages, result.viewerEntries) ||
 					"(no output)",
@@ -404,4 +388,6 @@ export async function executeSingleMode({
 		],
 		details,
 	};
+	handleInvocationUpdate(terminalPartial);
+	return terminalPartial;
 }

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -414,6 +414,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 			"reading chunk",
 			"file contents",
 			"final single answer",
+			"final single answer",
 		]);
 		expect(
 			updates[1].details.results[0].viewerEntries.some(
@@ -423,7 +424,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 					entry.content === "reading chunk",
 			),
 		).toBe(true);
-		expect(updates.at(-1).details.results[0]).toMatchObject({
+		expect(updates.at(-2).details.results[0]).toMatchObject({
 			agent: "tars",
 			agentSource: "user",
 			exitCode: -1,
@@ -437,6 +438,13 @@ describe("pi-gremlins execute streaming characterization", () => {
 				contextTokens: 18,
 				turns: 1,
 			},
+		});
+		expect(updates.at(-1).details.status).toBe("Completed");
+		expect(updates.at(-1).details.results[0]).toMatchObject({
+			agent: "tars",
+			agentSource: "user",
+			exitCode: 0,
+			model: "gpt-5",
 		});
 		expect(result.isError).toBeUndefined();
 		expect(result.content[0].text).toBe("final single answer");
@@ -520,7 +528,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 			createExecutionContext(workspace.repoRoot),
 		);
 
-		expect(updates).toHaveLength(3);
+		expect(updates).toHaveLength(4);
 		expect(updates[0].content[0].text).toBe("draft");
 		expect(updates[0].details.results[0].viewerEntries).toEqual([
 			expect.objectContaining({
@@ -537,6 +545,9 @@ describe("pi-gremlins execute streaming characterization", () => {
 			}),
 		]);
 		expect(updates[2].content[0].text).toBe("final answer");
+		expect(updates[2].details.status).toBe("Running");
+		expect(updates[3].content[0].text).toBe("final answer");
+		expect(updates[3].details.status).toBe("Completed");
 		expect(result.content[0].text).toBe("final answer");
 	});
 
@@ -617,7 +628,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 			createExecutionContext(workspace.repoRoot),
 		);
 
-		expect(updates).toHaveLength(4);
+		expect(updates).toHaveLength(5);
 		expect(updates[0].content[0].text).toBe("(running...)");
 		expect(updates[0].details.results[0].viewerEntries).toEqual([
 			expect.objectContaining({
@@ -638,6 +649,8 @@ describe("pi-gremlins execute streaming characterization", () => {
 				streaming: false,
 			}),
 		]);
+		expect(updates[4].content[0].text).toBe("draft final");
+		expect(updates[4].details.status).toBe("Completed");
 	});
 
 	test("single mode skips duplicate publish for no-op tool_execution_start after assistant tool call", async () => {
@@ -710,6 +723,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 		expect(updates.map((update) => update.content[0].text)).toEqual([
 			"(running...)",
 			"final answer",
+			"final answer",
 		]);
 		expect(updates[0].details.results[0].viewerEntries).toEqual([
 			expect.objectContaining({
@@ -780,6 +794,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 
 		expect(updates.map((update) => update.content[0].text)).toEqual([
 			"drafting",
+			"final answer",
 			"final answer",
 		]);
 		expect(updates[0].details.results[0].viewerEntries).toEqual([
@@ -899,6 +914,107 @@ describe("pi-gremlins execute streaming characterization", () => {
 			agent: "tars",
 			exitCode: 0,
 		});
+	});
+
+	test("single mode emits terminal completion update after child exit", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					jsonLine({
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: [{ type: "text", text: "final answer" }],
+							usage: {
+								input: 2,
+								output: 3,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: { total: 0.01 },
+								totalTokens: 5,
+							},
+						},
+					}),
+				],
+				closeCode: 0,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const result = await tool.execute(
+			"single-terminal-update",
+			{ agent: "tars", task: "Finish cleanly" },
+			undefined,
+			(partial) => updates.push(cloneForAssertion(partial)),
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		expect(updates.at(-1).content[0].text).toBe("final answer");
+		expect(updates.at(-1).details.status).toBe("Completed");
+		expect(updates.at(-1).details.results[0]).toMatchObject({
+			agent: "tars",
+			exitCode: 0,
+		});
+		expect(result.details.status).toBe("Completed");
+	});
+
+	test("chain mode emits terminal completion update for one-child runs", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "writer.md", "writer");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					jsonLine({
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: [{ type: "text", text: "chain final answer" }],
+							usage: {
+								input: 3,
+								output: 4,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: { total: 0.01 },
+								totalTokens: 7,
+							},
+						},
+					}),
+				],
+				closeCode: 0,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const result = await tool.execute(
+			"chain-single-terminal-update",
+			{
+				chain: [{ agent: "writer", task: "Draft once" }],
+			},
+			undefined,
+			(partial) => updates.push(cloneForAssertion(partial)),
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		expect(updates.at(-1).content[0].text).toBe("chain final answer");
+		expect(updates.at(-1).details.status).toBe("Completed");
+		expect(updates.at(-1).details.results).toEqual([
+			expect.objectContaining({
+				agent: "writer",
+				exitCode: 0,
+				step: 1,
+			}),
+		]);
+		expect(result.details.status).toBe("Completed");
 	});
 
 	test("chain mode emits pending snapshots, previous substitution, and stops on error", async () => {

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -1437,7 +1437,6 @@ export default function (pi: ExtensionAPI) {
 			if (params.chain && params.chain.length > 0) {
 				return finalizeResult(
 					await executeChainMode({
-						toolCallId,
 						chain: params.chain,
 						ctxCwd: ctx.cwd,
 						agents,
@@ -1445,7 +1444,6 @@ export default function (pi: ExtensionAPI) {
 						runSingleAgent,
 						handleInvocationUpdate,
 						makeDetails,
-						updateInvocation,
 						packageDiscoveryWarning,
 					}),
 				);
@@ -1454,7 +1452,6 @@ export default function (pi: ExtensionAPI) {
 			if (params.tasks && params.tasks.length > 0) {
 				return finalizeResult(
 					await executeParallelMode({
-						toolCallId,
 						tasks: params.tasks,
 						ctxCwd: ctx.cwd,
 						agents,
@@ -1462,7 +1459,6 @@ export default function (pi: ExtensionAPI) {
 						runSingleAgent,
 						handleInvocationUpdate,
 						makeDetails,
-						updateInvocation,
 						maxConcurrency: MAX_CONCURRENCY,
 						mapWithConcurrencyLimit,
 						packageDiscoveryWarning,
@@ -1473,7 +1469,6 @@ export default function (pi: ExtensionAPI) {
 			if (params.agent && params.task) {
 				return finalizeResult(
 					await executeSingleMode({
-						toolCallId,
 						agent: params.agent,
 						task: params.task,
 						cwd: params.cwd,
@@ -1483,7 +1478,6 @@ export default function (pi: ExtensionAPI) {
 						runSingleAgent,
 						handleInvocationUpdate,
 						makeDetails,
-						updateInvocation,
 						packageDiscoveryWarning,
 					}),
 				);


### PR DESCRIPTION
## Summary
- emit explicit terminal invocation updates for single-child `single` runs and one-step/terminal `chain` runs after child exit
- add regression coverage proving final partial updates now carry terminal `Completed` status and exit codes
- document fix in `CHANGELOG.md`

## Root cause
`runSingleAgent(...)` emitted final child content while result exit state was still pending, so parent partial updates stayed `Running`. `executeSingleMode(...)` and `executeChainMode(...)` then published terminal snapshots internally but did not emit a matching terminal partial update back through parent flow.

## Verification
- `npm run check`

Closes #10