### PR TITLE
fix: finalize gremlin runs after terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `pi-gremlins` child runs now publish prompt terminal lifecycle state after safe protocol completion with a 100ms grace window, so single and parallel invocations stop showing finished children as `Running` while slow subprocess exit/close telemetry trickles in.
 - Gremlins🧌 mission control now keeps full ordered chain result slots in live viewer snapshots, so left/right navigation can reach completed earlier steps and pending later steps while current chain work is still running.
 - `pi-gremlins` now emits explicit terminal completion updates for single-child `single` and one-step `chain` runs after child exit, so parent flows receive terminal status snapshots before final tool results land.
 - `pi-gremlins` now finalizes child runs on process exit even if `close` never arrives, preserving terminal tool results and parent-session completion for exit-complete gremlin work.

--- a/extensions/pi-gremlins/execution-modes.ts
+++ b/extensions/pi-gremlins/execution-modes.ts
@@ -6,6 +6,8 @@ import {
 	getSingleResultErrorText,
 	getSingleResultStatus,
 	type InvocationMode,
+	type InvocationStatus,
+	isSingleResultTerminal,
 	type PiGremlinsDetails,
 	type SingleResult,
 } from "./execution-shared.js";
@@ -56,6 +58,11 @@ interface ExecutionModeDependencies {
 	signal: AbortSignal | undefined;
 	runSingleAgent: RunSingleAgentFn;
 	handleInvocationUpdate: OnUpdateCallback;
+	readInvocationStatus: () => InvocationStatus | undefined;
+	publishInvocationDetails: (
+		details: PiGremlinsDetails,
+		status?: InvocationStatus,
+	) => void;
 	makeDetails: (
 		mode: InvocationMode,
 	) => (results: SingleResult[]) => PiGremlinsDetails;
@@ -131,6 +138,23 @@ function applyPreviousOutputToChainTask(
 	).text;
 }
 
