### PR TITLE
Add stable gremlin ids to child runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README now leads with gremlin artwork and refreshed package presentation for the updated viewer experience.
 
 ### Added
+- `pi-gremlins` now assigns stable human-friendly child run ids (`g1`, `g2`, …) at creation time, carries them through result snapshots, and surfaces them in embedded inline summaries, popup viewer chrome, and repeated-agent execution summaries.
 - Product, architecture, and implementation records for viewer overhaul in `docs/prd/0001-pi-gremlins-immersive-theming-and-viewer-ux-overhaul.md`, `docs/adr/0001-semantic-presentation-architecture-for-pi-gremlins-viewer-and-embedded-surfaces.md`, and `docs/plans/pi-gremlins-immersive-theming-viewer-ux-overhaul.md`.
 - PRD/ADR index and template scaffolding under `docs/prd/` and `docs/adr/` for future feature and architecture tracking.
 

--- a/extensions/pi-gremlins/execution-modes.ts
+++ b/extensions/pi-gremlins/execution-modes.ts
@@ -29,6 +29,7 @@ export type RunSingleAgentFn = (
 	task: string,
 	cwd: string | undefined,
 	step: number | undefined,
+	gremlinId: string,
 	signal: AbortSignal | undefined,
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => PiGremlinsDetails,
@@ -48,6 +49,7 @@ interface ExecutionModeDependencies {
 	makeDetails: (
 		mode: InvocationMode,
 	) => (results: SingleResult[]) => PiGremlinsDetails;
+	allocateGremlinId: () => string;
 	packageDiscoveryWarning?: string;
 }
 
@@ -65,10 +67,12 @@ interface ParallelExecutionDependencies extends ExecutionModeDependencies {
 	) => Promise<R[]>;
 }
 
