### PR TITLE
fix: rename user-facing pi-gremlins surfaces to Gremlins🧌

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chain `{previous}` handoff now truncates oversized carry-forward payloads before spawning follow-up gremlin steps, avoiding oversized subprocess task arguments during long chains.
 
 ### Changed
+- User-facing Gremlins🧌 branding now replaces `pi-gremlins` across inline tool chrome, popup viewer copy, viewer hints, README examples, and slash-command help, while machine-facing package/install identifiers stay `pi-gremlins`.
 - `pi-gremlins` now prunes older terminal invocation snapshots while preserving latest and active viewer state, reducing long-session mission-control memory growth.
 - Internal subprocess lifecycle and tool text logic now live in focused modules, reducing `index.ts` responsibility concentration and lowering reliability-fix change risk.
 - Inline `pi-gremlins` expand hints now advertise `Alt+O`, and lair scroll-to-start/end aliases now use `Alt+↑` / `Alt+↓` while preserving `Home` / `End` support.
 - **Immersive Viewer UX and Theming** (PRD-0001, ADR-0001): Overhauled embedded and popup `pi-gremlins` presentation with shared status semantics, `viewerEntries`-driven summaries, clearer source/trust badges, compact live activity rows, narrow-layout hardening, and differentiated tool/result rendering.
-- README now leads with gremlin artwork and refreshed package presentation for the updated viewer experience.
+- README now leads with gremlin artwork, refreshed `Gremlins🧌` user-facing branding, and `/gremlins:view` command guidance while package/install identifiers remain `pi-gremlins`.
 
 ### Added
 - Product, architecture, and implementation records for viewer overhaul in `docs/prd/0001-pi-gremlins-immersive-theming-and-viewer-ux-overhaul.md`, `docs/adr/0001-semantic-presentation-architecture-for-pi-gremlins-viewer-and-embedded-surfaces.md`, and `docs/plans/pi-gremlins-immersive-theming-viewer-ux-overhaul.md`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Gizmo](docs/gremlins.png)
-# pi-gremlins
+# Gremlins🧌 (`pi-gremlins`)
 
