### PR TITLE
fix: keep live mission-control chain results navigable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Gremlins🧌 mission control now keeps full ordered chain result slots in live viewer snapshots, so left/right navigation can reach completed earlier steps and pending later steps while current chain work is still running.
 - `pi-gremlins` now emits explicit terminal completion updates for single-child `single` and one-step `chain` runs after child exit, so parent flows receive terminal status snapshots before final tool results land.
 - `pi-gremlins` now finalizes child runs on process exit even if `close` never arrives, preserving terminal tool results and parent-session completion for exit-complete gremlin work.
 - Embedded `pi-gremlins` inline expansion now reuses its rendered text component so newly revealed content keeps viewport anchoring stable instead of forcing a jump to bottom.

--- a/extensions/pi-gremlins/execution-modes.ts
+++ b/extensions/pi-gremlins/execution-modes.ts
@@ -131,39 +131,58 @@ export async function executeChainMode({
 	allocateGremlinId,
 	packageDiscoveryWarning,
 }: ChainExecutionDependencies): Promise<PiGremlinsToolResult> {
+	const chainRuns = chain.map((step, index) => ({
+		...step,
+		stepNumber: index + 1,
+		gremlinId: allocateGremlinId(),
+	}));
+	const viewerResults: SingleResult[] = chainRuns.map((step) =>
+		createPendingResult(
+			step.agent,
+			step.task,
+			step.stepNumber,
+			"unknown",
+			step.gremlinId,
+		),
+	);
+	const buildLiveChainDetails = (
+		results: SingleResult[],
+	): PiGremlinsDetails => ({
+		...makeDetails("chain")(results),
+		viewerResults: [...viewerResults],
+	});
 	const results: SingleResult[] = [];
 	let previousOutput = "";
 
-	for (let i = 0; i < chain.length; i++) {
-		const step = chain[i];
+	for (let i = 0; i < chainRuns.length; i++) {
+		const step = chainRuns[i];
 		const taskWithContext = applyPreviousOutputToChainTask(
 			step.task,
 			previousOutput,
 		);
+		const pendingResult = createPendingResult(
+			step.agent,
+			taskWithContext,
+			step.stepNumber,
+			"unknown",
+			step.gremlinId,
+		);
+		viewerResults[i] = pendingResult;
 
-		const gremlinId = allocateGremlinId();
 		const chainUpdate: OnUpdateCallback = (partial) => {
 			const currentResult = partial.details?.results[0];
 			if (!currentResult) return;
+			viewerResults[i] = currentResult;
 			const allResults = [...results, currentResult];
 			handleInvocationUpdate({
 				content: partial.content,
-				details: makeDetails("chain")(allResults),
+				details: buildLiveChainDetails(allResults),
 			});
 		};
 
 		handleInvocationUpdate({
 			content: [{ type: "text", text: "(running...)" }],
-			details: makeDetails("chain")([
-				...results,
-				createPendingResult(
-					step.agent,
-					taskWithContext,
-					i + 1,
-					"unknown",
-					gremlinId,
-				),
-			]),
+			details: buildLiveChainDetails([...results, pendingResult]),
 		});
 
 		const result = await runSingleAgent(
@@ -172,14 +191,15 @@ export async function executeChainMode({
 			step.agent,
 			taskWithContext,
 			step.cwd,
-			i + 1,
-			gremlinId,
+			step.stepNumber,
+			step.gremlinId,
 			signal,
 			chainUpdate,
 			makeDetails("chain"),
 			packageDiscoveryWarning,
 		);
 		results.push(result);
+		viewerResults[i] = result;
 
 		const resultStatus = getSingleResultStatus(result);
 		if (resultStatus === "Failed" || resultStatus === "Canceled") {
@@ -189,7 +209,7 @@ export async function executeChainMode({
 					content: [
 						{
 							type: "text" as const,
-							text: `Chain canceled at step ${i + 1} (${step.agent}): ${getSingleResultErrorText(result)}`,
+							text: `Chain canceled at step ${step.stepNumber} (${step.agent}): ${getSingleResultErrorText(result)}`,
 						},
 					],
 					details,
@@ -201,7 +221,7 @@ export async function executeChainMode({
 				content: [
 					{
 						type: "text" as const,
-						text: `Chain stopped at step ${i + 1} (${step.agent}): ${getSingleResultErrorText(result)}`,
+						text: `Chain stopped at step ${step.stepNumber} (${step.agent}): ${getSingleResultErrorText(result)}`,
 					},
 				],
 				details,

--- a/extensions/pi-gremlins/execution-shared.ts
+++ b/extensions/pi-gremlins/execution-shared.ts
@@ -83,6 +83,7 @@ export interface PiGremlinsDetails {
 	agentScope: AgentScope;
 	projectAgentsDir: string | null;
 	results: SingleResult[];
+	viewerResults?: SingleResult[];
 }
 
 export interface ViewerToolCallRecord {

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -1234,22 +1234,52 @@ describe("pi-gremlins execute streaming characterization", () => {
 				task: "Draft initial answer",
 				exitCode: -1,
 			}),
+			expect.objectContaining({
+				agent: "reviewer",
+				step: 2,
+				task: "Review {previous} carefully",
+				exitCode: -1,
+			}),
+			expect.objectContaining({
+				agent: "closer",
+				step: 3,
+				task: "Finalize {previous}",
+				exitCode: -1,
+			}),
+		]);
+		expect(updates[0].details.viewerResults).toEqual([
+			expect.objectContaining({
+				agent: "writer",
+				step: 1,
+				task: "Draft initial answer",
+				exitCode: -1,
+			}),
+			expect.objectContaining({
+				agent: "reviewer",
+				step: 2,
+				task: "Review {previous} carefully",
+				exitCode: -1,
+			}),
+			expect.objectContaining({
+				agent: "closer",
+				step: 3,
+				task: "Finalize {previous}",
+				exitCode: -1,
+			}),
 		]);
 		expect(
-			updates.some(
-				(update) =>
-					update.details.results.length === 1 &&
-					update.details.results[0].viewerEntries.some(
-						(entry) =>
-							entry.type === "tool-result" &&
-							entry.streaming === true &&
-							entry.content === "drafting",
-					),
+			updates.some((update) =>
+				update.details.results[0].viewerEntries.some(
+					(entry) =>
+						entry.type === "tool-result" &&
+						entry.streaming === true &&
+						entry.content === "drafting",
+				),
 			),
 		).toBe(true);
 		const secondStepPending = updates.find(
 			(update) =>
-				update.details.results.length === 2 &&
+				update.details.results.length === 3 &&
 				update.details.results[1].task === "Review draft one carefully",
 		);
 		expect(secondStepPending).toBeDefined();
@@ -1262,16 +1292,33 @@ describe("pi-gremlins execute streaming characterization", () => {
 			step: 2,
 			exitCode: -1,
 		});
+		expect(secondStepPending.details.viewerResults).toEqual([
+			expect.objectContaining({
+				agent: "writer",
+				step: 1,
+				exitCode: 0,
+			}),
+			expect.objectContaining({
+				agent: "reviewer",
+				step: 2,
+				task: "Review draft one carefully",
+				exitCode: -1,
+			}),
+			expect.objectContaining({
+				agent: "closer",
+				step: 3,
+				task: "Finalize {previous}",
+				exitCode: -1,
+			}),
+		]);
 		expect(
-			updates.some(
-				(update) =>
-					update.details.results.length === 2 &&
-					update.details.results[1].viewerEntries.some(
-						(entry) =>
-							entry.type === "tool-result" &&
-							entry.streaming === true &&
-							entry.content === "reviewing",
-					),
+			updates.some((update) =>
+				update.details.results[1].viewerEntries.some(
+					(entry) =>
+						entry.type === "tool-result" &&
+						entry.streaming === true &&
+						entry.content === "reviewing",
+				),
 			),
 		).toBe(true);
 		expect(result.isError).toBe(true);

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -511,8 +511,9 @@ export function createInvocationSnapshot(
 	status = getInvocationStatus(details.mode, details.results),
 	previousSnapshot?: InvocationSnapshot,
 ): InvocationSnapshot {
+	const snapshotResults = details.viewerResults ?? details.results;
 	const previousResults = previousSnapshot?.results ?? [];
-	const nextResults = details.results.map((result, index) => {
+	const nextResults = snapshotResults.map((result, index) => {
 		initializeResultRevisions(result);
 		const previousResult = previousResults[index];
 		if (

--- a/extensions/pi-gremlins/index.viewer.test.js
+++ b/extensions/pi-gremlins/index.viewer.test.js
@@ -865,6 +865,62 @@ describe("pi-gremlins viewer command", () => {
 		expect(text).not.toContain("←/→ result");
 	});
 
+	test("uses full ordered live chain viewer results for navigation beyond active step", () => {
+		const writer = createPendingResult(
+			"writer",
+			"Draft initial answer",
+			1,
+			"user",
+			"g1",
+		);
+		writer.exitCode = 0;
+		writer.messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: "draft ready" }],
+		});
+		bumpResultVisibleRevision(writer);
+		bumpResultDerivedRevision(writer);
+
+		const reviewer = createPendingResult(
+			"reviewer",
+			"Review draft ready carefully",
+			2,
+			"user",
+			"g2",
+		);
+		reviewer.viewerEntries.push({
+			type: "assistant-text",
+			text: "reviewing",
+			streaming: true,
+		});
+		bumpResultDerivedRevision(reviewer);
+
+		const closer = createPendingResult(
+			"closer",
+			"Finalize {previous}",
+			3,
+			"user",
+			"g3",
+		);
+
+		const snapshot = createInvocationSnapshot(
+			"viewer-chain-live-full-order",
+			{
+				...createDetails("chain", [writer, reviewer]),
+				viewerResults: [writer, reviewer, closer],
+			},
+			"Running",
+		);
+		const text = renderOverlayText(snapshot, {
+			width: 72,
+			rows: 24,
+			selectedResultIndex: 2,
+		});
+
+		expect(text).toContain("focus · step 3/3 · closer [user] · Running · g3");
+		expect(text).toContain("task · Finalize {previous}");
+	});
+
 	test("renders mission-control chrome with focused mixed-model telemetry visible", () => {
 		const planner = createPendingResult("planner", "Plan route", 1, "project");
 		planner.exitCode = 0;


### PR DESCRIPTION
## Summary
- keep full ordered chain result slots in live mission-control snapshots so left/right navigation can reach completed and pending steps during active runs
- preserve existing terminal chain summaries while exposing viewer-only result ordering for live snapshots
- add regression coverage for live chain snapshot ordering and viewer navigation

## Verification
- npm run check

Closes #16