### PR TITLE
fix: restore Ctrl+O embedded expand hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `pi-gremlins` now prunes older terminal invocation snapshots while preserving latest and active viewer state, reducing long-session mission-control memory growth.
 - Internal subprocess lifecycle and tool text logic now live in focused modules, reducing `index.ts` responsibility concentration and lowering reliability-fix change risk.
-- Inline `pi-gremlins` expand hints now advertise `Alt+O`, and lair scroll-to-start/end aliases now use `Alt+↑` / `Alt+↓` while preserving `Home` / `End` support.
+- Inline `pi-gremlins` expand hints now advertise `Ctrl+O`, and lair scroll-to-start/end aliases now use `Alt+↑` / `Alt+↓` while preserving `Home` / `End` support.
 - **Immersive Viewer UX and Theming** (PRD-0001, ADR-0001): Overhauled embedded and popup `pi-gremlins` presentation with shared status semantics, `viewerEntries`-driven summaries, clearer source/trust badges, compact live activity rows, narrow-layout hardening, and differentiated tool/result rendering.
 - README now leads with gremlin artwork and refreshed package presentation for the updated viewer experience.
 

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -268,7 +268,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Completed] tars · single · [user]");
 		expect(text).toContain("digest · line 11");
 		expect(text).toContain("… 8 earlier events");
-		expect(text).toContain("Alt+O expands embedded view.");
+		expect(text).toContain("Ctrl+O expands embedded view.");
 		expect(text).toContain("usage · turns:2 · input:10 · output:20");
 		expect(text).not.toContain(
 			"viewer · /pi-gremlins:view opens mission control.",
@@ -366,7 +366,7 @@ describe("pi-gremlins renderResult characterization", () => {
 
 		expect(expanded).toBe(collapsed);
 		expect(expanded.text).toContain("digest · line 6");
-		expect(expanded.text).not.toContain("Alt+O expands embedded view.");
+		expect(expanded.text).not.toContain("Ctrl+O expands embedded view.");
 		const lineCount = expanded.text.split("\n").length;
 		expect(lineCount).toBeGreaterThan(6);
 	});
@@ -742,7 +742,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Failed] step 2 · reviewer [user]");
 		expect(text).toContain("quiet · No output captured.");
 		expect(text).toContain("usage total · turns:3 · input:15 · output:12");
-		expect(text).toContain("Alt+O expands embedded view.");
+		expect(text).toContain("Ctrl+O expands embedded view.");
 	});
 
 	test("renders chain running and canceled states with semantic badges instead of failure markers", () => {
@@ -863,7 +863,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Completed] beta [user]");
 		expect(text).toContain("digest · beta complete");
 		expect(text).toContain("usage total · turns:1 · input:9 · output:3");
-		expect(text).toContain("Alt+O expands embedded view.");
+		expect(text).toContain("Ctrl+O expands embedded view.");
 	});
 
 	test("renders parallel completed collapsed state with explicit failure count and totals", () => {
@@ -901,7 +901,35 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("digest · alpha collapsed");
 		expect(text).toContain("digest · beta collapsed");
 		expect(text).toContain("usage total · turns:3 · input:10 · output:6");
-		expect(text).toContain("Alt+O expands embedded view.");
+		expect(text).toContain("Ctrl+O expands embedded view.");
+	});
+
+	test("renders collapsed overflow hint with Ctrl+O under narrow width pressure", () => {
+		const tool = createRegisteredTool();
+		const text = renderToText(
+			tool,
+			{
+				content: [{ type: "text", text: "unused" }],
+				details: createDetails(
+					"parallel",
+					Array.from({ length: 5 }, (_value, index) =>
+						createSingleResult({
+							agent: `agent-${index + 1}`,
+							messages: [
+								{
+									role: "assistant",
+									content: [{ type: "text", text: `result ${index + 1}` }],
+								},
+							],
+						}),
+					),
+				),
+			},
+			{},
+			{ width: 14 },
+		);
+
+		expect(text).toContain("… +1 · Ctrl+O");
 	});
 
 	test("reuses derived render cache for same revision and invalidates when messages append", () => {

--- a/extensions/pi-gremlins/result-rendering.ts
+++ b/extensions/pi-gremlins/result-rendering.ts
@@ -24,10 +24,10 @@ const VIEWER_HINT_VARIANTS = [
 	"viewer · /pi-gremlins:view",
 ] as const;
 const EXPAND_HINT_VARIANTS = [
-	"Alt+O expands embedded view.",
-	"Alt+O expands view.",
-	"Alt+O expands.",
-	"Alt+O",
+	"Ctrl+O expands embedded view.",
+	"Ctrl+O expands view.",
+	"Ctrl+O expands.",
+	"Ctrl+O",
 ] as const;
 const WAITING_TEXT = "Waiting for first event.";
 const NO_OUTPUT_TEXT = "No output captured.";
@@ -392,10 +392,10 @@ function createOverflowHint(
 	return theme.fg(
 		"muted",
 		pickLineVariant(width, [
-			`… ${remaining} more ${kind} · Alt+O to expand`,
-			`… ${remaining} more ${kind} · Alt+O`,
-			`… +${remaining} ${kind} · Alt+O`,
-			`… +${remaining} · Alt+O`,
+			`… ${remaining} more ${kind} · Ctrl+O to expand`,
+			`… ${remaining} more ${kind} · Ctrl+O`,
+			`… +${remaining} ${kind} · Ctrl+O`,
+			`… +${remaining} · Ctrl+O`,
 		]),
 	);
 }


### PR DESCRIPTION
## Summary
- restore embedded expand hint copy from Alt+O to Ctrl+O in result rendering
- update collapsed overflow hint variants for narrow embedded layouts
- refresh render tests and changelog copy to match reverted shortcut

## Verification
- pnpm test
- pnpm typecheck
- pnpm build *(fails: script missing)*
- pnpm lint *(fails: script missing)*

Closes #11