### PR TITLE
feat: add targeted gremlin steering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - User-facing Gremlins🧌 branding now replaces `pi-gremlins` across inline tool chrome, popup viewer copy, viewer hints, README examples, and slash-command help, while machine-facing package/install identifiers stay `pi-gremlins`.
+- Gremlin child execution now runs through Pi RPC mode with live stdin steering, letting session commands route targeted follow-up guidance into one active gremlin instead of fire-and-finish subprocesses only.
 - `pi-gremlins` now prunes older terminal invocation snapshots while preserving latest and active viewer state, reducing long-session mission-control memory growth.
 - Internal subprocess lifecycle and tool text logic now live in focused modules, reducing `index.ts` responsibility concentration and lowering reliability-fix change risk.
 - Inline `pi-gremlins` expand hints now advertise `Ctrl+O`, and lair scroll-to-start/end aliases now use `Alt+↑` / `Alt+↓` while preserving `Home` / `End` support.
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `pi-gremlins` now assigns stable human-friendly child run ids (`g1`, `g2`, …) at creation time, carries them through result snapshots, and surfaces them in embedded inline summaries, popup viewer chrome, and repeated-agent execution summaries.
+- New `/gremlins:steer <gremlin-id> <message>` command routes a follow-up message to one active gremlin session, records the steering event in embedded/popup output, and reports helpful errors for missing payload, unknown ids, and inactive gremlins.
 - Product, architecture, and implementation records for viewer overhaul in `docs/prd/0001-pi-gremlins-immersive-theming-and-viewer-ux-overhaul.md`, `docs/adr/0001-semantic-presentation-architecture-for-pi-gremlins-viewer-and-embedded-surfaces.md`, and `docs/plans/pi-gremlins-immersive-theming-viewer-ux-overhaul.md`.
 - PRD/ADR index and template scaffolding under `docs/prd/` and `docs/adr/` for future feature and architecture tracking.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,30 @@ Viewer command:
 
 Opens popup lair for latest `Gremlins🧌` run in current session.
 