-Pi package. Adds `pi-gremlins` tool for summoning mischievous specialist workers in isolated Pi subprocesses.
+Pi package. Adds `Gremlins🧌` user-facing tool branding for summoning mischievous specialist workers in isolated Pi subprocesses.
 
 Forked from and inspired by [`nicobailon/pi-subagents`](https://github.com/nicobailon/pi-subagents).
 
@@ -19,7 +19,7 @@ Fun branding. Same real Pi primitive underneath: agents. That means gremlin defi
 
 ## What tool does
 
-`pi-gremlins` delegates work into isolated subprocesses so each gremlin gets fresh context.
+`Gremlins🧌` delegates work into isolated subprocesses so each gremlin gets fresh context.
 
 Modes:
 
@@ -51,12 +51,12 @@ pi install -l git:github.com/magimetal/pi-gremlins
 
 ## Use
 
-Important: API still uses `agent` and `agentScope` keys because Pi discovery still runs through agent directories.
+Important: user-facing tool surface now appears as `Gremlins🧌`. Machine-facing package/runtime identifiers that Pi uses for install and wiring still stay `pi-gremlins`, and API still uses `agent` / `agentScope` because discovery still runs through agent directories.
 
 Single summon:
 
 ```text
-pi-gremlins({
+Gremlins🧌({
   agent: "researcher",
   task: "Summarize repo architecture"
 })
@@ -65,7 +65,7 @@ pi-gremlins({
 Parallel swarm:
 
 ```text
-pi-gremlins({
+Gremlins🧌({
   tasks: [
     { agent: "researcher", task: "Find auth flow" },
     { agent: "reviewer", task: "Review recent changes" }
@@ -76,7 +76,7 @@ pi-gremlins({
 Chain of gremlins:
 
 ```text
-pi-gremlins({
+Gremlins🧌({
   chain: [
     { agent: "researcher", task: "Gather facts" },
     { agent: "writer", task: "Draft answer from {previous}" },
@@ -102,10 +102,10 @@ UI sessions ask for trust confirmation before running repo-local gremlins by def
 Viewer command:
 
 ```text
-/pi-gremlins:view
+/gremlins:view
 ```
 
-Opens popup lair for latest `pi-gremlins` run in current session.
+Opens popup lair for latest `Gremlins🧌` run in current session.
 
 ## Repo layout
 

--- a/docs/adr/0001-semantic-presentation-architecture-for-pi-gremlins-viewer-and-embedded-surfaces.md
+++ b/docs/adr/0001-semantic-presentation-architecture-for-pi-gremlins-viewer-and-embedded-surfaces.md
@@ -63,7 +63,7 @@ Rationale: This initiative is no longer only styling or isolated viewer polish o
 
 ## Verification
 
-- **Automated:** `npm run typecheck`; `npm test`; add or update tests covering shared projection/rendering behavior for single, parallel, and chain results across embedded rendering and `/pi-gremlins:view` popup flows.
+- **Automated:** `npm run typecheck`; `npm test`; add or update tests covering shared projection/rendering behavior for single, parallel, and chain results across embedded rendering and `/gremlins:view` popup flows.
 - **Manual:** Run representative single, parallel, and chain gremlin invocations; compare embedded output and popup lair output for tool calls, streaming text, truncated tool results, error states, and navigation context; confirm no cross-session history or persistence artifacts are introduced.
 
 ## Notes

--- a/docs/prd/0001-pi-gremlins-immersive-theming-and-viewer-ux-overhaul.md
+++ b/docs/prd/0001-pi-gremlins-immersive-theming-and-viewer-ux-overhaul.md
@@ -3,7 +3,7 @@
 - **Status:** Completed
 - **Date:** 2026-04-21
 - **Author:** Magi Metal
-- **Related:** `extensions/pi-gremlins`, `/pi-gremlins:view`, `README.md`, `docs/adr/0001-semantic-presentation-architecture-for-pi-gremlins-viewer-and-embedded-surfaces.md` (ADR-0001)
+- **Related:** `extensions/pi-gremlins`, `/gremlins:view`, `README.md`, `docs/adr/0001-semantic-presentation-architecture-for-pi-gremlins-viewer-and-embedded-surfaces.md` (ADR-0001)
 - **Supersedes:** None
 
 ## Problem Statement
@@ -43,7 +43,7 @@ This work targets people actively dispatching single, parallel, and chain gremli
 - Timeline/tree improvements for chain and parallel result inspection.
 - Usage-stat readability improvements for inline and viewer surfaces.
 - Adaptive narrow-width behavior for embedded and viewer output.
-- Themed discoverability hints, especially around `/pi-gremlins:view`.
+- Themed discoverability hints, especially around `/gremlins:view`.
 - Subtle motion or live affordance polish only if current TUI/runtime makes it safe, readable, and optional.
 - Embedded running-actions enhancements: active action row, inline tool-result summaries, compact-live density tier.
 - Running-state semantics fix so active, pending, completed, failed, and canceled states are presented accurately.

--- a/extensions/pi-gremlins/execution-modes.ts
+++ b/extensions/pi-gremlins/execution-modes.ts
@@ -74,9 +74,9 @@ interface SingleExecutionDependencies extends ExecutionModeDependencies {
 const MAX_CHAIN_CARRY_FORWARD_CHARS = 8000;
 const MAX_CHAIN_TASK_CHARS = 12000;
 const CHAIN_CARRY_FORWARD_TRUNCATION_NOTE =
-	"...[truncated by pi-gremlins chain handoff]";
+	"...[truncated by Gremlins🧌 chain handoff]";
 const CHAIN_TASK_TRUNCATION_NOTE =
-	"...[task truncated by pi-gremlins chain handoff]";
+	"...[task truncated by Gremlins🧌 chain handoff]";
 
 function clampTextWithNote(
 	text: string,

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -308,7 +308,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 			"Gremlin protocol error: child emitted 1 malformed JSON stdout line.",
 		);
 		expect(result.details.results[0].stderr).toContain(
-			"[pi-gremlins] dropped malformed child stdout line 1: not-json",
+			"[Gremlins🧌] dropped malformed child stdout line 1: not-json",
 		);
 	});
 
@@ -1743,7 +1743,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 			(arg) => typeof arg === "string" && arg.startsWith("Task: Review "),
 		);
 		expect(secondTaskArg).toContain(
-			"...[truncated by pi-gremlins chain handoff]",
+			"...[truncated by Gremlins🧌 chain handoff]",
 		);
 		expect(secondTaskArg.length).toBeLessThanOrEqual(8100);
 	});

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -191,7 +191,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 			"user",
 		);
 		canceled.stopReason = "aborted";
-		canceled.errorMessage = "pi-gremlins run was aborted";
+		canceled.errorMessage = "Gremlins🧌 run was aborted";
 
 		expect(getSingleResultStatus(canceled)).toBe("Canceled");
 		expect(getInvocationStatus("single", [canceled])).toBe("Canceled");

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -237,6 +237,23 @@ describe("pi-gremlins renderResult characterization", () => {
 		});
 	});
 
+	test("registers Gremlins🧌 branding for user-facing tool label and call chrome", () => {
+		const tool = createRegisteredTool();
+		const call = flattenRenderedNode(
+			tool.renderCall(
+				{ agent: "tars", task: "Inspect task" },
+				createTheme(),
+				{},
+				undefined,
+			),
+		);
+
+		expect(tool.name).toBe("pi-gremlins");
+		expect(tool.label).toBe("Gremlins🧌");
+		expect(call).toContain("Gremlins🧌 tars [user]");
+		expect(call).not.toContain("pi-gremlins ");
+	});
+
 	test("falls back to tool text when details are missing", () => {
 		const tool = createRegisteredTool();
 		expect(
@@ -271,7 +288,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("Alt+O expands embedded view.");
 		expect(text).toContain("usage · turns:2 · input:10 · output:20");
 		expect(text).not.toContain(
-			"viewer · /pi-gremlins:view opens mission control.",
+			"viewer · /gremlins:view opens mission control.",
 		);
 	});
 
@@ -330,7 +347,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain(
 			"usage · turns:3 · input:1.5k · output:40 · cacheRead:10 · cacheWrite:5 · cost:$1.2345 · context:2.2k · model:gpt-5",
 		);
-		expect(text).toContain("viewer · /pi-gremlins:view opens mission control.");
+		expect(text).toContain("viewer · /gremlins:view opens mission control.");
 	});
 
 	test("reuses inline result component when expanding so viewport anchoring can stay stable", () => {
@@ -599,7 +616,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Running]");
 		expect(text).toContain("[project]");
 		expect(text).toContain("trust · Project agent");
-		expect(text).toContain("viewer · /pi-gremlins:view");
+		expect(text).toContain("viewer · /gremlins:view");
 	});
 
 	test("compresses chain embedded summary deterministically at narrow width", async () => {
@@ -650,7 +667,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Running] chain");
 		expect(text).toContain("active ·");
 		expect(text).toContain("[project]");
-		expect(text).toContain("viewer · /pi-gremlins:view");
+		expect(text).toContain("viewer · /gremlins:view");
 	});
 
 	test("compresses parallel embedded summary deterministically at narrow width", async () => {
@@ -708,7 +725,7 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("[Running] parallel");
 		expect(text).toContain("active ·");
 		expect(text).toContain("[project]");
-		expect(text).toContain("viewer · /pi-gremlins:view");
+		expect(text).toContain("viewer · /gremlins:view");
 	});
 
 	test("renders chain collapsed with status-first rows, active-free summary, and readable totals", () => {
@@ -777,7 +794,7 @@ describe("pi-gremlins renderResult characterization", () => {
 					step: 3,
 					exitCode: 130,
 					stopReason: "aborted",
-					errorMessage: "pi-gremlins run was aborted",
+					errorMessage: "Gremlins🧌 run was aborted",
 				}),
 			]),
 		});

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -95,8 +95,10 @@ import {
 const MAX_PARALLEL_TASKS = 8;
 const MAX_CONCURRENCY = 4;
 const MAX_INVOCATION_SNAPSHOTS = 24;
-const NO_INVOCATION_TEXT = "No pi-gremlins run available in this session.";
-const VIEWER_TITLE = "pi-gremlins mission control";
+const BRAND_NAME = "Gremlins🧌";
+const VIEWER_COMMAND = "gremlins:view";
+const NO_INVOCATION_TEXT = `No ${BRAND_NAME} run available in this session.`;
+const VIEWER_TITLE = `${BRAND_NAME} mission control`;
 
 function formatToolCall(
 	toolName: string,
@@ -1285,7 +1287,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.registerTool({
 		name: "pi-gremlins",
-		label: "pi-gremlins",
+		label: BRAND_NAME,
 		description: [
 			"Summon specialized gremlins with isolated context.",
 			"Modes: single (one gremlin), parallel (many gremlins), chain (gremlins passing {previous} output along).",
@@ -1498,7 +1500,7 @@ export default function (pi: ExtensionAPI) {
 			const scope: AgentScope = args.agentScope ?? "user";
 			if (args.chain && args.chain.length > 0) {
 				let text =
-					theme.fg("toolTitle", theme.bold("pi-gremlins ")) +
+					theme.fg("toolTitle", theme.bold(`${BRAND_NAME} `)) +
 					theme.fg("accent", `chain (${args.chain.length} steps)`) +
 					theme.fg("muted", ` [${scope}]`);
 				for (let i = 0; i < Math.min(args.chain.length, 3); i++) {
@@ -1520,7 +1522,7 @@ export default function (pi: ExtensionAPI) {
 			}
 			if (args.tasks && args.tasks.length > 0) {
 				let text =
-					theme.fg("toolTitle", theme.bold("pi-gremlins ")) +
+					theme.fg("toolTitle", theme.bold(`${BRAND_NAME} `)) +
 					theme.fg("accent", `parallel (${args.tasks.length} tasks)`) +
 					theme.fg("muted", ` [${scope}]`);
 				for (const t of args.tasks.slice(0, 3)) {
@@ -1539,7 +1541,7 @@ export default function (pi: ExtensionAPI) {
 					: args.task
 				: "...";
 			let text =
-				theme.fg("toolTitle", theme.bold("pi-gremlins ")) +
+				theme.fg("toolTitle", theme.bold(`${BRAND_NAME} `)) +
 				theme.fg("accent", agentName) +
 				theme.fg("muted", ` [${scope}]`);
 			text += `\n  ${theme.fg("dim", preview)}`;
@@ -1554,9 +1556,8 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerCommand("pi-gremlins:view", {
-		description:
-			"Open popup viewer for latest pi-gremlins run in this session.",
+	pi.registerCommand(VIEWER_COMMAND, {
+		description: `Open popup lair for latest ${BRAND_NAME} run in this session.`,
 		handler: async (_args, ctx) => {
 			await openViewer(ctx);
 		},

--- a/extensions/pi-gremlins/index.viewer.test.js
+++ b/extensions/pi-gremlins/index.viewer.test.js
@@ -238,7 +238,13 @@ describe("pi-gremlins viewer command", () => {
 		const { commands, events } = createExtensionHarness();
 		const notifications = [];
 
-		await commands.get("pi-gremlins:view").handler([], {
+		expect(commands.has("gremlins:view")).toBe(true);
+		expect(commands.has("pi-gremlins:view")).toBe(false);
+		expect(commands.get("gremlins:view").description).toBe(
+			"Open popup lair for latest Gremlins🧌 run in this session.",
+		);
+
+		await commands.get("gremlins:view").handler([], {
 			hasUI: true,
 			ui: {
 				notify: (message, level) => {
@@ -250,7 +256,7 @@ describe("pi-gremlins viewer command", () => {
 
 		expect(notifications).toEqual([
 			{
-				message: "No pi-gremlins run available in this session.",
+				message: "No Gremlins🧌 run available in this session.",
 				level: "warning",
 			},
 		]);
@@ -275,7 +281,7 @@ describe("pi-gremlins viewer command", () => {
 			hide() {},
 		};
 
-		await commands.get("pi-gremlins:view").handler([], {
+		await commands.get("gremlins:view").handler([], {
 			hasUI: true,
 			ui: {
 				notify: () => {},
@@ -525,7 +531,7 @@ describe("pi-gremlins viewer command", () => {
 		);
 		result.exitCode = 130;
 		result.stopReason = "aborted";
-		result.errorMessage = "pi-gremlins run was aborted";
+		result.errorMessage = "Gremlins🧌 run was aborted";
 		bumpResultVisibleRevision(result);
 
 		const snapshot = createInvocationSnapshot(
@@ -536,7 +542,7 @@ describe("pi-gremlins viewer command", () => {
 		const body = getCachedInvocationBodyLines(null, snapshot, 0, createTheme());
 
 		expect(snapshot.status).toBe("Canceled");
-		expect(body.lines.join("\n")).toContain("pi-gremlins run was aborted");
+		expect(body.lines.join("\n")).toContain("Gremlins🧌 run was aborted");
 	});
 
 	test("renders popup body with differentiated assistant tool and error lines", () => {
@@ -604,7 +610,7 @@ describe("pi-gremlins viewer command", () => {
 		);
 		const text = renderOverlayText(snapshot);
 
-		expect(text).toContain("pi-gremlins mission control");
+		expect(text).toContain("Gremlins🧌 mission control");
 		expect(text).toContain("[Completed] single");
 		expect(text).toContain("focus · awaiting result selection");
 		expect(text).toContain("telemetry · idle");
@@ -743,7 +749,7 @@ describe("pi-gremlins viewer command", () => {
 			selectedResultIndex: 1,
 		});
 
-		expect(text).toContain("pi-gremlins mission control");
+		expect(text).toContain("Gremlins🧌 mission control");
 		expect(text).toContain("[Running] chain");
 		expect(text).toContain("focus · reviewer [package] · result [Running]");
 		expect(text).toContain("telemetry · turns:3 · input:140");
@@ -869,7 +875,7 @@ describe("pi-gremlins viewer command", () => {
 			selectedResultIndex: 1,
 		});
 
-		expect(text).toContain("pi-gremlins mission control");
+		expect(text).toContain("Gremlins🧌 mission control");
 		expect(text).toContain("[Running] chain");
 		expect(text).toContain("focus · reviewer [package] · result [Running]");
 		expect(text).toContain("telemetry · turns:3 · input:140");
@@ -935,8 +941,8 @@ describe("pi-gremlins viewer command", () => {
 			{ toolCallId: "viewer-prune-25" },
 		);
 
-		expect(prunedText).not.toContain("viewer · /pi-gremlins:view");
-		expect(latestText).toContain("viewer · /pi-gremlins:view");
+		expect(prunedText).not.toContain("viewer · /gremlins:view");
+		expect(latestText).toContain("viewer · /gremlins:view");
 	});
 
 	test("focuses existing overlay instead of opening duplicate viewer", async () => {
@@ -976,8 +982,8 @@ describe("pi-gremlins viewer command", () => {
 			},
 		};
 
-		await commands.get("pi-gremlins:view").handler([], ctx);
-		await commands.get("pi-gremlins:view").handler([], ctx);
+		await commands.get("gremlins:view").handler([], ctx);
+		await commands.get("gremlins:view").handler([], ctx);
 
 		expect(customCalls).toHaveLength(1);
 		expect(handle.focusCalls).toBe(2);

--- a/extensions/pi-gremlins/result-rendering.ts
+++ b/extensions/pi-gremlins/result-rendering.ts
@@ -19,9 +19,9 @@ const COLLAPSED_CHILD_COUNT = 4;
 const COLLAPSED_EVENT_COUNT = 3;
 const DIGEST_MAX_LENGTH = 88;
 const VIEWER_HINT_VARIANTS = [
-	"viewer · /pi-gremlins:view opens mission control.",
-	"viewer · /pi-gremlins:view opens viewer.",
-	"viewer · /pi-gremlins:view",
+	"viewer · /gremlins:view opens mission control.",
+	"viewer · /gremlins:view opens viewer.",
+	"viewer · /gremlins:view",
 ] as const;
 const EXPAND_HINT_VARIANTS = [
 	"Alt+O expands embedded view.",

--- a/extensions/pi-gremlins/single-agent-runner.ts
+++ b/extensions/pi-gremlins/single-agent-runner.ts
@@ -27,7 +27,7 @@ import { formatAgentLookupError } from "./tool-text.js";
 const CHILD_PROCESS_EXIT_GRACE_MS = 50;
 const CHILD_PROCESS_KILL_GRACE_MS = 5000;
 const CHILD_PROTOCOL_ERROR_PREVIEW_LENGTH = 180;
-const CHILD_PROTOCOL_ERROR_PREFIX = "[pi-gremlins]";
+const CHILD_PROTOCOL_ERROR_PREFIX = "[Gremlins🧌]";
 
 function coerceRecord(value: unknown): Record<string, unknown> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return {};

--- a/extensions/pi-gremlins/single-agent-runner.ts
+++ b/extensions/pi-gremlins/single-agent-runner.ts
@@ -679,7 +679,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 		}
 		if (wasAborted) {
 			currentResult.stopReason = "aborted";
-			currentResult.errorMessage = "pi-gremlins run was aborted";
+			currentResult.errorMessage = "Gremlins🧌 run was aborted";
 			bumpResultVisibleRevision(currentResult);
 		}
 		if (childProcessErrorMessage) {


### PR DESCRIPTION
## Summary
- rename user-facing inline and popup UI copy from `pi-gremlins` to `Gremlins🧌` while keeping machine-facing runtime identifiers intact
- rename viewer slash command and inline hints from `/pi-gremlins:view` to `/gremlins:view`
- refresh README and related product/architecture docs for new branding and command usage

## Verification
- npm test
- npm run typecheck

Closes #4