### PR TITLE
fix: stabilize mission control popup hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `pi-gremlins` child runs now publish prompt terminal lifecycle state after safe protocol completion with a 100ms grace window, so single and parallel invocations stop showing finished children as `Running` while slow subprocess exit/close telemetry trickles in.
+- Gremlins🧌 mission control now keeps a stable footer hotkey row visible across single-result, multi-result, and narrow popup states, so active scroll, paging, dismiss, and result-navigation controls stay discoverable.
 - Gremlins🧌 mission control now keeps full ordered chain result slots in live viewer snapshots, so left/right navigation can reach completed earlier steps and pending later steps while current chain work is still running.
 - `pi-gremlins` now emits explicit terminal completion updates for single-child `single` and one-step `chain` runs after child exit, so parent flows receive terminal status snapshots before final tool results land.
 - `pi-gremlins` now finalizes child runs on process exit even if `close` never arrives, preserving terminal tool results and parent-session completion for exit-complete gremlin work.

--- a/extensions/pi-gremlins/index.viewer.test.js
+++ b/extensions/pi-gremlins/index.viewer.test.js
@@ -51,44 +51,59 @@ mock.module("@sinclair/typebox", () => ({
 	},
 }));
 
-mock.module("@mariozechner/pi-tui", () => ({
-	Container: class {
-		constructor() {
-			this.children = [];
-		}
-		addChild(child) {
-			this.children.push(child);
-		}
-	},
-	Key: {
+mock.module("@mariozechner/pi-tui", () => {
+	const Key = {
 		home: "home",
 		end: "end",
 		up: "up",
 		down: "down",
+		left: "left",
+		right: "right",
+		pageUp: "pageUp",
+		pageDown: "pageDown",
 		ctrl: (key) => `ctrl-${key}`,
 		alt: (key) => `alt-${key}`,
-	},
-	Markdown: class {
-		constructor(text) {
-			this.text = text;
-		}
-	},
-	Spacer: class {
-		constructor(lines = 1) {
-			this.lines = lines;
-		}
-	},
-	Text: class {
-		constructor(text) {
-			this.text = text;
-		}
-	},
-	matchesKey: () => false,
-	parseKey: () => null,
-	truncateToWidth: (text) => text,
-	visibleWidth: (text) => text.length,
-	wrapTextWithAnsi: (text) => [text],
-}));
+	};
+	const keyMap = new Map([
+		["\u001b[A", Key.up],
+		["\u001b[B", Key.down],
+		["\u001b[D", Key.left],
+		["\u001b[C", Key.right],
+		["\u001b[5~", Key.pageUp],
+		["\u001b[6~", Key.pageDown],
+	]);
+	return {
+		Container: class {
+			constructor() {
+				this.children = [];
+			}
+			addChild(child) {
+				this.children.push(child);
+			}
+		},
+		Key,
+		Markdown: class {
+			constructor(text) {
+				this.text = text;
+			}
+		},
+		Spacer: class {
+			constructor(lines = 1) {
+				this.lines = lines;
+			}
+		},
+		Text: class {
+			constructor(text) {
+				this.text = text;
+			}
+		},
+		matchesKey: (data, key) => keyMap.get(data) === key,
+		parseKey: () => null,
+		truncateToWidth: (text) => text,
+		visibleWidth: (text) => text.length,
+		wrapTextWithAnsi: (text) => [text],
+	};
+});
 
 const { default: registerPiGremlins } = await import("./index.ts");
 const { createInvocationSnapshot } = await import("./invocation-state.ts");
@@ -189,16 +204,27 @@ async function seedInvocation(tool, workspace, toolCallId = "viewer-seeded") {
 	);
 }
 