+function emitTerminalOrSyncSnapshot(
+	status: InvocationStatus,
+	partial: AgentToolResult<PiGremlinsDetails>,
+	handleInvocationUpdate: OnUpdateCallback,
+	readInvocationStatus: () => InvocationStatus | undefined,
+	publishInvocationDetails: (
+		details: PiGremlinsDetails,
+		status?: InvocationStatus,
+	) => void,
+): void {
+	if (partial.details && readInvocationStatus() === status) {
+		publishInvocationDetails(partial.details, status);
+		return;
+	}
+	handleInvocationUpdate(partial);
+}
+
 export async function executeChainMode({
 	chain,
 	ctxCwd,
@@ -138,6 +162,8 @@ export async function executeChainMode({
 	signal,
 	runSingleAgent,
 	handleInvocationUpdate,
+	readInvocationStatus,
+	publishInvocationDetails,
 	makeDetails,
 	allocateGremlinId,
 	packageDiscoveryWarning,
@@ -236,7 +262,13 @@ export async function executeChainMode({
 					],
 					details,
 				};
-				handleInvocationUpdate(terminalPartial);
+				emitTerminalOrSyncSnapshot(
+					resultStatus,
+					terminalPartial,
+					handleInvocationUpdate,
+					readInvocationStatus,
+					publishInvocationDetails,
+				);
 				return terminalPartial;
 			}
 			const terminalPartial = {
@@ -248,7 +280,13 @@ export async function executeChainMode({
 				],
 				details,
 			};
-			handleInvocationUpdate(terminalPartial);
+			emitTerminalOrSyncSnapshot(
+				resultStatus,
+				terminalPartial,
+				handleInvocationUpdate,
+				readInvocationStatus,
+				publishInvocationDetails,
+			);
 			return {
 				...terminalPartial,
 				isError: true,
@@ -270,7 +308,13 @@ export async function executeChainMode({
 		],
 		details,
 	};
-	handleInvocationUpdate(terminalPartial);
+	emitTerminalOrSyncSnapshot(
+		"Completed",
+		terminalPartial,
+		handleInvocationUpdate,
+		readInvocationStatus,
+		publishInvocationDetails,
+	);
 	return terminalPartial;
 }
 
@@ -281,6 +325,7 @@ export async function executeParallelMode({
 	signal,
 	runSingleAgent,
 	handleInvocationUpdate,
+	publishInvocationDetails,
 	makeDetails,
 	allocateGremlinId,
 	maxConcurrency,
@@ -301,21 +346,28 @@ export async function executeParallelMode({
 			task.gremlinId,
 		),
 	);
-	const trackedExitCodes = allResults.map((result) => result.exitCode);
+	const trackedTerminalStates = allResults.map((result) =>
+		isSingleResultTerminal(result),
+	);
 	let runningCount = allResults.length;
 	let doneCount = 0;
 
 	const replaceParallelResult = (index: number, nextResult: SingleResult) => {
-		const previousExitCode = trackedExitCodes[index];
-		if (previousExitCode === -1 && nextResult.exitCode !== -1) {
+		const previousResult = allResults[index];
+		const previousStatus = getSingleResultStatus(previousResult);
+		const nextStatus = getSingleResultStatus(nextResult);
+		const previousTerminal = trackedTerminalStates[index];
+		const nextTerminal = isSingleResultTerminal(nextResult);
+		if (!previousTerminal && nextTerminal) {
 			runningCount -= 1;
 			doneCount += 1;
-		} else if (previousExitCode !== -1 && nextResult.exitCode === -1) {
+		} else if (previousTerminal && !nextTerminal) {
 			runningCount += 1;
 			doneCount -= 1;
 		}
-		trackedExitCodes[index] = nextResult.exitCode;
+		trackedTerminalStates[index] = nextTerminal;
 		allResults[index] = nextResult;
+		return previousStatus !== nextStatus;
 	};
 
 	const emitParallelUpdate = () => {
@@ -355,8 +407,12 @@ export async function executeParallelMode({
 				packageDiscoveryWarning,
 				steerableSessionCallbacks,
 			);
-			replaceParallelResult(index, result);
-			emitParallelUpdate();
+			const statusChanged = replaceParallelResult(index, result);
+			if (statusChanged) {
+				emitParallelUpdate();
+			} else {
+				publishInvocationDetails(makeDetails("parallel")(allResults));
+			}
 			return result;
 		},
 	);
@@ -397,6 +453,8 @@ export async function executeSingleMode({
 	signal,
 	runSingleAgent,
 	handleInvocationUpdate,
+	readInvocationStatus,
+	publishInvocationDetails,
 	makeDetails,
 	packageDiscoveryWarning,
 	gremlinId,
@@ -428,7 +486,13 @@ export async function executeSingleMode({
 			],
 			details,
 		};
-		handleInvocationUpdate(terminalPartial);
+		emitTerminalOrSyncSnapshot(
+			resultStatus,
+			terminalPartial,
+			handleInvocationUpdate,
+			readInvocationStatus,
+			publishInvocationDetails,
+		);
 		return {
 			...terminalPartial,
 			isError: true,
@@ -444,7 +508,13 @@ export async function executeSingleMode({
 			],
 			details,
 		};
-		handleInvocationUpdate(terminalPartial);
+		emitTerminalOrSyncSnapshot(
+			resultStatus,
+			terminalPartial,
+			handleInvocationUpdate,
+			readInvocationStatus,
+			publishInvocationDetails,
+		);
 		return terminalPartial;
 	}
 
@@ -457,6 +527,12 @@ export async function executeSingleMode({
 		],
 		details,
 	};
-	handleInvocationUpdate(terminalPartial);
+	emitTerminalOrSyncSnapshot(
+		"Completed",
+		terminalPartial,
+		handleInvocationUpdate,
+		readInvocationStatus,
+		publishInvocationDetails,
+	);
 	return terminalPartial;
 }

--- a/extensions/pi-gremlins/execution-shared.ts
+++ b/extensions/pi-gremlins/execution-shared.ts
@@ -69,6 +69,7 @@ export interface SingleResult {
 	agentSource: AgentSource | "unknown";
 	task: string;
 	exitCode: number;
+	lifecycle: ResultLifecycle;
 	messages: Message[];
 	viewerEntries: ViewerEntry[];
 	stderr: string;
@@ -591,6 +592,7 @@ export function createPendingResult(
 		agentSource,
 		task,
 		exitCode: -1,
+		lifecycle: "pending",
 		messages: [],
 		viewerEntries: [],
 		stderr: "",
@@ -599,11 +601,37 @@ export function createPendingResult(
 	});
 }
 
+export function getSingleResultLifecycle(
+	result: SingleResult,
+): ResultLifecycle {
+	if (result.lifecycle && result.lifecycle !== "pending") {
+		return result.lifecycle;
+	}
+	if (result.stopReason === "aborted") return "canceled";
+	if (result.stopReason === "error" && result.exitCode === -1) {
+		return "failed";
+	}
+	if (result.exitCode === -1) return result.lifecycle ?? "pending";
+	if (result.exitCode !== 0 || result.stopReason === "error") return "failed";
+	return "completed";
+}
+
+export function isSingleResultTerminal(result: SingleResult): boolean {
+	return getSingleResultLifecycle(result) !== "pending";
+}
+
 export function getSingleResultStatus(result: SingleResult): InvocationStatus {
-	if (result.stopReason === "aborted") return "Canceled";
-	if (result.exitCode === -1) return "Running";
-	if (result.exitCode !== 0 || result.stopReason === "error") return "Failed";
-	return "Completed";
+	switch (getSingleResultLifecycle(result)) {
+		case "completed":
+			return "Completed";
+		case "failed":
+			return "Failed";
+		case "canceled":
+			return "Canceled";
+		case "pending":
+		default:
+			return "Running";
+	}
 }
 
 export function getInvocationStatus(

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -245,6 +245,23 @@ function createDetails(mode, results) {
 	};
 }
 
+async function waitForCondition(
+	check,
+	{
+		timeout = 200,
+		interval = 5,
+		errorMessage = "timed out waiting for condition",
+	} = {},
+) {
+	const start = Date.now();
+	while (Date.now() - start <= timeout) {
+		const value = check();
+		if (value) return value;
+		await new Promise((resolve) => setTimeout(resolve, interval));
+	}
+	throw new Error(errorMessage);
+}
+
 let workspaceRoot = null;
 
 beforeEach(() => {
@@ -1235,6 +1252,541 @@ describe("pi-gremlins execute streaming characterization", () => {
 			exitCode: 0,
 		});
 		expect(result.details.status).toBe("Completed");
+	});
+
+	test("single mode completes within protocol grace after agent_end before delayed close", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					{
+						delay: 5,
+						data: jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "agent_end final answer" }],
+								usage: {
+									input: 2,
+									output: 3,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 5,
+								},
+							},
+						}),
+					},
+					{ delay: 10, data: jsonLine({ type: "agent_end" }) },
+				],
+				exitCode: 0,
+				exitDelay: 240,
+				closeCode: 0,
+				closeDelay: 240,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const startedAt = Date.now();
+		const executePromise = tool.execute(
+			"single-agent-end-grace",
+			{ agent: "tars", task: "Finish on agent_end" },
+			undefined,
+			(partial) => {
+				updates.push({ at: Date.now(), partial: cloneForAssertion(partial) });
+			},
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		const completedUpdate = await waitForCondition(
+			() =>
+				updates.find((update) => update.partial.details.status === "Completed"),
+			{
+				timeout: 180,
+				errorMessage: "timed out waiting for prompt completion after agent_end",
+			},
+		);
+
+		expect(completedUpdate.at - startedAt).toBeLessThan(200);
+		expect(completedUpdate.partial.content[0].text).toBe(
+			"agent_end final answer",
+		);
+		expect(completedUpdate.partial.details.results[0].exitCode).toBe(-1);
+
+		const result = await executePromise;
+		expect(result.details.status).toBe("Completed");
+		expect(result.content[0].text).toBe("agent_end final answer");
+	});
+
+	test("single mode completes within protocol grace after safe assistant message_end before delayed close", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					{
+						delay: 5,
+						data: jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "message_end final answer" }],
+								usage: {
+									input: 2,
+									output: 3,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 5,
+								},
+							},
+						}),
+					},
+				],
+				exitCode: 0,
+				exitDelay: 240,
+				closeCode: 0,
+				closeDelay: 240,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const executePromise = tool.execute(
+			"single-message-end-grace",
+			{ agent: "tars", task: "Finish on message_end" },
+			undefined,
+			(partial) => {
+				updates.push({ at: Date.now(), partial: cloneForAssertion(partial) });
+			},
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		const completedUpdate = await waitForCondition(
+			() =>
+				updates.find((update) => update.partial.details.status === "Completed"),
+			{
+				timeout: 180,
+				errorMessage:
+					"timed out waiting for prompt completion after assistant message_end",
+			},
+		);
+
+		expect(completedUpdate.partial.content[0].text).toBe(
+			"message_end final answer",
+		);
+		expect(completedUpdate.partial.details.results[0].exitCode).toBe(-1);
+
+		const result = await executePromise;
+		expect(result.details.status).toBe("Completed");
+		expect(result.content[0].text).toBe("message_end final answer");
+	});
+
+	test("single mode prefers cancellation over optimistic completion when aborted during protocol grace", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					{
+						delay: 5,
+						data: jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "abort before completion" }],
+								usage: {
+									input: 2,
+									output: 3,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 5,
+								},
+							},
+						}),
+					},
+					{ delay: 10, data: jsonLine({ type: "agent_end" }) },
+				],
+				exitCode: 130,
+				exitDelay: 240,
+				closeCode: 130,
+				closeDelay: 240,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const controller = new AbortController();
+		const updates = [];
+		const executePromise = tool.execute(
+			"single-abort-during-grace",
+			{ agent: "tars", task: "Abort before grace completes" },
+			controller.signal,
+			(partial) => {
+				updates.push({ at: Date.now(), partial: cloneForAssertion(partial) });
+			},
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 35));
+		controller.abort();
+
+		const canceledUpdate = await waitForCondition(
+			() =>
+				updates.find((update) => update.partial.details.status === "Canceled"),
+			{
+				timeout: 140,
+				errorMessage: "timed out waiting for canceled terminal update",
+			},
+		);
+
+		expect(canceledUpdate.partial.content[0].text).toBe(
+			"abort before completion",
+		);
+		expect(
+			updates.some((update) => update.partial.details.status === "Completed"),
+		).toBe(false);
+
+		const result = await executePromise;
+		expect(result.details.status).toBe("Canceled");
+		expect(result.content[0].text).toBe("Canceled: Gremlins🧌 run was aborted");
+	});
+
+	test("single mode fails instead of completing when non-zero exit arrives during protocol grace", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					{
+						delay: 5,
+						data: jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "almost done" }],
+								usage: {
+									input: 2,
+									output: 3,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 5,
+								},
+							},
+						}),
+					},
+					{ delay: 10, data: jsonLine({ type: "agent_end" }) },
+				],
+				exitCode: 2,
+				exitDelay: 40,
+				closeCode: 2,
+				closeDelay: 240,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const result = await tool.execute(
+			"single-failed-during-grace",
+			{ agent: "tars", task: "Fail during protocol grace" },
+			undefined,
+			(partial) => {
+				updates.push({ at: Date.now(), partial: cloneForAssertion(partial) });
+			},
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		expect(
+			updates.some((update) => update.partial.details.status === "Completed"),
+		).toBe(false);
+		expect(
+			updates.some((update) => update.partial.details.status === "Failed"),
+		).toBe(true);
+		expect(result.details.status).toBe("Failed");
+		expect(result.content[0].text).toBe("Agent failed: almost done");
+	});
+
+	test("single mode unregisters steering on first terminal publish before delayed close", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					{
+						delay: 5,
+						data: jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "terminal before close" }],
+								usage: {
+									input: 2,
+									output: 3,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 5,
+								},
+							},
+						}),
+					},
+					{ delay: 10, data: jsonLine({ type: "agent_end" }) },
+				],
+				exitCode: 0,
+				exitDelay: 240,
+				closeCode: 0,
+				closeDelay: 240,
+			}),
+		);
+
+		const { tool, commands } = createExtensionHarness();
+		const updates = [];
+		const executePromise = tool.execute(
+			"single-steer-after-terminal-publish",
+			{ agent: "tars", task: "Complete before close and reject steer" },
+			undefined,
+			(partial) => {
+				updates.push({ at: Date.now(), partial: cloneForAssertion(partial) });
+			},
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		await waitForCondition(
+			() =>
+				updates.find((update) => update.partial.details.status === "Completed"),
+			{
+				timeout: 180,
+				errorMessage:
+					"timed out waiting for terminal publish before steer rejection check",
+			},
+		);
+
+		const notifications = [];
+		await commands.get("gremlins:steer").handler("g1 one more thing", {
+			hasUI: true,
+			ui: {
+				notify: (message, level) => {
+					notifications.push({ message, level });
+				},
+				custom: async () => {},
+			},
+		});
+
+		const result = await executePromise;
+		expect(notifications).toContainEqual({
+			message: "Gremlin g1 is no longer active.",
+			level: "error",
+		});
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0][3].stdinWrites.join("")).not.toContain(
+			'"type":"steer"',
+		);
+		expect(result.details.results[0].viewerEntries).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ type: "steer" })]),
+		);
+	});
+
+	test("single mode publishes completed status exactly once and keeps it after late non-zero exit", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		spawnPlans.push(() =>
+			createMockProcess({
+				stdoutChunks: [
+					{
+						delay: 5,
+						data: jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "completed before late exit" }],
+								usage: {
+									input: 2,
+									output: 3,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 5,
+								},
+							},
+						}),
+					},
+					{ delay: 10, data: jsonLine({ type: "agent_end" }) },
+				],
+				exitCode: 3,
+				exitDelay: 220,
+				closeCode: 3,
+				closeDelay: 240,
+			}),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const executePromise = tool.execute(
+			"single-late-non-zero-exit",
+			{ agent: "tars", task: "Succeed before late exit" },
+			undefined,
+			(partial) => {
+				updates.push({ at: Date.now(), partial: cloneForAssertion(partial) });
+			},
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		await waitForCondition(
+			() =>
+				updates.find((update) => update.partial.details.status === "Completed"),
+			{
+				timeout: 180,
+				errorMessage:
+					"timed out waiting for completed status before late non-zero exit",
+			},
+		);
+
+		const result = await executePromise;
+		const completedUpdates = updates.filter(
+			(update) => update.partial.details.status === "Completed",
+		);
+		expect(completedUpdates).toHaveLength(1);
+		expect(result.details.status).toBe("Completed");
+		expect(result.content[0].text).toBe("completed before late exit");
+		expect(result.details.results[0].exitCode).toBe(3);
+	});
+
+	test("parallel mode counts lifecycle-terminal children as done before delayed exit telemetry arrives", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "alpha.md", "alpha");
+		writeAgentFile(workspace.userAgentsDir, "beta.md", "beta");
+
+		spawnPlans.push(
+			createSpawnPlanForTask("Do alpha", () =>
+				createMockProcess({
+					stdoutChunks: [
+						{
+							delay: 5,
+							data: jsonLine({
+								type: "message_end",
+								message: {
+									role: "assistant",
+									content: [{ type: "text", text: "alpha done early" }],
+									usage: {
+										input: 2,
+										output: 2,
+										cacheRead: 0,
+										cacheWrite: 0,
+										cost: { total: 0.01 },
+										totalTokens: 4,
+									},
+								},
+							}),
+						},
+						{ delay: 10, data: jsonLine({ type: "agent_end" }) },
+					],
+					exitCode: 0,
+					exitDelay: 240,
+					closeCode: 0,
+					closeDelay: 240,
+				}),
+			),
+			createSpawnPlanForTask("Do beta", () =>
+				createMockProcess({
+					stdoutChunks: [
+						{
+							delay: 5,
+							data: jsonLine({
+								type: "message_start",
+								message: {
+									role: "assistant",
+									content: [{ type: "text", text: "beta still running" }],
+								},
+							}),
+						},
+						{
+							delay: 260,
+							data: jsonLine({
+								type: "message_end",
+								message: {
+									role: "assistant",
+									content: [{ type: "text", text: "beta finally done" }],
+									usage: {
+										input: 2,
+										output: 2,
+										cacheRead: 0,
+										cacheWrite: 0,
+										cost: { total: 0.01 },
+										totalTokens: 4,
+									},
+								},
+							}),
+						},
+					],
+					exitCode: 0,
+					exitDelay: 270,
+					closeCode: 0,
+					closeDelay: 270,
+				}),
+			),
+		);
+
+		const tool = createRegisteredTool();
+		const updates = [];
+		const executePromise = tool.execute(
+			"parallel-lifecycle-progress",
+			{
+				tasks: [
+					{ agent: "alpha", task: "Do alpha" },
+					{ agent: "beta", task: "Do beta" },
+				],
+			},
+			undefined,
+			(partial) => {
+				updates.push({ at: Date.now(), partial: cloneForAssertion(partial) });
+			},
+			createExecutionContext(workspace.repoRoot),
+		);
+
+		const aggregateUpdate = await waitForCondition(
+			() =>
+				updates.find(
+					(update) =>
+						update.partial.content[0].text ===
+						"Parallel: 1/2 done, 1 running...",
+				),
+			{
+				timeout: 180,
+				errorMessage:
+					"timed out waiting for lifecycle-based parallel aggregate progress",
+			},
+		);
+
+		expect(aggregateUpdate.partial.details.results[0].exitCode).toBe(-1);
+
+		const result = await executePromise;
+		expect(result.details.status).toBe("Completed");
+		expect(result.content[0].text).toContain(
+			"[g1 alpha] completed: alpha done early",
+		);
 	});
 
 	test("single mode assigns stable gremlin id from pending through completion", async () => {

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -346,6 +346,14 @@ export default function (pi: ExtensionAPI) {
 			const handleInvocationUpdate = (
 				partial: AgentToolResult<PiGremlinsDetails>,
 			) => invocationUpdates.applyPartial(toolCallId, partial);
+			const readInvocationStatus = () =>
+				invocationRegistry.get(toolCallId)?.status;
+			const publishInvocationDetails = (
+				details: PiGremlinsDetails,
+				status = getInvocationStatus(details.mode, details.results),
+			) => {
+				updateInvocation(toolCallId, details, status);
+			};
 			const allocateGremlinId = () => `g${nextGremlinOrdinal++}`;
 			const steerableSessionCallbacks = {
 				register: (gremlinId: string, session: SteerableGremlinSession) => {
@@ -474,6 +482,8 @@ export default function (pi: ExtensionAPI) {
 						runSingleAgent,
 						handleInvocationUpdate,
 						makeDetails,
+						readInvocationStatus,
+						publishInvocationDetails,
 						allocateGremlinId,
 						packageDiscoveryWarning,
 						steerableSessionCallbacks,
@@ -490,6 +500,8 @@ export default function (pi: ExtensionAPI) {
 						signal,
 						runSingleAgent,
 						handleInvocationUpdate,
+						readInvocationStatus,
+						publishInvocationDetails,
 						makeDetails,
 						allocateGremlinId,
 						maxConcurrency: MAX_CONCURRENCY,
@@ -511,6 +523,8 @@ export default function (pi: ExtensionAPI) {
 						signal,
 						runSingleAgent,
 						handleInvocationUpdate,
+						readInvocationStatus,
+						publishInvocationDetails,
 						makeDetails,
 						packageDiscoveryWarning,
 						gremlinId: singleGremlinId,

--- a/extensions/pi-gremlins/single-agent-runner.ts
+++ b/extensions/pi-gremlins/single-agent-runner.ts
@@ -21,6 +21,7 @@ import {
 	createUsageStats,
 	getResultFinalOutput,
 	initializeResultRevisions,
+	type ResultLifecycle,
 	type SingleResult,
 	type SingleRunViewerState,
 	type ViewerToolCallRecord,
@@ -29,6 +30,7 @@ import { formatAgentLookupError } from "./tool-text.js";
 
 const CHILD_PROCESS_EXIT_GRACE_MS = 50;
 const CHILD_PROCESS_KILL_GRACE_MS = 5000;
+const CHILD_PROTOCOL_TERMINAL_GRACE_MS = 100;
 const CHILD_PROTOCOL_ERROR_PREVIEW_LENGTH = 180;
 const CHILD_PROTOCOL_ERROR_PREFIX = "[Gremlins🧌]";
 
@@ -404,6 +406,15 @@ function hasCapturedChildContent(result: SingleResult): boolean {
 	return result.messages.length > 0 || result.viewerEntries.length > 0;
 }
 
+function setResultLifecycle(
+	result: SingleResult,
+	lifecycle: ResultLifecycle,
+): boolean {
+	if (result.lifecycle === lifecycle) return false;
+	result.lifecycle = lifecycle;
+	return true;
+}
+
 function writeChildFailureDetails(
 	result: SingleResult,
 	message: string,
@@ -418,6 +429,33 @@ function writeChildFailureDetails(
 		changed = true;
 	}
 	return changed;
+}
+
+function writeChildCanceledDetails(
+	result: SingleResult,
+	{
+		forceDefaultErrorMessage = false,
+	}: { forceDefaultErrorMessage?: boolean } = {},
+): boolean {
+	let changed = false;
+	if (result.stopReason !== "aborted") {
+		result.stopReason = "aborted";
+		changed = true;
+	}
+	if (
+		forceDefaultErrorMessage ||
+		(!result.errorMessage?.trim() && !getResultFinalOutput(result).trim())
+	) {
+		if (result.errorMessage !== "Gremlins🧌 run was aborted") {
+			result.errorMessage = "Gremlins🧌 run was aborted";
+			changed = true;
+		}
+	}
+	return changed;
+}
+
+function formatLateChildExitDiagnostic(exitCode: number): string {
+	return `${CHILD_PROTOCOL_ERROR_PREFIX} child exited with code ${exitCode} after terminal completion; keeping published status.`;
 }
 
 function writePromptTempFile(
@@ -487,6 +525,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			agentSource: "unknown",
 			task,
 			exitCode: 1,
+			lifecycle: "failed",
 			messages: [],
 			viewerEntries: [],
 			stderr: formatAgentLookupError(
@@ -518,6 +557,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 		agentSource: agent.source,
 		task,
 		exitCode: -1,
+		lifecycle: "pending",
 		messages: [],
 		viewerEntries: [],
 		stderr: "",
@@ -553,6 +593,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 		let childProcessErrorMessage: string | null = null;
 		let malformedStdoutCount = 0;
 		let lastMalformedStdoutPreview: string | null = null;
+		let lateTerminalExitDiagnostic: string | null = null;
 
 		const exitCode = await new Promise<number>((resolve) => {
 			const invocation = getPiInvocation(args);
@@ -565,9 +606,17 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			let settled = false;
 			let observedExitCode: number | undefined;
 			let exitFallbackTimer: ReturnType<typeof setTimeout> | undefined;
+			let protocolTerminalGraceTimer: ReturnType<typeof setTimeout> | undefined;
+			let protocolTerminalGraceSource:
+				| "agent_end"
+				| "assistant_message_end"
+				| null = null;
 			let removeAbortListener: (() => void) | undefined;
 			let steeringActive = true;
 			let stdinClosed = false;
+			let terminalPublished = false;
+			let turnActive = false;
+			const activeToolExecutionIds = new Set<string>();
 
 			const closeStdin = () => {
 				if (stdinClosed) return;
@@ -585,6 +634,91 @@ export const runSingleAgent: RunSingleAgentFn = async (
 				unregisterSteerableSession(steerableSessionCallbacks, gremlinId);
 			};
 
+			const clearProtocolTerminalGrace = () => {
+				if (protocolTerminalGraceTimer) {
+					clearTimeout(protocolTerminalGraceTimer);
+				}
+				protocolTerminalGraceTimer = undefined;
+				protocolTerminalGraceSource = null;
+			};
+
+			const publishTerminalLifecycle = (
+				lifecycle: ResultLifecycle,
+				applyDetails?: () => boolean,
+			) => {
+				if (terminalPublished) return false;
+				clearProtocolTerminalGrace();
+				deactivateSteering();
+				let visibleChanged = setResultLifecycle(currentResult, lifecycle);
+				if (applyDetails) {
+					visibleChanged = applyDetails() || visibleChanged;
+				}
+				if (finishAssistantViewerEntry(currentResult, viewerState)) {
+					bumpResultDerivedRevision(currentResult);
+				} else if (visibleChanged) {
+					bumpResultVisibleRevision(currentResult);
+				}
+				terminalPublished = true;
+				emitUpdate();
+				return true;
+			};
+
+			const failBeforeTerminal = (message?: string) => {
+				publishTerminalLifecycle("failed", () => {
+					if (!message) return false;
+					return writeChildFailureDetails(currentResult, message);
+				});
+			};
+
+			const cancelBeforeTerminal = (forceDefaultErrorMessage = false) => {
+				publishTerminalLifecycle("canceled", () => {
+					return writeChildCanceledDetails(currentResult, {
+						forceDefaultErrorMessage,
+					});
+				});
+			};
+
+			const armProtocolTerminalGrace = (
+				source: "agent_end" | "assistant_message_end",
+			) => {
+				if (
+					settled ||
+					terminalPublished ||
+					currentResult.lifecycle !== "pending"
+				) {
+					return;
+				}
+				if (
+					protocolTerminalGraceSource === "agent_end" &&
+					source !== "agent_end"
+				) {
+					return;
+				}
+				clearProtocolTerminalGrace();
+				protocolTerminalGraceSource = source;
+				protocolTerminalGraceTimer = setTimeout(() => {
+					protocolTerminalGraceTimer = undefined;
+					protocolTerminalGraceSource = null;
+					publishTerminalLifecycle("completed");
+				}, CHILD_PROTOCOL_TERMINAL_GRACE_MS);
+			};
+
+			const cancelProtocolTerminalGraceForEvent = (eventType: string) => {
+				if (!protocolTerminalGraceTimer) return;
+				if (
+					eventType === "message_start" ||
+					eventType === "message_update" ||
+					eventType === "message_end" ||
+					eventType === "turn_start" ||
+					eventType === "tool_execution_start" ||
+					eventType === "tool_execution_update" ||
+					eventType === "tool_execution_end" ||
+					eventType === "tool_result_end"
+				) {
+					clearProtocolTerminalGrace();
+				}
+			};
+
 			const writeRpcCommand = (command: Record<string, unknown>) => {
 				if (!proc.stdin || stdinClosed || !steeringActive || settled) {
 					throw new Error(`Gremlin ${gremlinId} is no longer active.`);
@@ -595,6 +729,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			const finalize = (code: number) => {
 				if (settled) return;
 				settled = true;
+				clearProtocolTerminalGrace();
 				deactivateSteering();
 				if (exitFallbackTimer) clearTimeout(exitFallbackTimer);
 				if (buffer.trim()) processLine(buffer);
@@ -607,6 +742,50 @@ export const runSingleAgent: RunSingleAgentFn = async (
 				appendSteerViewerEntry(currentResult, viewerState, message, isError);
 				bumpResultDerivedRevision(currentResult);
 				emitUpdate();
+			};
+
+			const updateChildActivityState = (event: Record<string, unknown>) => {
+				if (event.type === "turn_start") {
+					turnActive = true;
+					return;
+				}
+				if (event.type === "turn_end") {
+					turnActive = false;
+					return;
+				}
+				if (event.type === "tool_execution_start") {
+					if (typeof event.toolCallId === "string") {
+						activeToolExecutionIds.add(event.toolCallId);
+					}
+					return;
+				}
+				if (event.type === "tool_execution_end") {
+					if (typeof event.toolCallId === "string") {
+						activeToolExecutionIds.delete(event.toolCallId);
+					}
+					return;
+				}
+				if (event.type === "tool_result_end") {
+					const messageValue = event.message;
+					if (
+						messageValue &&
+						typeof messageValue === "object" &&
+						typeof (messageValue as ToolResultMessage).toolCallId === "string"
+					) {
+						activeToolExecutionIds.delete(
+							(messageValue as ToolResultMessage).toolCallId,
+						);
+					}
+				}
+			};
+
+			const canArmGraceFromAssistantMessageEnd = (message: Message) => {
+				if (message.role !== "assistant") return false;
+				if (protocolTerminalGraceSource === "agent_end") return false;
+				if (message.stopReason === "aborted" || Boolean(message.errorMessage)) {
+					return false;
+				}
+				return !turnActive && activeToolExecutionIds.size === 0;
 			};
 
 			const processLine = (line: string) => {
@@ -624,14 +803,19 @@ export const runSingleAgent: RunSingleAgentFn = async (
 					return;
 				}
 
-				if (event.type === "response") return;
-				if (event.type === "agent_start") return;
-				if (event.type === "agent_end") {
-					deactivateSteering();
+				const eventType = typeof event.type === "string" ? event.type : null;
+				if (!eventType) return;
+				cancelProtocolTerminalGraceForEvent(eventType);
+				updateChildActivityState(event);
+
+				if (eventType === "response") return;
+				if (eventType === "agent_start") return;
+				if (eventType === "agent_end") {
 					closeStdin();
+					armProtocolTerminalGrace("agent_end");
 					return;
 				}
-				if (event.type === "extension_ui_request") {
+				if (eventType === "extension_ui_request") {
 					const method =
 						typeof event.method === "string" ? event.method : "unknown";
 					appendStderrLine(
@@ -640,7 +824,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 					);
 					return;
 				}
-				if (event.type === "extension_error") {
+				if (eventType === "extension_error") {
 					const errorText =
 						typeof event.error === "string"
 							? event.error
@@ -651,6 +835,7 @@ export const runSingleAgent: RunSingleAgentFn = async (
 					);
 					return;
 				}
+				if (terminalPublished) return;
 
 				const contentBearingChildMutation = applyChildEventToSingleResult(
 					currentResult,
@@ -660,19 +845,19 @@ export const runSingleAgent: RunSingleAgentFn = async (
 
 				if (
 					contentBearingChildMutation &&
-					(event.type === "message_start" ||
-						event.type === "message_update" ||
-						event.type === "turn_end" ||
-						event.type === "tool_execution_start" ||
-						event.type === "tool_execution_update" ||
-						event.type === "tool_execution_end")
+					(eventType === "message_start" ||
+						eventType === "message_update" ||
+						eventType === "turn_end" ||
+						eventType === "tool_execution_start" ||
+						eventType === "tool_execution_update" ||
+						eventType === "tool_execution_end")
 				) {
 					bumpResultDerivedRevision(currentResult);
 					emitUpdate();
 					return;
 				}
 
-				if (event.type === "message_end" && event.message) {
+				if (eventType === "message_end" && event.message) {
 					const message = event.message as Message;
 					if (message.role === "assistant") {
 						const usage = message.usage;
@@ -700,10 +885,13 @@ export const runSingleAgent: RunSingleAgentFn = async (
 					}
 					bumpResultDerivedRevision(currentResult);
 					emitUpdate();
+					if (canArmGraceFromAssistantMessageEnd(message)) {
+						armProtocolTerminalGrace("assistant_message_end");
+					}
 					return;
 				}
 
-				if (event.type === "tool_result_end" && event.message) {
+				if (eventType === "tool_result_end" && event.message) {
 					if (currentResult.viewerEntries.length === 0) {
 						currentResult.messages.push(event.message as Message);
 					}
@@ -718,7 +906,11 @@ export const runSingleAgent: RunSingleAgentFn = async (
 					if (!trimmedMessage) {
 						throw new Error("Steering message cannot be empty.");
 					}
-					if (!steeringActive || settled || currentResult.exitCode !== -1) {
+					if (
+						!steeringActive ||
+						settled ||
+						currentResult.lifecycle !== "pending"
+					) {
 						throw new Error(`Gremlin ${gremlinId} is no longer active.`);
 					}
 					try {
@@ -747,6 +939,17 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			proc.on("exit", (code) => {
 				if (settled) return;
 				observedExitCode = code ?? observedExitCode ?? 0;
+				if ((observedExitCode ?? 0) !== 0) {
+					if (currentResult.lifecycle === "completed") {
+						lateTerminalExitDiagnostic = formatLateChildExitDiagnostic(
+							observedExitCode ?? 0,
+						);
+					} else if (wasAborted || currentResult.stopReason === "aborted") {
+						cancelBeforeTerminal();
+					} else {
+						failBeforeTerminal();
+					}
+				}
 				if (exitFallbackTimer) clearTimeout(exitFallbackTimer);
 				exitFallbackTimer = setTimeout(() => {
 					finalize(observedExitCode ?? 0);
@@ -758,17 +961,20 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			});
 
 			proc.on("error", (error) => {
-				deactivateSteering();
 				childProcessErrorMessage = formatChildProcessError(error);
 				appendStderrLine(currentResult, childProcessErrorMessage);
+				if (currentResult.lifecycle !== "completed") {
+					failBeforeTerminal(childProcessErrorMessage);
+				}
 				finalize(1);
 			});
 
 			if (signal) {
 				const killProc = () => {
+					if (wasAborted) return;
 					wasAborted = true;
-					deactivateSteering();
 					closeStdin();
+					cancelBeforeTerminal(true);
 					proc.kill("SIGTERM");
 					setTimeout(() => {
 						if (!proc.killed) proc.kill("SIGKILL");
@@ -787,42 +993,77 @@ export const runSingleAgent: RunSingleAgentFn = async (
 			try {
 				writeRpcCommand({ type: "prompt", message: `Task: ${task}` });
 			} catch (error) {
-				deactivateSteering();
 				childProcessErrorMessage = formatChildProcessError(error);
 				appendStderrLine(currentResult, childProcessErrorMessage);
+				failBeforeTerminal(childProcessErrorMessage);
 				finalize(1);
 			}
 		});
 
+		let visibleChanged = false;
 		if (currentResult.exitCode !== exitCode) {
 			currentResult.exitCode = exitCode;
-			bumpResultVisibleRevision(currentResult);
+			visibleChanged = true;
 		} else {
 			currentResult.exitCode = exitCode;
 		}
-		if (wasAborted) {
-			currentResult.stopReason = "aborted";
-			currentResult.errorMessage = "Gremlins🧌 run was aborted";
-			bumpResultVisibleRevision(currentResult);
-		}
-		if (childProcessErrorMessage) {
-			if (writeChildFailureDetails(currentResult, childProcessErrorMessage)) {
-				bumpResultVisibleRevision(currentResult);
-			}
-		} else if (
-			malformedStdoutCount > 0 &&
-			!hasCapturedChildContent(currentResult)
+		if (
+			lateTerminalExitDiagnostic &&
+			!currentResult.stderr.includes(lateTerminalExitDiagnostic)
 		) {
-			const protocolErrorMessage = formatChildProtocolError(
-				malformedStdoutCount,
-				lastMalformedStdoutPreview,
-			);
-			if (writeChildFailureDetails(currentResult, protocolErrorMessage)) {
-				bumpResultVisibleRevision(currentResult);
+			appendStderrLine(currentResult, lateTerminalExitDiagnostic);
+			visibleChanged = true;
+		}
+		if (currentResult.lifecycle === "pending") {
+			if (wasAborted || currentResult.stopReason === "aborted") {
+				visibleChanged =
+					setResultLifecycle(currentResult, "canceled") || visibleChanged;
+				visibleChanged =
+					writeChildCanceledDetails(currentResult) || visibleChanged;
+			} else if (childProcessErrorMessage) {
+				visibleChanged =
+					setResultLifecycle(currentResult, "failed") || visibleChanged;
+				visibleChanged =
+					writeChildFailureDetails(currentResult, childProcessErrorMessage) ||
+					visibleChanged;
+			} else if (
+				malformedStdoutCount > 0 &&
+				!hasCapturedChildContent(currentResult)
+			) {
+				const protocolErrorMessage = formatChildProtocolError(
+					malformedStdoutCount,
+					lastMalformedStdoutPreview,
+				);
+				visibleChanged =
+					setResultLifecycle(currentResult, "failed") || visibleChanged;
+				visibleChanged =
+					writeChildFailureDetails(currentResult, protocolErrorMessage) ||
+					visibleChanged;
+			} else if (currentResult.stopReason === "error") {
+				visibleChanged =
+					setResultLifecycle(currentResult, "failed") || visibleChanged;
+			} else if (exitCode !== 0) {
+				visibleChanged =
+					setResultLifecycle(currentResult, "failed") || visibleChanged;
+			} else {
+				visibleChanged =
+					setResultLifecycle(currentResult, "completed") || visibleChanged;
 			}
+		} else if (currentResult.lifecycle === "canceled") {
+			visibleChanged =
+				writeChildCanceledDetails(currentResult) || visibleChanged;
+		} else if (
+			currentResult.lifecycle !== "completed" &&
+			childProcessErrorMessage
+		) {
+			visibleChanged =
+				writeChildFailureDetails(currentResult, childProcessErrorMessage) ||
+				visibleChanged;
 		}
 		if (finishAssistantViewerEntry(currentResult, viewerState)) {
 			bumpResultDerivedRevision(currentResult);
+		} else if (visibleChanged) {
+			bumpResultVisibleRevision(currentResult);
 		}
 		return currentResult;
 	} finally {


### PR DESCRIPTION
## Summary
- treat terminal protocol milestones as bounded completion signals instead of waiting on slow child teardown
- preserve late exit and cancellation handling without double-finalizing completed runs
- add regression coverage for delayed close, protocol grace, and late terminal process events

## Verification
- bun test extensions/pi-gremlins/index.execute.test.js
- bun test extensions/pi-gremlins/index.render.test.js

Closes #20