+Friendly gremlin ids:
+
+- each active child run gets session-local id like `g1`, `g2`, `g3`
+- ids appear in embedded summaries and popup viewer metadata
+- repeated agent names stay steerable because routing keys on gremlin id, not agent name
+
+Targeted steering command:
+
+```text
+/gremlins:steer <gremlin-id> <message>
+```
+
+Example:
+
+```text
+/gremlins:steer g2 update README too
+```
+
+Behavior:
+
+- routes follow-up message only to selected active gremlin session
+- records steering event in inline feed and popup viewer for auditability
+- shows helpful error for missing message, unknown id, or completed/inactive gremlin
+
 ## Repo layout
 
 ```text

--- a/extensions/pi-gremlins/agents.test.js
+++ b/extensions/pi-gremlins/agents.test.js
@@ -36,6 +36,10 @@ function createMockProcess({
 	const proc = new EventEmitter();
 	proc.stdout = new EventEmitter();
 	proc.stderr = new EventEmitter();
+	proc.stdin = {
+		write: () => true,
+		end: () => {},
+	};
 	proc.killed = false;
 	proc.kill = () => {
 		proc.killed = true;
@@ -48,6 +52,7 @@ function createMockProcess({
 		for (const chunk of stderrChunks) {
 			proc.stderr.emit("data", Buffer.from(chunk));
 		}
+		proc.emit("exit", closeCode);
 		proc.emit("close", closeCode);
 	});
 

--- a/extensions/pi-gremlins/execution-modes.ts
+++ b/extensions/pi-gremlins/execution-modes.ts
@@ -22,6 +22,15 @@ export interface TaskExecutionItem {
 
 export interface ChainExecutionItem extends TaskExecutionItem {}
 
+export interface SteerableGremlinSession {
+	steer: (message: string) => Promise<void>;
+}
+
+export interface SteerableSessionCallbacks {
+	register: (gremlinId: string, session: SteerableGremlinSession) => void;
+	unregister: (gremlinId: string) => void;
+}
+
 export type RunSingleAgentFn = (
 	defaultCwd: string,
 	agents: AgentConfig[],
@@ -34,6 +43,7 @@ export type RunSingleAgentFn = (
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => PiGremlinsDetails,
 	packageDiscoveryWarning?: string,
+	steerableSessionCallbacks?: SteerableSessionCallbacks,
 ) => Promise<SingleResult>;
 
 export type OnUpdateCallback = (
@@ -51,6 +61,7 @@ interface ExecutionModeDependencies {
 	) => (results: SingleResult[]) => PiGremlinsDetails;
 	allocateGremlinId: () => string;
 	packageDiscoveryWarning?: string;
+	steerableSessionCallbacks?: SteerableSessionCallbacks;
 }
 
 interface ChainExecutionDependencies extends ExecutionModeDependencies {
@@ -130,6 +141,7 @@ export async function executeChainMode({
 	makeDetails,
 	allocateGremlinId,
 	packageDiscoveryWarning,
+	steerableSessionCallbacks,
 }: ChainExecutionDependencies): Promise<PiGremlinsToolResult> {
 	const results: SingleResult[] = [];
 	let previousOutput = "";
@@ -178,6 +190,7 @@ export async function executeChainMode({
 			chainUpdate,
 			makeDetails("chain"),
 			packageDiscoveryWarning,
+			steerableSessionCallbacks,
 		);
 		results.push(result);
 
@@ -246,6 +259,7 @@ export async function executeParallelMode({
 	maxConcurrency,
 	mapWithConcurrencyLimit,
 	packageDiscoveryWarning,
+	steerableSessionCallbacks,
 }: ParallelExecutionDependencies): Promise<PiGremlinsToolResult> {
 	const taskRuns = tasks.map((task) => ({
 		...task,
@@ -312,6 +326,7 @@ export async function executeParallelMode({
 				},
 				makeDetails("parallel"),
 				packageDiscoveryWarning,
+				steerableSessionCallbacks,
 			);
 			replaceParallelResult(index, result);
 			emitParallelUpdate();
@@ -358,6 +373,7 @@ export async function executeSingleMode({
 	makeDetails,
 	packageDiscoveryWarning,
 	gremlinId,
+	steerableSessionCallbacks,
 }: SingleExecutionDependencies): Promise<PiGremlinsToolResult> {
 	const result = await runSingleAgent(
 		ctxCwd,
@@ -371,6 +387,7 @@ export async function executeSingleMode({
 		handleInvocationUpdate,
 		makeDetails("single"),
 		packageDiscoveryWarning,
+		steerableSessionCallbacks,
 	);
 	const details = makeDetails("single")([result]);
 	const resultStatus = getSingleResultStatus(result);

--- a/extensions/pi-gremlins/execution-shared.ts
+++ b/extensions/pi-gremlins/execution-shared.ts
@@ -46,6 +46,7 @@ export type StatusTone = "warning" | "success" | "error";
 
 export type ViewerEntry =
 	| { type: "assistant-text"; text: string; streaming: boolean }
+	| { type: "steer"; text: string; streaming: boolean; isError: boolean }
 	| {
 			type: "tool-call";
 			toolCallId: string;
@@ -97,6 +98,7 @@ export interface SingleRunViewerState {
 
 export type DisplayItem =
 	| { type: "text"; text: string; streaming?: boolean }
+	| { type: "steer"; content: string; streaming: boolean; isError: boolean }
 	| {
 			type: "toolCall";
 			name: string;
@@ -333,6 +335,15 @@ function buildDerivedRenderDataFromViewerEntries(
 				streaming: entry.streaming || undefined,
 			});
 			if (entry.text.trim()) finalAssistantOutput = entry.text;
+			continue;
+		}
+		if (entry.type === "steer") {
+			displayItems.push({
+				type: "steer",
+				content: entry.text,
+				streaming: entry.streaming,
+				isError: entry.isError,
+			});
 			continue;
 		}
 		if (entry.type === "tool-call") {

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { execSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 
 import {
@@ -18,10 +19,76 @@ let packageResolveError = null;
 
 function createSpawnPlanForTask(task, factory) {
 	return {
+		task,
 		match: (_command, args) =>
 			Array.isArray(args) && args.includes(`Task: ${task}`),
 		factory,
 	};
+}
+
+function createDeferredPromptMatchedProcess(args) {
+	const proc = new EventEmitter();
+	proc.stdout = new EventEmitter();
+	proc.stderr = new EventEmitter();
+	proc.stdinWrites = [];
+	proc.stdinEnded = false;
+	proc.killed = false;
+	let stdinBuffer = "";
+	proc.stdin = {
+		write(chunk) {
+			const text = Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+			proc.stdinWrites.push(text);
+			stdinBuffer += text;
+			const lines = stdinBuffer.split("\n");
+			stdinBuffer = lines.pop() || "";
+			for (const line of lines) {
+				if (!line.trim()) continue;
+				let command;
+				try {
+					command = JSON.parse(line);
+				} catch {
+					continue;
+				}
+				if (typeof command?.message !== "string") continue;
+				const matchedIndex = spawnPlans.findIndex(
+					(plan) =>
+						typeof plan !== "function" &&
+						command.message === `Task: ${plan.task}`,
+				);
+				if (matchedIndex === -1) continue;
+				const [plan] = spawnPlans.splice(matchedIndex, 1);
+				const targetProc = plan.factory(...args);
+				proc.kill = (...killArgs) => {
+					proc.killed = true;
+					return targetProc.kill?.(...killArgs);
+				};
+				targetProc.stdout.on("data", (data) => {
+					proc.stdout.emit("data", data);
+				});
+				targetProc.stderr.on("data", (data) => {
+					proc.stderr.emit("data", data);
+				});
+				targetProc.on("exit", (code) => {
+					proc.emit("exit", code);
+				});
+				targetProc.on("close", (code) => {
+					proc.emit("close", code);
+				});
+				targetProc.on("error", (error) => {
+					proc.emit("error", error);
+				});
+			}
+			return true;
+		},
+		end(chunk) {
+			if (chunk !== undefined) this.write(chunk);
+			proc.stdinEnded = true;
+		},
+	};
+	proc.kill = () => {
+		proc.killed = true;
+	};
+	return proc;
 }
 
 function resolveSpawnPlan(args) {
@@ -34,6 +101,9 @@ function resolveSpawnPlan(args) {
 		const [plan] = spawnPlans.splice(matchedIndex, 1);
 		return plan.factory(...args);
 	}
+	if (spawnPlans.some((plan) => typeof plan !== "function")) {
+		return createDeferredPromptMatchedProcess(args);
+	}
 	const next = spawnPlans.shift();
 	if (!next) return createMockProcess();
 	return typeof next === "function" ? next(...args) : next.factory(...args);
@@ -42,8 +112,9 @@ function resolveSpawnPlan(args) {
 mock.module("node:child_process", () => ({
 	execSync,
 	spawn: (...args) => {
-		spawnCalls.push(args);
-		return resolveSpawnPlan(args);
+		const proc = resolveSpawnPlan(args);
+		spawnCalls.push([...args, proc]);
+		return proc;
 	},
 }));
 
@@ -129,16 +200,23 @@ const {
 	getSingleResultStatus,
 } = await import("./execution-shared.ts");
 
-function createRegisteredTool() {
+function createExtensionHarness() {
 	let registeredTool;
+	const commands = new Map();
 	registerPiGremlins({
 		on: () => {},
-		registerCommand: () => {},
+		registerCommand: (name, command) => {
+			commands.set(name, command);
+		},
 		registerTool: (tool) => {
 			registeredTool = tool;
 		},
 	});
-	return registeredTool;
+	return { tool: registeredTool, commands };
+}
+
+function createRegisteredTool() {
+	return createExtensionHarness().tool;
 }
 
 function createExecutionContext(cwd) {
@@ -1350,8 +1428,9 @@ describe("pi-gremlins execute streaming characterization", () => {
 		);
 
 		expect(spawnCalls).toHaveLength(2);
-		expect(spawnCalls[1][1]).toContain(
-			"Task: Review carry-forward draft carefully",
+		const secondPrompt = spawnCalls[1][3].stdinWrites.join("");
+		expect(secondPrompt).toContain(
+			'"message":"Task: Review carry-forward draft carefully"',
 		);
 		expect(result.isError).toBeUndefined();
 		expect(result.content[0].text).toBe(
@@ -1723,6 +1802,140 @@ describe("pi-gremlins execute streaming characterization", () => {
 		});
 	});
 
+	test("parallel mode steers only targeted gremlin session by id", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "alpha.md", "alpha");
+		writeAgentFile(workspace.userAgentsDir, "beta.md", "beta");
+
+		spawnPlans.push(
+			createSpawnPlanForTask("Do alpha", () =>
+				createMockProcess({
+					stdoutChunks: [
+						{
+							delay: 5,
+							data: jsonLine({
+								type: "message_start",
+								message: {
+									role: "assistant",
+									content: [{ type: "text", text: "alpha drafting" }],
+								},
+							}),
+						},
+						{
+							delay: 45,
+							data: jsonLine({
+								type: "message_end",
+								message: {
+									role: "assistant",
+									content: [{ type: "text", text: "alpha done" }],
+									usage: {
+										input: 2,
+										output: 2,
+										cacheRead: 0,
+										cacheWrite: 0,
+										cost: { total: 0.01 },
+										totalTokens: 4,
+									},
+								},
+							}),
+						},
+					],
+					closeCode: 0,
+					closeDelay: 60,
+				}),
+			),
+			createSpawnPlanForTask("Do beta", () =>
+				createMockProcess({
+					stdoutChunks: [
+						{
+							delay: 5,
+							data: jsonLine({
+								type: "message_start",
+								message: {
+									role: "assistant",
+									content: [{ type: "text", text: "beta drafting" }],
+								},
+							}),
+						},
+						{
+							delay: 50,
+							data: jsonLine({
+								type: "message_end",
+								message: {
+									role: "assistant",
+									content: [{ type: "text", text: "beta done" }],
+									usage: {
+										input: 2,
+										output: 2,
+										cacheRead: 0,
+										cacheWrite: 0,
+										cost: { total: 0.01 },
+										totalTokens: 4,
+									},
+								},
+							}),
+						},
+					],
+					closeCode: 0,
+					closeDelay: 65,
+				}),
+			),
+		);
+
+		const { tool, commands } = createExtensionHarness();
+		const executePromise = tool.execute(
+			"parallel-steer-targeted",
+			{
+				tasks: [
+					{ agent: "alpha", task: "Do alpha" },
+					{ agent: "beta", task: "Do beta" },
+				],
+			},
+			undefined,
+			undefined,
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 15));
+		const notifications = [];
+		await commands.get("gremlins:steer").handler("g2 update README too", {
+			hasUI: true,
+			ui: {
+				notify: (message, level) => {
+					notifications.push({ message, level });
+				},
+				custom: async () => {},
+			},
+		});
+
+		const result = await executePromise;
+
+		const alphaCommands = spawnCalls[0][3].stdinWrites.join("");
+		const betaCommands = spawnCalls[1][3].stdinWrites.join("");
+		expect(alphaCommands).not.toContain('"type":"steer"');
+		expect(betaCommands).toContain(
+			'"type":"steer","message":"update README too"',
+		);
+		expect(notifications).toContainEqual({
+			message: "Steered g2 (beta): update README too",
+			level: "info",
+		});
+		expect(result.details.results[0].viewerEntries).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ type: "steer" })]),
+		);
+		expect(result.details.results[1].viewerEntries).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "steer",
+					text: "update README too",
+					isError: false,
+				}),
+			]),
+		);
+	});
+
 	test("parallel mode streams initial pending state, per-task progress, and final aggregate details", async () => {
 		const workspace = createWorkspace();
 		workspaceRoot = workspace.root;
@@ -1940,13 +2153,11 @@ describe("pi-gremlins execute streaming characterization", () => {
 		);
 
 		expect(spawnCalls).toHaveLength(2);
-		const secondTaskArg = spawnCalls[1][1].find(
-			(arg) => typeof arg === "string" && arg.startsWith("Task: Review "),
-		);
-		expect(secondTaskArg).toContain(
+		const secondPrompt = spawnCalls[1][3].stdinWrites.join("");
+		expect(secondPrompt).toContain(
 			"...[truncated by Gremlins🧌 chain handoff]",
 		);
-		expect(secondTaskArg.length).toBeLessThanOrEqual(8100);
+		expect(secondPrompt.length).toBeLessThanOrEqual(8200);
 	});
 
 	test("parallel mode reports canceled children without labeling them failed", async () => {

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -440,6 +440,38 @@ describe("pi-gremlins renderResult characterization", () => {
 		expect(text).not.toContain("✗ tars");
 	});
 
+	test("renders steering events in embedded summaries for auditability", () => {
+		const tool = createRegisteredTool();
+		const text = renderToText(
+			tool,
+			{
+				content: [{ type: "text", text: "unused" }],
+				details: createDetails("single", [
+					createSingleResult({
+						exitCode: -1,
+						viewerEntries: [
+							{
+								type: "assistant-text",
+								text: "drafting answer",
+								streaming: true,
+							},
+							{
+								type: "steer",
+								text: "update README too",
+								streaming: false,
+								isError: false,
+							},
+						],
+					}),
+				]),
+			},
+			{ expanded: true },
+		);
+
+		expect(text).toContain("steer · update README too");
+		expect(text).toContain("live · drafting answer");
+	});
+
 	test("keeps no-entry tool-call-only single summaries terminal-safe and running-live", () => {
 		const tool = createRegisteredTool();
 		const completed = renderToText(tool, {

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -41,6 +41,7 @@ import {
 	executeParallelMode,
 	executeSingleMode,
 	type PiGremlinsToolResult,
+	type SteerableGremlinSession,
 } from "./execution-modes.js";
 import {
 	aggregateUsage,
@@ -97,8 +98,10 @@ const MAX_CONCURRENCY = 4;
 const MAX_INVOCATION_SNAPSHOTS = 24;
 const BRAND_NAME = "Gremlins🧌";
 const VIEWER_COMMAND = "gremlins:view";
+const STEER_COMMAND = "gremlins:steer";
 const NO_INVOCATION_TEXT = `No ${BRAND_NAME} run available in this session.`;
 const VIEWER_TITLE = `${BRAND_NAME} mission control`;
+const STEER_USAGE_TEXT = `Usage: /${STEER_COMMAND} <gremlin-id> <message>`;
 
 function formatToolCall(
 	toolName: string,
@@ -183,6 +186,12 @@ interface InvocationSnapshot extends PiGremlinsDetails {
 	toolCallId: string;
 	status: InvocationStatus;
 	updatedAt: number;
+}
+
+interface ActiveGremlinSessionRecord {
+	toolCallId: string;
+	agent: string;
+	session: SteerableGremlinSession;
 }
 
 interface ViewerOverlayRuntime {
@@ -313,6 +322,26 @@ function buildViewerEntryLines(
 			);
 			continue;
 		}
+		if (entry.type === "steer") {
+			const badges: string[] = [];
+			if (entry.streaming) badges.push(theme.fg("warning", "[live]"));
+			if (entry.isError) badges.push(theme.fg("error", "[error]"));
+			const steerTone = entry.isError
+				? "error"
+				: entry.streaming
+					? "warning"
+					: "accent";
+			pushViewerTextBlock(
+				lines,
+				theme,
+				entry.isError ? "steer error" : "steer",
+				entry.text,
+				steerTone,
+				badges,
+			);
+			continue;
+		}
+		if (entry.type !== "tool-result") continue;
 		const badges: string[] = [];
 		if (entry.streaming) badges.push(theme.fg("warning", "[live]"));
 		if (entry.truncated) badges.push(theme.fg("muted", "[truncated]"));
@@ -1161,12 +1190,24 @@ function pruneInvocationRegistry(
 
 export default function (pi: ExtensionAPI) {
 	const invocationRegistry = new Map<string, InvocationSnapshot>();
+	const activeGremlinSessions = new Map<string, ActiveGremlinSessionRecord>();
 	let latestToolCallId: string | null = null;
 	let viewerOverlayRuntime: ViewerOverlayRuntime | null = null;
 	let nextGremlinOrdinal = 1;
 
 	const hasViewerSnapshot = (toolCallId: string | undefined): boolean => {
 		return toolCallId ? invocationRegistry.has(toolCallId) : false;
+	};
+
+	const findGremlinResult = (gremlinId: string) => {
+		const snapshots = Array.from(invocationRegistry.values()).reverse();
+		for (const snapshot of snapshots) {
+			const result = snapshot.results.find(
+				(candidate) => candidate.gremlinId === gremlinId,
+			);
+			if (result) return { snapshot, result };
+		}
+		return null;
 	};
 
 	const publishInvocationSnapshot = (
@@ -1204,6 +1245,7 @@ export default function (pi: ExtensionAPI) {
 		dismissViewerOverlay();
 		latestToolCallId = null;
 		nextGremlinOrdinal = 1;
+		activeGremlinSessions.clear();
 		invocationRegistry.clear();
 	};
 
@@ -1347,6 +1389,19 @@ export default function (pi: ExtensionAPI) {
 				partial: AgentToolResult<PiGremlinsDetails>,
 			) => invocationUpdates.applyPartial(toolCallId, partial);
 			const allocateGremlinId = () => `g${nextGremlinOrdinal++}`;
+			const steerableSessionCallbacks = {
+				register: (gremlinId: string, session: SteerableGremlinSession) => {
+					const knownGremlin = findGremlinResult(gremlinId);
+					activeGremlinSessions.set(gremlinId, {
+						toolCallId,
+						agent: knownGremlin?.result.agent ?? "unknown",
+						session,
+					});
+				},
+				unregister: (gremlinId: string) => {
+					activeGremlinSessions.delete(gremlinId);
+				},
+			};
 			const finalizeResult = (
 				result: PiGremlinsToolResult,
 			): PiGremlinsToolResult => {
@@ -1457,6 +1512,7 @@ export default function (pi: ExtensionAPI) {
 						makeDetails,
 						allocateGremlinId,
 						packageDiscoveryWarning,
+						steerableSessionCallbacks,
 					}),
 				);
 			}
@@ -1475,6 +1531,7 @@ export default function (pi: ExtensionAPI) {
 						maxConcurrency: MAX_CONCURRENCY,
 						mapWithConcurrencyLimit,
 						packageDiscoveryWarning,
+						steerableSessionCallbacks,
 					}),
 				);
 			}
@@ -1493,6 +1550,7 @@ export default function (pi: ExtensionAPI) {
 						makeDetails,
 						packageDiscoveryWarning,
 						gremlinId: singleGremlinId,
+						steerableSessionCallbacks,
 					}),
 				);
 			}
@@ -1572,6 +1630,49 @@ export default function (pi: ExtensionAPI) {
 		description: `Open popup lair for latest ${BRAND_NAME} run in this session.`,
 		handler: async (_args, ctx) => {
 			await openViewer(ctx);
+		},
+	});
+
+	pi.registerCommand(STEER_COMMAND, {
+		description: `Steer one active ${BRAND_NAME} run by gremlin id.`,
+		handler: async (args, ctx) => {
+			if (!ctx.hasUI) return;
+			const argText = Array.isArray(args) ? args.join(" ") : args;
+			const argParts = argText.trim() ? argText.trim().split(/\s+/) : [];
+			const gremlinId = argParts[0]?.trim();
+			const message = argParts.slice(1).join(" ").trim();
+			if (!gremlinId || !message) {
+				ctx.ui.notify(STEER_USAGE_TEXT, "error");
+				return;
+			}
+
+			const activeSession = activeGremlinSessions.get(gremlinId);
+			if (!activeSession) {
+				const knownGremlin = findGremlinResult(gremlinId);
+				if (!knownGremlin) {
+					ctx.ui.notify(`Unknown gremlin id: ${gremlinId}.`, "error");
+					return;
+				}
+				const inactiveMessage =
+					knownGremlin.snapshot.status === "Running"
+						? `Gremlin ${gremlinId} is no longer steerable.`
+						: `Gremlin ${gremlinId} is no longer active.`;
+				ctx.ui.notify(inactiveMessage, "error");
+				return;
+			}
+
+			try {
+				await activeSession.session.steer(message);
+				ctx.ui.notify(
+					`Steered ${gremlinId} (${activeSession.agent}): ${message}`,
+					"info",
+				);
+			} catch (error) {
+				ctx.ui.notify(
+					error instanceof Error ? error.message : String(error),
+					"error",
+				);
+			}
 		},
 	});
 }

--- a/extensions/pi-gremlins/index.viewer.test.js
+++ b/extensions/pi-gremlins/index.viewer.test.js
@@ -263,6 +263,60 @@ describe("pi-gremlins viewer command", () => {
 		events.get("session_shutdown")?.();
 	});
 
+	test("reports steer command errors for missing payload unknown id and inactive gremlin", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		const { tool, commands } = createExtensionHarness();
+		const notifications = [];
+
+		expect(commands.has("gremlins:steer")).toBe(true);
+		await commands.get("gremlins:steer").handler("", {
+			hasUI: true,
+			ui: {
+				notify: (message, level) => {
+					notifications.push({ message, level });
+				},
+				custom: async () => {},
+			},
+		});
+		await commands.get("gremlins:steer").handler("g99 update README", {
+			hasUI: true,
+			ui: {
+				notify: (message, level) => {
+					notifications.push({ message, level });
+				},
+				custom: async () => {},
+			},
+		});
+
+		await seedInvocation(tool, workspace, "steer-inactive");
+		await commands.get("gremlins:steer").handler("g1 update README", {
+			hasUI: true,
+			ui: {
+				notify: (message, level) => {
+					notifications.push({ message, level });
+				},
+				custom: async () => {},
+			},
+		});
+
+		expect(notifications).toEqual([
+			{
+				message: "Usage: /gremlins:steer <gremlin-id> <message>",
+				level: "error",
+			},
+			{
+				message: "Unknown gremlin id: g99.",
+				level: "error",
+			},
+			{
+				message: "Gremlin g1 is no longer active.",
+				level: "error",
+			},
+		]);
+	});
+
 	test("opens new viewer overlay for latest invocation", async () => {
 		const workspace = createWorkspace();
 		workspaceRoot = workspace.root;

--- a/extensions/pi-gremlins/result-rendering.ts
+++ b/extensions/pi-gremlins/result-rendering.ts
@@ -36,6 +36,7 @@ type LiveStage = "active" | "pending" | "terminal";
 
 type DigestEntry =
 	| { kind: "assistant"; text: string; streaming: boolean }
+	| { kind: "steer"; text: string; streaming: boolean; isError: boolean }
 	| {
 			kind: "toolCall";
 			text: string;
@@ -321,6 +322,16 @@ function buildDigestEntries(
 			continue;
 		}
 
+		if (item.type === "steer") {
+			entries.push({
+				kind: "steer",
+				text: summarizeInlineText(item.content),
+				streaming: item.streaming,
+				isError: item.isError,
+			});
+			continue;
+		}
+
 		if (item.type === "toolCall") {
 			entries.push({
 				kind: "toolCall",
@@ -332,6 +343,8 @@ function buildDigestEntries(
 			});
 			continue;
 		}
+
+		if (item.type !== "toolResult") continue;
 
 		const summary = summarizeInlineText(item.content);
 		const pendingIndex = findPendingToolCallIndex(
@@ -415,6 +428,22 @@ function describeDigestEntry(
 			label: entry.streaming ? "live" : "digest",
 			text: entry.text,
 			tone: entry.streaming ? "warning" : "toolOutput",
+		};
+	}
+	if (entry.kind === "steer") {
+		let label = "steer";
+		let tone = "accent";
+		if (entry.isError) {
+			label = "steer error";
+			tone = "error";
+		} else if (entry.streaming) {
+			label = "steering";
+			tone = "warning";
+		}
+		return {
+			label,
+			text: entry.text,
+			tone,
 		};
 	}
 	if (entry.kind === "toolCall") {

--- a/extensions/pi-gremlins/single-agent-runner.ts
+++ b/extensions/pi-gremlins/single-agent-runner.ts
@@ -10,7 +10,10 @@ import type {
 } from "@mariozechner/pi-ai";
 import { withFileMutationQueue } from "@mariozechner/pi-coding-agent";
 import { resolveAgentByName } from "./agents.js";
-import type { RunSingleAgentFn } from "./execution-modes.js";
+import type {
+	RunSingleAgentFn,
+	SteerableSessionCallbacks,
+} from "./execution-modes.js";
 import {
 	bumpResultDerivedRevision,
 	bumpResultVisibleRevision,
@@ -133,6 +136,22 @@ function finishAssistantViewerEntry(
 	}
 	if (clearIndex) state.currentAssistantEntryIndex = null;
 	return changed;
+}
+
+function appendSteerViewerEntry(
+	result: SingleResult,
+	state: SingleRunViewerState,
+	text: string,
+	isError: boolean,
+): boolean {
+	const assistantEntryChanged = finishAssistantViewerEntry(result, state);
+	result.viewerEntries.push({
+		type: "steer",
+		text,
+		streaming: false,
+		isError,
+	});
+	return true || assistantEntryChanged;
 }
 
 function ensureToolCallViewerEntry(
@@ -437,6 +456,13 @@ function getPiInvocation(args: string[]): { command: string; args: string[] } {
 	return { command: "pi", args };
 }
 
+function unregisterSteerableSession(
+	callbacks: SteerableSessionCallbacks | undefined,
+	gremlinId: string,
+): void {
+	callbacks?.unregister(gremlinId);
+}
+
 export const runSingleAgent: RunSingleAgentFn = async (
 	defaultCwd,
 	agents,
@@ -449,6 +475,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 	onUpdate,
 	makeDetails,
 	packageDiscoveryWarning,
+	steerableSessionCallbacks,
 ): Promise<SingleResult> => {
 	const agentLookup = resolveAgentByName(agents, agentName);
 	const agent = agentLookup.agent;
@@ -475,7 +502,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 		return missingAgentResult;
 	}
 
-	const args: string[] = ["--mode", "json", "-p", "--no-session"];
+	const args: string[] = ["--mode", "rpc", "--no-session"];
 	if (agent.model) args.push("--model", agent.model);
 	if (agent.thinking) args.push("--thinking", agent.thinking);
 	if (agent.tools && agent.tools.length > 0) {
@@ -524,7 +551,6 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			args.push("--append-system-prompt", tmpPromptPath);
 		}
 
-		args.push(`Task: ${task}`);
 		let wasAborted = false;
 		let childProcessErrorMessage: string | null = null;
 		let malformedStdoutCount = 0;
@@ -535,9 +561,55 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			const proc = spawn(invocation.command, invocation.args, {
 				cwd: cwd ?? defaultCwd,
 				shell: false,
-				stdio: ["ignore", "pipe", "pipe"],
+				stdio: ["pipe", "pipe", "pipe"],
 			});
 			let buffer = "";
+			let settled = false;
+			let observedExitCode: number | undefined;
+			let exitFallbackTimer: ReturnType<typeof setTimeout> | undefined;
+			let removeAbortListener: (() => void) | undefined;
+			let steeringActive = true;
+			let stdinClosed = false;
+
+			const closeStdin = () => {
+				if (stdinClosed) return;
+				stdinClosed = true;
+				try {
+					proc.stdin?.end();
+				} catch {
+					/* ignore child stdin shutdown errors */
+				}
+			};
+
+			const deactivateSteering = () => {
+				if (!steeringActive) return;
+				steeringActive = false;
+				unregisterSteerableSession(steerableSessionCallbacks, gremlinId);
+			};
+
+			const writeRpcCommand = (command: Record<string, unknown>) => {
+				if (!proc.stdin || stdinClosed || !steeringActive || settled) {
+					throw new Error(`Gremlin ${gremlinId} is no longer active.`);
+				}
+				proc.stdin.write(`${JSON.stringify(command)}\n`);
+			};
+
+			const finalize = (code: number) => {
+				if (settled) return;
+				settled = true;
+				deactivateSteering();
+				if (exitFallbackTimer) clearTimeout(exitFallbackTimer);
+				if (buffer.trim()) processLine(buffer);
+				buffer = "";
+				removeAbortListener?.();
+				resolve(code);
+			};
+
+			const appendSteerEvent = (message: string, isError: boolean) => {
+				appendSteerViewerEntry(currentResult, viewerState, message, isError);
+				bumpResultDerivedRevision(currentResult);
+				emitUpdate();
+			};
 
 			const processLine = (line: string) => {
 				if (!line.trim()) return;
@@ -550,6 +622,34 @@ export const runSingleAgent: RunSingleAgentFn = async (
 					appendStderrLine(
 						currentResult,
 						`${CHILD_PROTOCOL_ERROR_PREFIX} dropped malformed child stdout line ${malformedStdoutCount}: ${lastMalformedStdoutPreview}`,
+					);
+					return;
+				}
+
+				if (event.type === "response") return;
+				if (event.type === "agent_start") return;
+				if (event.type === "agent_end") {
+					deactivateSteering();
+					closeStdin();
+					return;
+				}
+				if (event.type === "extension_ui_request") {
+					const method =
+						typeof event.method === "string" ? event.method : "unknown";
+					appendStderrLine(
+						currentResult,
+						`${CHILD_PROTOCOL_ERROR_PREFIX} child requested unsupported UI method: ${method}`,
+					);
+					return;
+				}
+				if (event.type === "extension_error") {
+					const errorText =
+						typeof event.error === "string"
+							? event.error
+							: "child extension error";
+					appendStderrLine(
+						currentResult,
+						`${CHILD_PROTOCOL_ERROR_PREFIX} ${errorText}`,
 					);
 					return;
 				}
@@ -610,20 +710,26 @@ export const runSingleAgent: RunSingleAgentFn = async (
 				}
 			};
 
-			let settled = false;
-			let observedExitCode: number | undefined;
-			let exitFallbackTimer: ReturnType<typeof setTimeout> | undefined;
-			let removeAbortListener: (() => void) | undefined;
-
-			const finalize = (code: number) => {
-				if (settled) return;
-				settled = true;
-				if (exitFallbackTimer) clearTimeout(exitFallbackTimer);
-				if (buffer.trim()) processLine(buffer);
-				buffer = "";
-				removeAbortListener?.();
-				resolve(code);
-			};
+			steerableSessionCallbacks?.register(gremlinId, {
+				steer: async (message: string) => {
+					const trimmedMessage = message.trim();
+					if (!trimmedMessage) {
+						throw new Error("Steering message cannot be empty.");
+					}
+					if (!steeringActive || settled || currentResult.exitCode !== -1) {
+						throw new Error(`Gremlin ${gremlinId} is no longer active.`);
+					}
+					try {
+						writeRpcCommand({ type: "steer", message: trimmedMessage });
+						appendSteerEvent(trimmedMessage, false);
+					} catch (error) {
+						const errorMessage =
+							error instanceof Error ? error.message : String(error);
+						appendSteerEvent(`${trimmedMessage} → ${errorMessage}`, true);
+						throw error;
+					}
+				},
+			});
 
 			proc.stdout.on("data", (data) => {
 				buffer += data.toString();
@@ -650,6 +756,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			});
 
 			proc.on("error", (error) => {
+				deactivateSteering();
 				childProcessErrorMessage = formatChildProcessError(error);
 				appendStderrLine(currentResult, childProcessErrorMessage);
 				finalize(1);
@@ -658,6 +765,8 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			if (signal) {
 				const killProc = () => {
 					wasAborted = true;
+					deactivateSteering();
+					closeStdin();
 					proc.kill("SIGTERM");
 					setTimeout(() => {
 						if (!proc.killed) proc.kill("SIGKILL");
@@ -671,6 +780,15 @@ export const runSingleAgent: RunSingleAgentFn = async (
 						signal.removeEventListener("abort", killProc);
 					};
 				}
+			}
+
+			try {
+				writeRpcCommand({ type: "prompt", message: `Task: ${task}` });
+			} catch (error) {
+				deactivateSteering();
+				childProcessErrorMessage = formatChildProcessError(error);
+				appendStderrLine(currentResult, childProcessErrorMessage);
+				finalize(1);
 			}
 		});
 
@@ -706,6 +824,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 		}
 		return currentResult;
 	} finally {
+		unregisterSteerableSession(steerableSessionCallbacks, gremlinId);
 		if (tmpPromptDir) {
 			try {
 				fs.rmSync(tmpPromptDir, { recursive: true, force: true });

--- a/extensions/pi-gremlins/test-helpers.js
+++ b/extensions/pi-gremlins/test-helpers.js
@@ -39,11 +39,51 @@ export function createMockProcess({
 	exitDelay,
 	omitClose = false,
 	errorAt,
+	onStdinLine,
+	onStdinJson,
 } = {}) {
 	const proc = new EventEmitter();
 	proc.stdout = new EventEmitter();
 	proc.stderr = new EventEmitter();
+	proc.stdinWrites = [];
+	proc.stdinEnded = false;
 	proc.killed = false;
+	proc.emitStdout = (data, delay = 0) => {
+		setTimeout(() => {
+			proc.stdout.emit("data", Buffer.from(data));
+		}, delay);
+	};
+	proc.emitStderr = (data, delay = 0) => {
+		setTimeout(() => {
+			proc.stderr.emit("data", Buffer.from(data));
+		}, delay);
+	};
+	let stdinBuffer = "";
+	proc.stdin = {
+		write(chunk) {
+			const text = Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+			proc.stdinWrites.push(text);
+			stdinBuffer += text;
+			const lines = stdinBuffer.split("\n");
+			stdinBuffer = lines.pop() || "";
+			for (const line of lines) {
+				if (!line.trim()) continue;
+				onStdinLine?.(line, proc);
+				if (onStdinJson) {
+					try {
+						onStdinJson(JSON.parse(line), proc);
+					} catch {
+						/* ignore malformed stdin json in tests */
+					}
+				}
+			}
+			return true;
+		},
+		end(chunk) {
+			if (chunk !== undefined) this.write(chunk);
+			proc.stdinEnded = true;
+		},
+	};
 	proc.kill = () => {
 		proc.killed = true;
 	};
@@ -60,14 +100,10 @@ export function createMockProcess({
 		const finalExitDelay = exitDelay ?? finalCloseDelay;
 
 		for (const event of stdoutEvents) {
-			setTimeout(() => {
-				proc.stdout.emit("data", Buffer.from(event.data));
-			}, event.delay);
+			proc.emitStdout(event.data, event.delay);
 		}
 		for (const event of stderrEvents) {
-			setTimeout(() => {
-				proc.stderr.emit("data", Buffer.from(event.data));
-			}, event.delay);
+			proc.emitStderr(event.data, event.delay);
 		}
 		if (errorAt !== undefined) {
 			setTimeout(() => {


### PR DESCRIPTION
## Summary
- add `/gremlins:steer <gremlin-id> <message>` for routing follow-up steering to one active gremlin session
- switch child gremlin execution to Pi RPC mode so active sessions can accept targeted steering and record steering events in embedded/popup output
- document steering usage in `README.md` and cover success plus failure paths in tests

## Verification
- `npm test`
- `npm run typecheck`

Closes #6