-function renderOverlayText(
-	snapshot,
-	{ width = 72, rows = 24, selectedResultIndex = 0 } = {},
-) {
+function withTerminalRows(rows, callback) {
 	const originalRows = process.stdout.rows;
 	Object.defineProperty(process.stdout, "rows", {
 		value: rows,
 		configurable: true,
 	});
 	try {
+		return callback();
+	} finally {
+		Object.defineProperty(process.stdout, "rows", {
+			value: originalRows,
+			configurable: true,
+		});
+	}
+}
+
+function renderOverlayText(
+	snapshot,
+	{ width = 72, rows = 24, selectedResultIndex = 0 } = {},
+) {
+	return withTerminalRows(rows, () => {
 		const overlay = new PiGremlinsViewerOverlay(
 			{ requestRender: () => {} },
 			createTheme(),
@@ -209,12 +235,7 @@ function renderOverlayText(
 		overlay.selectedResultIndex = selectedResultIndex;
 		overlay.refresh();
 		return overlay.render(width).join("\n");
-	} finally {
-		Object.defineProperty(process.stdout, "rows", {
-			value: originalRows,
-			configurable: true,
-		});
-	}
+	});
 }
 
 let workspaceRoot = null;
@@ -812,6 +833,37 @@ describe("pi-gremlins viewer command", () => {
 		expect(text).toContain("task 2/2 · alpha [project] · Completed · g2");
 	});
 
+	test("renders popup footer hints even for single-result mission-control states", () => {
+		const scout = createPendingResult(
+			"scout",
+			"Inspect mission control footer",
+			undefined,
+			"user",
+			"g1",
+		);
+		scout.viewerEntries.push({
+			type: "assistant-text",
+			text: "footer still visible",
+			streaming: true,
+		});
+		bumpResultDerivedRevision(scout);
+
+		const snapshot = createInvocationSnapshot(
+			"viewer-single-footer-hints",
+			createDetails("single", [scout]),
+			"Running",
+		);
+		const text = renderOverlayText(snapshot, {
+			width: 72,
+			rows: 24,
+		});
+
+		expect(text).toContain("↑/↓ scroll");
+		expect(text).toContain("PgUp/PgDn");
+		expect(text).toContain("Esc close");
+		expect(text).not.toContain("←/→ result");
+	});
+
 	test("renders popup narrow-width layout with essential chrome only", () => {
 		const planner = createPendingResult("planner", "Plan route", 1, "project");
 		planner.exitCode = 0;
@@ -873,7 +925,9 @@ describe("pi-gremlins viewer command", () => {
 		expect(text).toContain("telemetry · turns:3 · input:140");
 		expect(text).not.toContain("invocation ·");
 		expect(text).not.toContain("step 2/2");
-		expect(text).not.toContain("←/→ result");
+		expect(text).toContain("←/→ result");
+		expect(text).toContain("↑/↓ scroll");
+		expect(text).toContain("Esc close");
 	});
 
 	test("renders popup short-height layout with body retained after chrome suppression", () => {
@@ -936,6 +990,134 @@ describe("pi-gremlins viewer command", () => {
 		expect(text).not.toContain("invocation ·");
 		expect(text).not.toContain("step 2/2");
 		expect(text).not.toContain("←/→ result");
+	});
+
+	test("lets ←/→ revisit completed chain steps and parallel siblings", () => {
+		const alpha = createPendingResult(
+			"alpha",
+			"Inspect completed alpha",
+			undefined,
+			"user",
+			"g1",
+		);
+		alpha.exitCode = 0;
+		alpha.messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: "alpha done" }],
+		});
+		bumpResultVisibleRevision(alpha);
+		bumpResultDerivedRevision(alpha);
+
+		const beta = createPendingResult(
+			"beta",
+			"Inspect completed beta",
+			undefined,
+			"project",
+			"g2",
+		);
+		beta.exitCode = 0;
+		beta.messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: "beta done" }],
+		});
+		bumpResultVisibleRevision(beta);
+		bumpResultDerivedRevision(beta);
+
+		const parallelSnapshot = createInvocationSnapshot(
+			"viewer-parallel-completed-navigation",
+			createDetails("parallel", [alpha, beta]),
+			"Completed",
+		);
+
+		withTerminalRows(24, () => {
+			const overlay = new PiGremlinsViewerOverlay(
+				{ requestRender: () => {} },
+				createTheme(),
+				{ matches: () => false },
+				() => parallelSnapshot,
+				() => {},
+			);
+			overlay.selectedResultIndex = 1;
+			overlay.refresh();
+			expect(overlay.render(72).join("\n")).toContain(
+				"task 2/2 · beta [project] · Completed · g2",
+			);
+			overlay.handleInput("\u001b[D");
+			expect(overlay.render(72).join("\n")).toContain(
+				"task 1/2 · alpha [user] · Completed · g1",
+			);
+		});
+
+		const writer = createPendingResult(
+			"writer",
+			"Draft initial answer",
+			1,
+			"user",
+			"g3",
+		);
+		writer.exitCode = 0;
+		writer.messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: "draft ready" }],
+		});
+		bumpResultVisibleRevision(writer);
+		bumpResultDerivedRevision(writer);
+
+		const reviewer = createPendingResult(
+			"reviewer",
+			"Review completed draft",
+			2,
+			"user",
+			"g4",
+		);
+		reviewer.exitCode = 0;
+		reviewer.messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: "review ready" }],
+		});
+		bumpResultVisibleRevision(reviewer);
+		bumpResultDerivedRevision(reviewer);
+
+		const closer = createPendingResult(
+			"closer",
+			"Finalize approved draft",
+			3,
+			"user",
+			"g5",
+		);
+		closer.exitCode = 0;
+		closer.messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: "final ready" }],
+		});
+		bumpResultVisibleRevision(closer);
+		bumpResultDerivedRevision(closer);
+
+		const chainSnapshot = createInvocationSnapshot(
+			"viewer-chain-completed-navigation",
+			createDetails("chain", [writer, reviewer, closer]),
+			"Completed",
+		);
+
+		withTerminalRows(24, () => {
+			const overlay = new PiGremlinsViewerOverlay(
+				{ requestRender: () => {} },
+				createTheme(),
+				{ matches: () => false },
+				() => chainSnapshot,
+				() => {},
+			);
+			overlay.selectedResultIndex = 2;
+			overlay.refresh();
+			expect(overlay.render(72).join("\n")).toContain(
+				"step 3/3 · closer [user] · Completed · g5",
+			);
+			overlay.handleInput("\u001b[D");
+			overlay.handleInput("\u001b[D");
+			expect(overlay.render(72).join("\n")).toContain(
+				"step 1/3 · writer [user] · Completed · g3",
+			);
+		});
 	});
 
 	test("uses full ordered live chain viewer results for navigation beyond active step", () => {

--- a/extensions/pi-gremlins/viewer-result-navigation.test.js
+++ b/extensions/pi-gremlins/viewer-result-navigation.test.js
@@ -55,7 +55,7 @@ const {
 } = await import(viewerNavigationModuleUrl);
 
 describe("viewer result navigation", () => {
-	test("shows result chrome only for multi-result popup states", () => {
+	test("keeps footer hotkey chrome visible for single and multi-result popup states", () => {
 		expect(hasMultiResultNavigation(0)).toBe(false);
 		expect(hasMultiResultNavigation(1)).toBe(false);
 		expect(hasMultiResultNavigation(2)).toBe(true);
@@ -67,8 +67,8 @@ describe("viewer result navigation", () => {
 			showResultContext: false,
 			showTopRule: true,
 			showBottomRule: true,
-			showNavigationHint: false,
-			chromeRowCount: 8,
+			showNavigationHint: true,
+			chromeRowCount: 9,
 		});
 		expect(getViewerChromeState(1)).toEqual({
 			showFrame: true,
@@ -78,8 +78,8 @@ describe("viewer result navigation", () => {
 			showResultContext: false,
 			showTopRule: true,
 			showBottomRule: true,
-			showNavigationHint: false,
-			chromeRowCount: 8,
+			showNavigationHint: true,
+			chromeRowCount: 9,
 		});
 		expect(getViewerChromeState(3)).toEqual({
 			showFrame: true,
@@ -92,11 +92,12 @@ describe("viewer result navigation", () => {
 			showNavigationHint: true,
 			chromeRowCount: 10,
 		});
-		expect(getViewerChromeRowCount(1)).toBe(8);
+		expect(getViewerChromeRowCount(1)).toBe(9);
 		expect(getViewerChromeRowCount(3)).toBe(10);
-		expect(getViewerBodyHeight(24, 1)).toBe(16);
+		expect(getViewerBodyHeight(24, 1)).toBe(15);
 		expect(getViewerBodyHeight(24, 3)).toBe(14);
 		expect(getViewerBodyHeight(12, 3)).toBe(2);
+		expect(getViewerBodyHeight(24, 0)).toBe(15);
 	});
 
 	test("keeps rendered chrome and body within overlay height budget for all terminal sizes", () => {
@@ -154,10 +155,10 @@ describe("viewer result navigation", () => {
 					showMetadata: true,
 					showTelemetry: true,
 					showInvocation: true,
-					showResultContext: true,
+					showResultContext: false,
 					showTopRule: false,
 					showBottomRule: false,
-					showNavigationHint: false,
+					showNavigationHint: true,
 					chromeRowCount: 7,
 					bodyHeight: 1,
 				},
@@ -173,9 +174,9 @@ describe("viewer result navigation", () => {
 					showResultContext: true,
 					showTopRule: false,
 					showBottomRule: false,
-					showNavigationHint: false,
-					chromeRowCount: 7,
-					bodyHeight: 2,
+					showNavigationHint: true,
+					chromeRowCount: 8,
+					bodyHeight: 1,
 				},
 			},
 		];
@@ -202,7 +203,11 @@ describe("viewer result navigation", () => {
 	});
 
 	test("surfaces width-aware popup hints and overlay sizing", () => {
-		expect(getViewerNavigationHint(1)).toBeNull();
+		expect(getViewerNavigationHint(0)).toBe("Esc close");
+		expect(getViewerNavigationHint(1)).toBe(
+			"↑/↓ scroll · PgUp/PgDn page · Home/End/Alt+↑/Alt+↓ · Esc close",
+		);
+		expect(getViewerNavigationHint(1, 32)).toBe("↑/↓ scroll · Esc close");
 		expect(getViewerNavigationHint(3)).toBe(
 			"←/→ result · ↑/↓ scroll · PgUp/PgDn · Home/End · Esc close",
 		);

--- a/extensions/pi-gremlins/viewer-result-navigation.ts
+++ b/extensions/pi-gremlins/viewer-result-navigation.ts
@@ -36,8 +36,6 @@ export interface ViewerChromeState {
 	chromeRowCount: number;
 }
 
-const BASE_VIEWER_CHROME_ROW_COUNT = 8;
-const MULTI_RESULT_EXTRA_CHROME_ROW_COUNT = 2;
 const VIEWER_DIALOG_MAX_HEIGHT = 32;
 const VIEWER_TAB_REPLACEMENT = "    ";
 const VIEWER_OVERLAY_MAX_HEIGHT_RATIO = 0.78;
@@ -46,15 +44,12 @@ const MIN_DIALOG_HEIGHT_FOR_FRAME = 3;
 const MIN_DIALOG_HEIGHT_FOR_METADATA = 5;
 const MIN_DIALOG_HEIGHT_FOR_TELEMETRY = 6;
 const MIN_DIALOG_HEIGHT_FOR_INVOCATION = 7;
-const MIN_DIALOG_HEIGHT_FOR_RESULT_CONTEXT = 8;
-const MIN_DIALOG_HEIGHT_FOR_NAVIGATION_HINT = 10;
-const MIN_DIALOG_HEIGHT_FOR_FULL_SINGLE_CHROME =
-	BASE_VIEWER_CHROME_ROW_COUNT + 1;
-const MIN_DIALOG_HEIGHT_FOR_FULL_MULTI_CHROME =
-	BASE_VIEWER_CHROME_ROW_COUNT + MULTI_RESULT_EXTRA_CHROME_ROW_COUNT + 1;
+const MIN_DIALOG_HEIGHT_FOR_NAVIGATION_HINT = 8;
+const MIN_DIALOG_HEIGHT_FOR_RESULT_CONTEXT = 9;
+const MIN_DIALOG_HEIGHT_FOR_FULL_SINGLE_CHROME = 10;
+const MIN_DIALOG_HEIGHT_FOR_FULL_MULTI_CHROME = 11;
 const MIN_DIALOG_WIDTH_FOR_INVOCATION = 40;
 const MIN_DIALOG_WIDTH_FOR_RESULT_CONTEXT = 44;
-const MIN_DIALOG_WIDTH_FOR_NAVIGATION_HINT = 64;
 
 export const VIEWER_SCROLL_LINE_STEP = 3;
 
@@ -113,9 +108,7 @@ export function getViewerChromeState(
 		boundedDialogHeight >= MIN_DIALOG_HEIGHT_FOR_RESULT_CONTEXT &&
 		boundedDialogWidth >= MIN_DIALOG_WIDTH_FOR_RESULT_CONTEXT;
 	const showNavigationHint =
-		showMultiResultChrome &&
-		boundedDialogHeight >= MIN_DIALOG_HEIGHT_FOR_NAVIGATION_HINT &&
-		boundedDialogWidth >= MIN_DIALOG_WIDTH_FOR_NAVIGATION_HINT;
+		boundedDialogHeight >= MIN_DIALOG_HEIGHT_FOR_NAVIGATION_HINT;
 	const showFullChromeRules =
 		showFrame &&
 		boundedDialogHeight >=
@@ -259,11 +252,20 @@ export function getViewerNavigationHint(
 	resultCount: number,
 	dialogWidth = 72,
 ): string | null {
-	if (!hasMultiResultNavigation(resultCount)) return null;
+	if (resultCount <= 0) {
+		return pickLineVariant(dialogWidth, ["Esc close"]);
+	}
+	if (hasMultiResultNavigation(resultCount)) {
+		return pickLineVariant(dialogWidth, [
+			"←/→ result · ↑/↓ scroll · PgUp/PgDn page · Home/End/Alt+↑/Alt+↓ · Esc close",
+			"←/→ result · ↑/↓ scroll · PgUp/PgDn · Home/End · Esc close",
+			"←/→ result · ↑/↓ scroll · Esc close",
+		]);
+	}
 	return pickLineVariant(dialogWidth, [
-		"←/→ result · ↑/↓ scroll · PgUp/PgDn page · Home/End/Alt+↑/Alt+↓ · Esc close",
-		"←/→ result · ↑/↓ scroll · PgUp/PgDn · Home/End · Esc close",
-		"←/→ result · ↑/↓ scroll · Esc close",
+		"↑/↓ scroll · PgUp/PgDn page · Home/End/Alt+↑/Alt+↓ · Esc close",
+		"↑/↓ scroll · PgUp/PgDn · Home/End · Esc close",
+		"↑/↓ scroll · Esc close",
 	]);
 }
 
@@ -285,12 +287,12 @@ export function getResultContextLabel(
 	dialogWidth = 72,
 ): string | null {
 	if (!hasMultiResultNavigation(resultCount)) return null;
-	const position =
-		mode === "chain"
-			? `step ${result.step ?? selectedResultIndex + 1}/${resultCount}`
-			: mode === "parallel"
-				? `task ${selectedResultIndex + 1}/${resultCount}`
-				: `item ${selectedResultIndex + 1}/${resultCount}`;
+	let position = `item ${selectedResultIndex + 1}/${resultCount}`;
+	if (mode === "chain") {
+		position = `step ${result.step ?? selectedResultIndex + 1}/${resultCount}`;
+	} else if (mode === "parallel") {
+		position = `task ${selectedResultIndex + 1}/${resultCount}`;
+	}
 	const sourceBadge = result.sourceBadge ? ` ${result.sourceBadge}` : "";
 	return pickLineVariant(dialogWidth, [
 		`focus · ${position} · ${result.agent}${sourceBadge} · ${result.status} · ${result.gremlinId}`,


### PR DESCRIPTION
## Summary
- keep mission control footer hotkeys visible for single-result, multi-result, and narrow popup states
- add regression coverage for completed chain and parallel result traversal with ←/→
- update changelog entry for viewer hotkey discoverability

## Verification
- npm test
- npm run typecheck

Closes #19