-interface SingleExecutionDependencies extends ExecutionModeDependencies {
+interface SingleExecutionDependencies
+	extends Omit<ExecutionModeDependencies, "allocateGremlinId"> {
 	agent: string;
 	task: string;
 	cwd?: string;
+	gremlinId: string;
 }
 
 const MAX_CHAIN_CARRY_FORWARD_CHARS = 8000;
@@ -124,6 +128,7 @@ export async function executeChainMode({
 	runSingleAgent,
 	handleInvocationUpdate,
 	makeDetails,
+	allocateGremlinId,
 	packageDiscoveryWarning,
 }: ChainExecutionDependencies): Promise<PiGremlinsToolResult> {
 	const results: SingleResult[] = [];
@@ -136,6 +141,7 @@ export async function executeChainMode({
 			previousOutput,
 		);
 
+		const gremlinId = allocateGremlinId();
 		const chainUpdate: OnUpdateCallback = (partial) => {
 			const currentResult = partial.details?.results[0];
 			if (!currentResult) return;
@@ -150,7 +156,13 @@ export async function executeChainMode({
 			content: [{ type: "text", text: "(running...)" }],
 			details: makeDetails("chain")([
 				...results,
-				createPendingResult(step.agent, taskWithContext, i + 1, "unknown"),
+				createPendingResult(
+					step.agent,
+					taskWithContext,
+					i + 1,
+					"unknown",
+					gremlinId,
+				),
 			]),
 		});
 
@@ -161,6 +173,7 @@ export async function executeChainMode({
 			taskWithContext,
 			step.cwd,
 			i + 1,
+			gremlinId,
 			signal,
 			chainUpdate,
 			makeDetails("chain"),
@@ -229,12 +242,23 @@ export async function executeParallelMode({
 	runSingleAgent,
 	handleInvocationUpdate,
 	makeDetails,
+	allocateGremlinId,
 	maxConcurrency,
 	mapWithConcurrencyLimit,
 	packageDiscoveryWarning,
 }: ParallelExecutionDependencies): Promise<PiGremlinsToolResult> {
-	const allResults: SingleResult[] = tasks.map((task) =>
-		createPendingResult(task.agent, task.task, undefined, "unknown"),
+	const taskRuns = tasks.map((task) => ({
+		...task,
+		gremlinId: allocateGremlinId(),
+	}));
+	const allResults: SingleResult[] = taskRuns.map((task) =>
+		createPendingResult(
+			task.agent,
+			task.task,
+			undefined,
+			"unknown",
+			task.gremlinId,
+		),
 	);
 	const trackedExitCodes = allResults.map((result) => result.exitCode);
 	let runningCount = allResults.length;
@@ -268,7 +292,7 @@ export async function executeParallelMode({
 	emitParallelUpdate();
 
 	const results = await mapWithConcurrencyLimit(
-		tasks,
+		taskRuns,
 		maxConcurrency,
 		async (task, index) => {
 			const result = await runSingleAgent(
@@ -278,6 +302,7 @@ export async function executeParallelMode({
 				task.task,
 				task.cwd,
 				undefined,
+				task.gremlinId,
 				signal,
 				(partial) => {
 					if (partial.details?.results[0]) {
@@ -307,7 +332,7 @@ export async function executeParallelMode({
 	if (canceledCount > 0) summaryParts.push(`${canceledCount} canceled`);
 	const summaries = results.map((result, index) => {
 		const output = getFinalOutput(result.messages, result.viewerEntries);
-		return `[${result.agent}] ${statuses[index].toLowerCase()}: ${output || "(no output)"}`;
+		return `[${result.gremlinId} ${result.agent}] ${statuses[index].toLowerCase()}: ${output || "(no output)"}`;
 	});
 	const details = makeDetails("parallel")(results);
 	return {
@@ -332,6 +357,7 @@ export async function executeSingleMode({
 	handleInvocationUpdate,
 	makeDetails,
 	packageDiscoveryWarning,
+	gremlinId,
 }: SingleExecutionDependencies): Promise<PiGremlinsToolResult> {
 	const result = await runSingleAgent(
 		ctxCwd,
@@ -340,6 +366,7 @@ export async function executeSingleMode({
 		task,
 		cwd,
 		undefined,
+		gremlinId,
 		signal,
 		handleInvocationUpdate,
 		makeDetails("single"),

--- a/extensions/pi-gremlins/execution-shared.ts
+++ b/extensions/pi-gremlins/execution-shared.ts
@@ -63,6 +63,7 @@ export type ViewerEntry =
 	  };
 
 export interface SingleResult {
+	gremlinId: string;
 	agent: string;
 	agentSource: AgentSource | "unknown";
 	task: string;
@@ -566,8 +567,10 @@ export function createPendingResult(
 	task: string,
 	step?: number,
 	agentSource: AgentSource | "unknown" = "unknown",
+	gremlinId: string = "g1",
 ): SingleResult {
 	return initializeResultRevisions({
+		gremlinId,
 		agent,
 		agentSource,
 		task,

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -964,6 +964,49 @@ describe("pi-gremlins execute streaming characterization", () => {
 		expect(result.details.status).toBe("Completed");
 	});
 
+	test("single mode assigns stable gremlin id from pending through completion", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					jsonLine({
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: [{ type: "text", text: "single gremlin done" }],
+							usage: {
+								input: 1,
+								output: 1,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: { total: 0.01 },
+								totalTokens: 2,
+							},
+						},
+					}),
+				],
+				closeCode: 0,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const result = await tool.execute(
+			"single-gremlin-id",
+			{ agent: "tars", task: "Track one gremlin id" },
+			undefined,
+			(partial) => updates.push(cloneForAssertion(partial)),
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		expect(updates[0].details.results[0].gremlinId).toBe("g1");
+		expect(result.details.results[0].gremlinId).toBe("g1");
+	});
+
 	test("chain mode emits terminal completion update for one-child runs", async () => {
 		const workspace = createWorkspace();
 		workspaceRoot = workspace.root;
@@ -1015,6 +1058,83 @@ describe("pi-gremlins execute streaming characterization", () => {
 			}),
 		]);
 		expect(result.details.status).toBe("Completed");
+	});
+
+	test("chain mode assigns stable gremlin ids for repeated agent names", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "writer.md", "writer");
+
+		spawnPlans.push(
+			() =>
+				createMockProcess({
+					stdoutChunks: [
+						jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "first pass" }],
+								usage: {
+									input: 1,
+									output: 1,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 2,
+								},
+							},
+						}),
+					],
+					closeCode: 0,
+				}),
+			() =>
+				createMockProcess({
+					stdoutChunks: [
+						jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "second pass" }],
+								usage: {
+									input: 1,
+									output: 1,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 2,
+								},
+							},
+						}),
+					],
+					closeCode: 0,
+				}),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const result = await tool.execute(
+			"chain-repeated-agent-ids",
+			{
+				chain: [
+					{ agent: "writer", task: "Write first pass" },
+					{ agent: "writer", task: "Write second pass" },
+				],
+			},
+			undefined,
+			(partial) => updates.push(cloneForAssertion(partial)),
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		expect(updates[0].details.results[0].gremlinId).toBe("g1");
+		expect(
+			updates.some((update) => update.details.results[1]?.gremlinId === "g2"),
+		).toBe(true);
+		expect(result.details.results.map((child) => child.gremlinId)).toEqual([
+			"g1",
+			"g2",
+		]);
+		expect(result.content[0].text).toBe("second pass");
 	});
 
 	test("chain mode emits pending snapshots, previous substitution, and stops on error", async () => {
@@ -1435,6 +1555,87 @@ describe("pi-gremlins execute streaming characterization", () => {
 		);
 	});
 
+	test("parallel mode assigns stable gremlin ids for repeated agent names", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "alpha.md", "alpha");
+
+		spawnPlans.push(
+			createSpawnPlanForTask("Do alpha first", () =>
+				createMockProcess({
+					stdoutChunks: [
+						jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "alpha first done" }],
+								usage: {
+									input: 3,
+									output: 2,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 5,
+								},
+							},
+						}),
+					],
+					closeCode: 0,
+				}),
+			),
+			createSpawnPlanForTask("Do alpha second", () =>
+				createMockProcess({
+					stdoutChunks: [
+						jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "alpha second done" }],
+								usage: {
+									input: 4,
+									output: 2,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 6,
+								},
+							},
+						}),
+					],
+					closeCode: 0,
+				}),
+			),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const result = await tool.execute(
+			"parallel-repeated-agent-ids",
+			{
+				tasks: [
+					{ agent: "alpha", task: "Do alpha first" },
+					{ agent: "alpha", task: "Do alpha second" },
+				],
+			},
+			undefined,
+			(partial) => updates.push(cloneForAssertion(partial)),
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		expect(updates[0].details.results.map((child) => child.gremlinId)).toEqual([
+			"g1",
+			"g2",
+		]);
+		expect(result.details.results.map((child) => child.gremlinId)).toEqual([
+			"g1",
+			"g2",
+		]);
+		expect(result.content[0].text).toBe(
+			"Parallel: 2/2 succeeded\n\n[g1 alpha] completed: alpha first done\n\n[g2 alpha] completed: alpha second done",
+		);
+	});
+
 	test("parallel mode keeps task outputs aligned when spawn order differs from task order", async () => {
 		const workspace = createWorkspace();
 		workspaceRoot = workspace.root;
@@ -1510,7 +1711,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 		);
 
 		expect(result.content[0].text).toBe(
-			"Parallel: 1/2 succeeded, 1 failed\n\n[alpha] completed: alpha done\n\n[beta] failed: beta failed",
+			"Parallel: 1/2 succeeded, 1 failed\n\n[g1 alpha] completed: alpha done\n\n[g2 beta] failed: beta failed",
 		);
 		expect(result.details.results[0]).toMatchObject({
 			agent: "alpha",
@@ -1657,7 +1858,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 			),
 		).toBe(true);
 		expect(result.content[0].text).toBe(
-			"Parallel: 1/2 succeeded, 1 failed\n\n[alpha] completed: alpha done\n\n[beta] failed: beta failed",
+			"Parallel: 1/2 succeeded, 1 failed\n\n[g1 alpha] completed: alpha done\n\n[g2 beta] failed: beta failed",
 		);
 		expect(result.details.results).toHaveLength(2);
 		expect(result.details.results[0]).toMatchObject({
@@ -1820,7 +2021,7 @@ describe("pi-gremlins execute streaming characterization", () => {
 		expect(result.isError).toBeUndefined();
 		expect(result.details.status).toBe("Canceled");
 		expect(result.content[0].text).toBe(
-			"Parallel: 1/2 succeeded, 1 canceled\n\n[alpha] completed: alpha done\n\n[beta] canceled: beta canceled",
+			"Parallel: 1/2 succeeded, 1 canceled\n\n[g1 alpha] completed: alpha done\n\n[g2 beta] canceled: beta canceled",
 		);
 		expect(result.details.results[1]).toMatchObject({
 			agent: "beta",

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -127,6 +127,7 @@ function createUsage(overrides = {}) {
 
 function createSingleResult(overrides = {}) {
 	return {
+		gremlinId: "g1",
 		agent: "tars",
 		agentSource: "user",
 		task: "Inspect task",
@@ -709,6 +710,44 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).toContain("active ·");
 		expect(text).toContain("[project]");
 		expect(text).toContain("viewer · /pi-gremlins:view");
+	});
+
+	test("renders gremlin ids in embedded parallel summaries for repeated agent names", () => {
+		const tool = createRegisteredTool();
+		const text = renderToText(tool, {
+			content: [{ type: "text", text: "unused" }],
+			details: createDetails("parallel", [
+				createSingleResult({
+					gremlinId: "g1",
+					agent: "alpha",
+					exitCode: -1,
+					task: "Do first alpha task",
+					viewerEntries: [
+						{
+							type: "assistant-text",
+							text: "first alpha still running",
+							streaming: true,
+						},
+					],
+				}),
+				createSingleResult({
+					gremlinId: "g2",
+					agent: "alpha",
+					exitCode: 0,
+					task: "Do second alpha task",
+					messages: [
+						{
+							role: "assistant",
+							content: [{ type: "text", text: "second alpha done" }],
+						},
+					],
+				}),
+			]),
+		});
+
+		expect(text).toContain("active · alpha · first alpha still running · g1");
+		expect(text).toContain("[Running] alpha [user] · g1");
+		expect(text).toContain("[Completed] alpha [user] · g2");
 	});
 
 	test("renders chain collapsed with status-first rows, active-free summary, and readable totals", () => {

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -416,6 +416,7 @@ function buildViewerMetadataLine(
 		formatViewerSourceBadge(theme, result),
 		theme.fg("muted", "· result"),
 		formatViewerStatusBadge(theme, getSingleResultStatus(result)),
+		theme.fg("muted", `· ${result.gremlinId}`),
 	].join(" ");
 }
 
@@ -494,6 +495,7 @@ function isSameResultSnapshotSlot(
 ): boolean {
 	if (!previousResult) return false;
 	return (
+		previousResult.gremlinId === nextResult.gremlinId &&
 		previousResult.agent === nextResult.agent &&
 		previousResult.agentSource === nextResult.agentSource &&
 		previousResult.task === nextResult.task &&
@@ -887,6 +889,7 @@ export class PiGremlinsViewerOverlay extends Container implements Focusable {
 						{
 							agent: this.selectedResult.agent,
 							status: getSingleResultStatus(this.selectedResult),
+							gremlinId: this.selectedResult.gremlinId,
 							step: this.selectedResult.step,
 							sourceBadge: formatViewerSourceBadge(
 								this.theme,
@@ -1158,6 +1161,7 @@ export default function (pi: ExtensionAPI) {
 	const invocationRegistry = new Map<string, InvocationSnapshot>();
 	let latestToolCallId: string | null = null;
 	let viewerOverlayRuntime: ViewerOverlayRuntime | null = null;
+	let nextGremlinOrdinal = 1;
 
 	const hasViewerSnapshot = (toolCallId: string | undefined): boolean => {
 		return toolCallId ? invocationRegistry.has(toolCallId) : false;
@@ -1197,6 +1201,7 @@ export default function (pi: ExtensionAPI) {
 	const clearViewerState = () => {
 		dismissViewerOverlay();
 		latestToolCallId = null;
+		nextGremlinOrdinal = 1;
 		invocationRegistry.clear();
 	};
 
@@ -1339,6 +1344,7 @@ export default function (pi: ExtensionAPI) {
 			const handleInvocationUpdate = (
 				partial: AgentToolResult<PiGremlinsDetails>,
 			) => invocationUpdates.applyPartial(toolCallId, partial);
+			const allocateGremlinId = () => `g${nextGremlinOrdinal++}`;
 			const finalizeResult = (
 				result: PiGremlinsToolResult,
 			): PiGremlinsToolResult => {
@@ -1419,7 +1425,9 @@ export default function (pi: ExtensionAPI) {
 
 			latestToolCallId = toolCallId;
 			updateInvocation(toolCallId, makeDetails(mode)([]), "Running");
-			if (params.agent && params.task) {
+			const singleGremlinId =
+				params.agent && params.task ? allocateGremlinId() : undefined;
+			if (params.agent && params.task && singleGremlinId) {
 				updateInvocation(
 					toolCallId,
 					makeDetails("single")([
@@ -1428,6 +1436,7 @@ export default function (pi: ExtensionAPI) {
 							params.task,
 							undefined,
 							"unknown",
+							singleGremlinId,
 						),
 					]),
 					"Running",
@@ -1444,6 +1453,7 @@ export default function (pi: ExtensionAPI) {
 						runSingleAgent,
 						handleInvocationUpdate,
 						makeDetails,
+						allocateGremlinId,
 						packageDiscoveryWarning,
 					}),
 				);
@@ -1459,6 +1469,7 @@ export default function (pi: ExtensionAPI) {
 						runSingleAgent,
 						handleInvocationUpdate,
 						makeDetails,
+						allocateGremlinId,
 						maxConcurrency: MAX_CONCURRENCY,
 						mapWithConcurrencyLimit,
 						packageDiscoveryWarning,
@@ -1466,7 +1477,7 @@ export default function (pi: ExtensionAPI) {
 				);
 			}
 
-			if (params.agent && params.task) {
+			if (params.agent && params.task && singleGremlinId) {
 				return finalizeResult(
 					await executeSingleMode({
 						agent: params.agent,
@@ -1479,6 +1490,7 @@ export default function (pi: ExtensionAPI) {
 						handleInvocationUpdate,
 						makeDetails,
 						packageDiscoveryWarning,
+						gremlinId: singleGremlinId,
 					}),
 				);
 			}

--- a/extensions/pi-gremlins/index.viewer.test.js
+++ b/extensions/pi-gremlins/index.viewer.test.js
@@ -688,6 +688,51 @@ describe("pi-gremlins viewer command", () => {
 		expect(popup).toContain("error · fatal: fallback mismatch");
 	});
 
+	test("renders gremlin ids in popup focus metadata and navigation context", () => {
+		const alpha = createPendingResult(
+			"alpha",
+			"Inspect first alpha",
+			undefined,
+			"user",
+			"g1",
+		);
+		alpha.viewerEntries.push({
+			type: "assistant-text",
+			text: "first alpha live",
+			streaming: true,
+		});
+		bumpResultDerivedRevision(alpha);
+
+		const beta = createPendingResult(
+			"alpha",
+			"Inspect second alpha",
+			undefined,
+			"project",
+			"g2",
+		);
+		beta.exitCode = 0;
+		beta.messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: "second alpha done" }],
+		});
+		bumpResultVisibleRevision(beta);
+		bumpResultDerivedRevision(beta);
+
+		const snapshot = createInvocationSnapshot(
+			"viewer-gremlin-ids",
+			createDetails("parallel", [alpha, beta]),
+			"Running",
+		);
+		const text = renderOverlayText(snapshot, {
+			width: 72,
+			rows: 24,
+			selectedResultIndex: 1,
+		});
+
+		expect(text).toContain("focus · alpha [project] · result [Completed] · g2");
+		expect(text).toContain("task 2/2 · alpha [project] · Completed · g2");
+	});
+
 	test("renders popup narrow-width layout with essential chrome only", () => {
 		const planner = createPendingResult("planner", "Plan route", 1, "project");
 		planner.exitCode = 0;

--- a/extensions/pi-gremlins/result-rendering.ts
+++ b/extensions/pi-gremlins/result-rendering.ts
@@ -241,17 +241,19 @@ function formatSingleHeader(
 ): string {
 	const status = getSingleResultSemantics(result);
 	const sourceBadge = getSourceBadge(theme, result);
+	const gremlinIdBadge = theme.fg("muted", `· ${result.gremlinId}`);
 	const full = [
 		theme.fg(getStatusTone(status.status), status.icon),
 		formatStatusBadge(theme, status),
 		theme.fg("toolTitle", theme.bold(result.agent)),
 		theme.fg("muted", `· ${modeLabel} ·`),
 		sourceBadge,
+		gremlinIdBadge,
 	].join(" ");
 	const compact = fitMiddleLine(
 		`${formatStatusBadge(theme, status)} `,
 		`${theme.fg("toolTitle", theme.bold(result.agent))}${theme.fg("muted", ` · ${modeLabel}`)}`,
-		` ${sourceBadge}`,
+		` ${sourceBadge} ${gremlinIdBadge}`,
 		width,
 	);
 	return pickLineVariant(width, [full, compact]);
@@ -727,7 +729,7 @@ function buildActiveOverviewLine(
 	return formatLabelLine(
 		theme,
 		"active",
-		`${identity} · ${summary.text}`,
+		`${identity} · ${summary.text} · ${target.gremlinId}`,
 		summary.tone,
 		width,
 	);
@@ -765,7 +767,7 @@ function buildChildRow(
 		fitMiddleLine(
 			`${marker} ${formatStatusBadge(theme, status)} `,
 			theme.fg("accent", identity),
-			` ${sourceBadge}`,
+			` ${sourceBadge} ${theme.fg("muted", `· ${result.gremlinId}`)}`,
 			width,
 		),
 		formatLabelLine(theme, summary.label, summary.text, summary.tone, width),

--- a/extensions/pi-gremlins/single-agent-runner.ts
+++ b/extensions/pi-gremlins/single-agent-runner.ts
@@ -444,6 +444,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 	task,
 	cwd,
 	step,
+	gremlinId,
 	signal,
 	onUpdate,
 	makeDetails,
@@ -454,6 +455,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 
 	if (!agent) {
 		const missingAgentResult = initializeResultRevisions({
+			gremlinId,
 			agent: agentName,
 			agentSource: "unknown",
 			task,
@@ -484,6 +486,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 	let tmpPromptPath: string | null = null;
 
 	const currentResult: SingleResult = initializeResultRevisions({
+		gremlinId,
 		agent: agent.name,
 		agentSource: agent.source,
 		task,

--- a/extensions/pi-gremlins/viewer-result-navigation.test.js
+++ b/extensions/pi-gremlins/viewer-result-navigation.test.js
@@ -360,16 +360,18 @@ describe("viewer result navigation", () => {
 			getResultContextLabel("chain", 1, 3, {
 				agent: "researcher",
 				status: "Running",
+				gremlinId: "g2",
 				step: 2,
 				sourceBadge: "[project]",
 			}),
-		).toBe("focus · step 2/3 · researcher [project] · Running");
+		).toBe("focus · step 2/3 · researcher [project] · Running · g2");
 		expect(
 			getResultContextLabel("parallel", 1, 3, {
 				agent: "reviewer",
 				status: "Completed",
+				gremlinId: "g2",
 			}),
-		).toBe("focus · task 2/3 · reviewer · Completed");
+		).toBe("focus · task 2/3 · reviewer · Completed · g2");
 		expect(
 			getResultContextLabel(
 				"parallel",
@@ -378,6 +380,7 @@ describe("viewer result navigation", () => {
 				{
 					agent: "reviewer-with-very-long-name",
 					status: "Completed",
+					gremlinId: "g2",
 					sourceBadge: "[project]",
 				},
 				30,
@@ -387,6 +390,7 @@ describe("viewer result navigation", () => {
 			getResultContextLabel("single", 0, 1, {
 				agent: "writer",
 				status: "Completed",
+				gremlinId: "g1",
 			}),
 		).toBeNull();
 	});

--- a/extensions/pi-gremlins/viewer-result-navigation.ts
+++ b/extensions/pi-gremlins/viewer-result-navigation.ts
@@ -10,6 +10,7 @@ export type ViewerResultContextMode = "single" | "parallel" | "chain";
 export interface ViewerResultContext {
 	agent: string;
 	status: string;
+	gremlinId: string;
 	step?: number;
 	sourceBadge?: string;
 }
@@ -292,8 +293,8 @@ export function getResultContextLabel(
 				: `item ${selectedResultIndex + 1}/${resultCount}`;
 	const sourceBadge = result.sourceBadge ? ` ${result.sourceBadge}` : "";
 	return pickLineVariant(dialogWidth, [
-		`focus · ${position} · ${result.agent}${sourceBadge} · ${result.status}`,
-		`${position} · ${result.agent}${sourceBadge} · ${result.status}`,
-		`${position} · ${result.agent}${sourceBadge}`,
+		`focus · ${position} · ${result.agent}${sourceBadge} · ${result.status} · ${result.gremlinId}`,
+		`${position} · ${result.agent}${sourceBadge} · ${result.status} · ${result.gremlinId}`,
+		`${position} · ${result.agent}${sourceBadge} · ${result.gremlinId}`,
 	]);
 }


### PR DESCRIPTION
## Summary
- assign stable user-friendly gremlin ids when child runs are created and carry them through result snapshots
- surface gremlin ids in inline render output, popup viewer context, and repeated-agent parallel summaries
- add regression coverage for single, chain, and parallel id stability plus repeated-agent rendering/viewer output

## Verification
- npm run check

Closes #5