### PR TITLE
feat: show timestamps in gremlin feed events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `pi-gremlins` now assigns stable human-friendly child run ids (`g1`, `g2`, …) at creation time, carries them through result snapshots, and surfaces them in embedded inline summaries, popup viewer chrome, and repeated-agent execution summaries.
+- Gremlin embedded feed rows and popup mission-control timelines now stamp viewer entries with compact `HH:mm:ss` event times, using latest entry update time for live rows and initial creation time for untouched rows.
 - New `/gremlins:steer <gremlin-id> <message>` command routes a follow-up message to one active gremlin session, records the steering event in embedded/popup output, and reports helpful errors for missing payload, unknown ids, and inactive gremlins.
 - Product, architecture, and implementation records for viewer overhaul in `docs/prd/0001-pi-gremlins-immersive-theming-and-viewer-ux-overhaul.md`, `docs/adr/0001-semantic-presentation-architecture-for-pi-gremlins-viewer-and-embedded-surfaces.md`, and `docs/plans/pi-gremlins-immersive-theming-viewer-ux-overhaul.md`.
 - PRD/ADR index and template scaffolding under `docs/prd/` and `docs/adr/` for future feature and architecture tracking.

--- a/extensions/pi-gremlins/execution-shared.ts
+++ b/extensions/pi-gremlins/execution-shared.ts
@@ -44,16 +44,30 @@ export interface UsageTelemetrySemantics {
 
 export type StatusTone = "warning" | "success" | "error";
 
+export interface ViewerEntryTimestamps {
+	createdAt?: number;
+	updatedAt?: number;
+}
+
 export type ViewerEntry =
-	| { type: "assistant-text"; text: string; streaming: boolean }
-	| { type: "steer"; text: string; streaming: boolean; isError: boolean }
-	| {
+	| ({
+			type: "assistant-text";
+			text: string;
+			streaming: boolean;
+	  } & ViewerEntryTimestamps)
+	| ({
+			type: "steer";
+			text: string;
+			streaming: boolean;
+			isError: boolean;
+	  } & ViewerEntryTimestamps)
+	| ({
 			type: "tool-call";
 			toolCallId: string;
 			toolName: string;
 			args: Record<string, unknown>;
-	  }
-	| {
+	  } & ViewerEntryTimestamps)
+	| ({
 			type: "tool-result";
 			toolCallId: string;
 			toolName: string;
@@ -61,7 +75,7 @@ export type ViewerEntry =
 			streaming: boolean;
 			truncated: boolean;
 			isError: boolean;
-	  };
+	  } & ViewerEntryTimestamps);
 
 export interface SingleResult {
 	gremlinId: string;
@@ -99,13 +113,25 @@ export interface SingleRunViewerState {
 }
 
 export type DisplayItem =
-	| { type: "text"; text: string; streaming?: boolean }
-	| { type: "steer"; content: string; streaming: boolean; isError: boolean }
+	| {
+			type: "text";
+			text: string;
+			streaming?: boolean;
+			timestampMs?: number;
+	  }
+	| {
+			type: "steer";
+			content: string;
+			streaming: boolean;
+			isError: boolean;
+			timestampMs?: number;
+	  }
 	| {
 			type: "toolCall";
 			name: string;
 			args: Record<string, unknown>;
 			toolCallId?: string;
+			timestampMs?: number;
 	  }
 	| {
 			type: "toolResult";
@@ -115,6 +141,7 @@ export type DisplayItem =
 			truncated: boolean;
 			isError: boolean;
 			toolCallId?: string;
+			timestampMs?: number;
 	  };
 
 export interface DerivedRenderData {
@@ -147,6 +174,25 @@ function getInternalResult(result: SingleResult): InternalSingleResult {
 
 function getInternalDetails(details: PiGremlinsDetails): InternalDetails {
 	return details as InternalDetails;
+}
+
+export function getViewerEntryTimestampMs(
+	entry: ViewerEntryTimestamps,
+): number | undefined {
+	return entry.updatedAt ?? entry.createdAt;
+}
+
+export function formatViewerEntryTimestamp(
+	timestampMs: number | undefined,
+): string | null {
+	if (typeof timestampMs !== "number" || !Number.isFinite(timestampMs)) {
+		return null;
+	}
+	const date = new Date(timestampMs);
+	const parts = [date.getHours(), date.getMinutes(), date.getSeconds()].map(
+		(value) => value.toString().padStart(2, "0"),
+	);
+	return `[${parts.join(":")}]`;
 }
 
 function formatTokens(count: number): string {
@@ -335,6 +381,7 @@ function buildDerivedRenderDataFromViewerEntries(
 				type: "text",
 				text: entry.text,
 				streaming: entry.streaming || undefined,
+				timestampMs: getViewerEntryTimestampMs(entry),
 			});
 			if (entry.text.trim()) finalAssistantOutput = entry.text;
 			continue;
@@ -345,6 +392,7 @@ function buildDerivedRenderDataFromViewerEntries(
 				content: entry.text,
 				streaming: entry.streaming,
 				isError: entry.isError,
+				timestampMs: getViewerEntryTimestampMs(entry),
 			});
 			continue;
 		}
@@ -354,6 +402,7 @@ function buildDerivedRenderDataFromViewerEntries(
 				name: entry.toolName,
 				args: entry.args,
 				toolCallId: entry.toolCallId,
+				timestampMs: getViewerEntryTimestampMs(entry),
 			});
 			continue;
 		}
@@ -365,6 +414,7 @@ function buildDerivedRenderDataFromViewerEntries(
 			truncated: entry.truncated,
 			isError: entry.isError,
 			toolCallId: entry.toolCallId,
+			timestampMs: getViewerEntryTimestampMs(entry),
 		});
 		if (entry.content.trim()) finalToolResultOutput = entry.content;
 	}

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -942,6 +942,141 @@ describe("pi-gremlins execute streaming characterization", () => {
 		expect(updates[4].details.status).toBe("Completed");
 	});
 
+	test("single mode stamps viewer entries when feed rows are created and updated", async () => {
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		mockAgentDir = workspace.userRoot;
+		writeAgentFile(workspace.userAgentsDir, "tars.md", "tars");
+
+		const originalDateNow = Date.now;
+		let now = 1_000;
+		Date.now = () => {
+			now += 1_000;
+			return now;
+		};
+
+		try {
+			spawnPlans.push(() =>
+				createMockProcess({
+					stdoutChunks: [
+						jsonLine({
+							type: "message_start",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "draft" }],
+							},
+						}),
+						jsonLine({
+							type: "message_update",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "draft reply" }],
+							},
+						}),
+						jsonLine({
+							type: "tool_execution_start",
+							toolCallId: "read-1",
+							toolName: "read",
+							args: { path: "/tmp/report.md" },
+						}),
+						jsonLine({
+							type: "tool_execution_update",
+							toolCallId: "read-1",
+							toolName: "read",
+							args: { path: "/tmp/report.md" },
+							partialResult: {
+								content: [{ type: "text", text: "reading chunk" }],
+							},
+						}),
+						jsonLine({
+							type: "tool_execution_end",
+							toolCallId: "read-1",
+							toolName: "read",
+							args: { path: "/tmp/report.md" },
+							result: {
+								content: [{ type: "text", text: "file contents" }],
+							},
+							isError: false,
+						}),
+						jsonLine({
+							type: "message_end",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "final answer" }],
+								usage: {
+									input: 3,
+									output: 5,
+									cacheRead: 0,
+									cacheWrite: 0,
+									cost: { total: 0.01 },
+									totalTokens: 8,
+								},
+							},
+						}),
+					],
+					closeCode: 0,
+				}),
+			);
+
+			const tool = createRegisteredTool();
+			const result = await tool.execute(
+				"single-timestamped-viewer-entries",
+				{ agent: "tars", task: "Stamp viewer feed rows" },
+				undefined,
+				undefined,
+				createExecutionContext(workspace.repoRoot),
+			);
+
+			const viewerEntries = result.details.results[0].viewerEntries;
+			const assistantEntry = viewerEntries.find(
+				(entry) => entry.type === "assistant-text",
+			);
+			const toolCallEntry = viewerEntries.find(
+				(entry) => entry.type === "tool-call" && entry.toolCallId === "read-1",
+			);
+			const toolResultEntry = viewerEntries.find(
+				(entry) =>
+					entry.type === "tool-result" && entry.toolCallId === "read-1",
+			);
+
+			expect(assistantEntry).toMatchObject({
+				type: "assistant-text",
+				text: "final answer",
+			});
+			expect(typeof assistantEntry?.createdAt).toBe("number");
+			expect(typeof assistantEntry?.updatedAt).toBe("number");
+			expect(assistantEntry?.updatedAt).toBeGreaterThan(
+				assistantEntry?.createdAt ?? 0,
+			);
+
+			expect(toolCallEntry).toMatchObject({
+				type: "tool-call",
+				toolCallId: "read-1",
+			});
+			expect(typeof toolCallEntry?.createdAt).toBe("number");
+			expect(toolCallEntry?.updatedAt).toBe(toolCallEntry?.createdAt);
+
+			expect(toolResultEntry).toMatchObject({
+				type: "tool-result",
+				toolCallId: "read-1",
+				content: "file contents",
+			});
+			expect(typeof toolResultEntry?.createdAt).toBe("number");
+			expect(typeof toolResultEntry?.updatedAt).toBe("number");
+			expect(toolResultEntry?.updatedAt).toBeGreaterThan(
+				toolResultEntry?.createdAt ?? 0,
+			);
+			expect(toolCallEntry?.createdAt).toBeGreaterThan(
+				assistantEntry?.createdAt ?? 0,
+			);
+			expect(toolResultEntry?.createdAt).toBeGreaterThan(
+				toolCallEntry?.createdAt ?? 0,
+			);
+		} finally {
+			Date.now = originalDateNow;
+		}
+	});
+
 	test("single mode skips duplicate publish for no-op tool_execution_start after assistant tool call", async () => {
 		const workspace = createWorkspace();
 		workspaceRoot = workspace.root;

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -150,6 +150,10 @@ function createDetails(mode, results) {
 	};
 }
 
+function createTimestamp(hour, minute, second) {
+	return new Date(2026, 0, 1, hour, minute, second).getTime();
+}
+
 function renderToText(tool, result, options = {}, context = {}) {
 	return flattenRenderedNode(
 		tool.renderResult(result, { expanded: false, ...options }, createTheme(), {
@@ -471,6 +475,75 @@ describe("pi-gremlins renderResult characterization", () => {
 
 		expect(text).toContain("steer · update README too");
 		expect(text).toContain("live · drafting answer");
+	});
+
+	test("renders compact timestamps for inline viewer-entry feed rows using last entry update time", () => {
+		const tool = createRegisteredTool();
+		const text = renderToText(
+			tool,
+			{
+				content: [{ type: "text", text: "unused" }],
+				details: createDetails("single", [
+					createSingleResult({
+						exitCode: -1,
+						viewerEntries: [
+							{
+								type: "tool-call",
+								toolCallId: "read-1",
+								toolName: "read",
+								args: { path: "/tmp/pending.md" },
+								createdAt: createTimestamp(14, 32, 8),
+								updatedAt: createTimestamp(14, 32, 8),
+							},
+							{
+								type: "tool-call",
+								toolCallId: "read-2",
+								toolName: "read",
+								args: { path: "/tmp/done.md" },
+								createdAt: createTimestamp(14, 32, 9),
+								updatedAt: createTimestamp(14, 32, 9),
+							},
+							{
+								type: "tool-result",
+								toolCallId: "read-2",
+								toolName: "read",
+								content: "file contents",
+								streaming: false,
+								truncated: false,
+								isError: false,
+								createdAt: createTimestamp(14, 32, 10),
+								updatedAt: createTimestamp(14, 32, 10),
+							},
+							{
+								type: "steer",
+								text: "update README too",
+								streaming: false,
+								isError: false,
+								createdAt: createTimestamp(14, 32, 11),
+								updatedAt: createTimestamp(14, 32, 11),
+							},
+							{
+								type: "assistant-text",
+								text: "drafting answer",
+								streaming: true,
+								createdAt: createTimestamp(14, 32, 12),
+								updatedAt: createTimestamp(14, 32, 13),
+							},
+						],
+					}),
+				]),
+			},
+			{ expanded: true },
+		);
+
+		expect(text).toContain(
+			"[14:32:08] active tool · read /tmp/pending.md → waiting",
+		);
+		expect(text).toContain(
+			"[14:32:10] tool · read /tmp/done.md → file contents",
+		);
+		expect(text).toContain("[14:32:11] steer · update README too");
+		expect(text).toContain("[14:32:13] live · drafting answer");
 	});
 
 	test("keeps no-entry tool-call-only single summaries terminal-safe and running-live", () => {

--- a/extensions/pi-gremlins/index.viewer.test.js
+++ b/extensions/pi-gremlins/index.viewer.test.js
@@ -140,6 +140,10 @@ function createDetails(mode, results) {
 	};
 }
 
+function createTimestamp(hour, minute, second) {
+	return new Date(2026, 0, 1, hour, minute, second).getTime();
+}
+
 function createTheme() {
 	return {
 		fg: (_color, text) => text,
@@ -673,6 +677,70 @@ describe("pi-gremlins viewer command", () => {
 		expect(text).toContain("Telemetry packet");
 		expect(text).toContain("tool error · bash [error]");
 		expect(text).toContain("fatal: boom");
+	});
+
+	test("renders popup viewer-entry timestamps with updated-at semantics", () => {
+		const result = createPendingResult(
+			"tars",
+			"Inspect timestamped mission telemetry",
+			undefined,
+			"user",
+		);
+		result.viewerEntries.push(
+			{
+				type: "assistant-text",
+				text: "Streaming mission update",
+				streaming: true,
+				createdAt: createTimestamp(14, 32, 12),
+				updatedAt: createTimestamp(14, 32, 13),
+			},
+			{
+				type: "tool-call",
+				toolCallId: "read-1",
+				toolName: "read",
+				args: { path: "/tmp/report.md" },
+				createdAt: createTimestamp(14, 32, 8),
+				updatedAt: createTimestamp(14, 32, 8),
+			},
+			{
+				type: "tool-result",
+				toolCallId: "read-1",
+				toolName: "read",
+				content: "Telemetry packet",
+				streaming: false,
+				truncated: true,
+				isError: false,
+				createdAt: createTimestamp(14, 32, 10),
+				updatedAt: createTimestamp(14, 32, 10),
+			},
+			{
+				type: "tool-result",
+				toolCallId: "bash-1",
+				toolName: "bash",
+				content: "fatal: boom",
+				streaming: false,
+				truncated: false,
+				isError: true,
+				createdAt: createTimestamp(14, 32, 11),
+				updatedAt: createTimestamp(14, 32, 11),
+			},
+		);
+		bumpResultDerivedRevision(result);
+
+		const snapshot = createInvocationSnapshot(
+			"viewer-body-timestamps",
+			createDetails("single", [result]),
+			"Running",
+		);
+		const body = getCachedInvocationBodyLines(null, snapshot, 0, createTheme());
+		const text = body.lines.join("\n");
+
+		expect(text).toContain(
+			"[14:32:13] assistant · Streaming mission update [live]",
+		);
+		expect(text).toContain("[14:32:08] tool call · read /tmp/report.md");
+		expect(text).toContain("[14:32:10] tool result · read [truncated]");
+		expect(text).toContain("[14:32:11] tool error · bash [error]");
 	});
 
 	test("renders popup empty state with themed idle telemetry", () => {

--- a/extensions/pi-gremlins/result-rendering.ts
+++ b/extensions/pi-gremlins/result-rendering.ts
@@ -5,6 +5,7 @@ import {
 	formatAgentSourceBadgeText,
 	formatStatusBadgeText,
 	formatUsageStats,
+	formatViewerEntryTimestamp,
 	getAgentSourceSemantics,
 	getDerivedRenderData,
 	getInvocationSemantics,
@@ -35,13 +36,25 @@ const NO_OUTPUT_TEXT = "No output captured.";
 type LiveStage = "active" | "pending" | "terminal";
 
 type DigestEntry =
-	| { kind: "assistant"; text: string; streaming: boolean }
-	| { kind: "steer"; text: string; streaming: boolean; isError: boolean }
+	| {
+			kind: "assistant";
+			text: string;
+			streaming: boolean;
+			timestampMs?: number;
+	  }
+	| {
+			kind: "steer";
+			text: string;
+			streaming: boolean;
+			isError: boolean;
+			timestampMs?: number;
+	  }
 	| {
 			kind: "toolCall";
 			text: string;
 			toolName: string;
 			toolCallId?: string;
+			timestampMs?: number;
 	  }
 	| {
 			kind: "toolResult";
@@ -49,6 +62,7 @@ type DigestEntry =
 			streaming: boolean;
 			isError: boolean;
 			toolCallId?: string;
+			timestampMs?: number;
 	  };
 
 interface RenderTheme {
@@ -200,16 +214,19 @@ function formatLabelLine(
 	tone: string = "dim",
 	width: number | null = null,
 ): string {
-	const prefix = theme.fg("muted", `${label} · `);
+	const timestampMatch = text.match(/^(\[\d{2}:\d{2}:\d{2}\])\s+(.*)$/);
+	const timestampPrefix = timestampMatch ? `${timestampMatch[1]} ` : "";
+	const contentText = timestampMatch ? timestampMatch[2] : text;
+	const prefix = theme.fg("muted", `${timestampPrefix}${label} · `);
 	if (width === null) {
-		return `${prefix}${theme.fg(tone, text)}`;
+		return `${prefix}${theme.fg(tone, contentText)}`;
 	}
 	const prefixWidth = visibleWidth(prefix);
 	if (prefixWidth >= width) {
 		return truncateLine(prefix, width);
 	}
 	const available = Math.max(1, width - prefixWidth);
-	return `${prefix}${theme.fg(tone, truncateLine(text, available))}`;
+	return `${prefix}${theme.fg(tone, truncateLine(contentText, available))}`;
 }
 
 function normalizeInlineText(text: string): string {
@@ -224,6 +241,14 @@ function summarizeInlineText(
 	if (!normalized) return "";
 	if (normalized.length <= maxLength) return normalized;
 	return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function withDigestTimestamp(
+	text: string,
+	timestampMs: number | undefined,
+): string {
+	const timestamp = formatViewerEntryTimestamp(timestampMs);
+	return timestamp ? `${timestamp} ${text}` : text;
 }
 
 function createPlainFg(): (color: string, text: string) => string {
@@ -317,6 +342,7 @@ function buildDigestEntries(
 					kind: "assistant",
 					text: summary,
 					streaming: Boolean(item.streaming),
+					timestampMs: item.timestampMs,
 				});
 			}
 			continue;
@@ -328,6 +354,7 @@ function buildDigestEntries(
 				text: summarizeInlineText(item.content),
 				streaming: item.streaming,
 				isError: item.isError,
+				timestampMs: item.timestampMs,
 			});
 			continue;
 		}
@@ -340,6 +367,7 @@ function buildDigestEntries(
 				),
 				toolName: item.name,
 				toolCallId: item.toolCallId,
+				timestampMs: item.timestampMs,
 			});
 			continue;
 		}
@@ -362,6 +390,7 @@ function buildDigestEntries(
 					streaming: item.streaming,
 					isError: item.isError,
 					toolCallId: item.toolCallId,
+					timestampMs: item.timestampMs,
 				};
 				continue;
 			}
@@ -374,6 +403,7 @@ function buildDigestEntries(
 			streaming: item.streaming,
 			isError: item.isError,
 			toolCallId: item.toolCallId,
+			timestampMs: item.timestampMs,
 		});
 	}
 
@@ -426,7 +456,7 @@ function describeDigestEntry(
 	if (entry.kind === "assistant") {
 		return {
 			label: entry.streaming ? "live" : "digest",
-			text: entry.text,
+			text: withDigestTimestamp(entry.text, entry.timestampMs),
 			tone: entry.streaming ? "warning" : "toolOutput",
 		};
 	}
@@ -442,7 +472,7 @@ function describeDigestEntry(
 		}
 		return {
 			label,
-			text: entry.text,
+			text: withDigestTimestamp(entry.text, entry.timestampMs),
 			tone,
 		};
 	}
@@ -456,23 +486,35 @@ function describeDigestEntry(
 			}
 			return {
 				label: "tool call",
-				text: entry.text,
+				text: withDigestTimestamp(entry.text, entry.timestampMs),
 				tone,
 			};
 		}
 		return {
 			label: "active tool",
-			text: `${entry.text} → waiting`,
+			text: withDigestTimestamp(`${entry.text} → waiting`, entry.timestampMs),
 			tone: "warning",
 		};
 	}
 	if (entry.isError) {
-		return { label: "error tool", text: entry.text, tone: "error" };
+		return {
+			label: "error tool",
+			text: withDigestTimestamp(entry.text, entry.timestampMs),
+			tone: "error",
+		};
 	}
 	if (entry.streaming) {
-		return { label: "active tool", text: entry.text, tone: "warning" };
+		return {
+			label: "active tool",
+			text: withDigestTimestamp(entry.text, entry.timestampMs),
+			tone: "warning",
+		};
 	}
-	return { label: "tool", text: entry.text, tone: "dim" };
+	return {
+		label: "tool",
+		text: withDigestTimestamp(entry.text, entry.timestampMs),
+		tone: "dim",
+	};
 }
 
 export function getResultSummaryLine(

--- a/extensions/pi-gremlins/single-agent-runner.ts
+++ b/extensions/pi-gremlins/single-agent-runner.ts
@@ -24,6 +24,7 @@ import {
 	type ResultLifecycle,
 	type SingleResult,
 	type SingleRunViewerState,
+	type ViewerEntry,
 	type ViewerToolCallRecord,
 } from "./execution-shared.js";
 import { formatAgentLookupError } from "./tool-text.js";
@@ -98,6 +99,20 @@ function summarizeToolResult(
 	};
 }
 
+function createViewerEntryTimestamps(): {
+	createdAt: number;
+	updatedAt: number;
+} {
+	const timestamp = Date.now();
+	return { createdAt: timestamp, updatedAt: timestamp };
+}
+
+function touchViewerEntryTimestamp(entry: ViewerEntry): void {
+	const timestamp = Date.now();
+	entry.updatedAt = timestamp;
+	entry.createdAt ??= timestamp;
+}
+
 function upsertAssistantViewerEntry(
 	result: SingleResult,
 	state: SingleRunViewerState,
@@ -114,11 +129,17 @@ function upsertAssistantViewerEntry(
 			}
 			existing.text = text;
 			existing.streaming = streaming;
+			touchViewerEntryTimestamp(existing);
 			return true;
 		}
 	}
 	state.currentAssistantEntryIndex =
-		result.viewerEntries.push({ type: "assistant-text", text, streaming }) - 1;
+		result.viewerEntries.push({
+			type: "assistant-text",
+			text,
+			streaming,
+			...createViewerEntryTimestamps(),
+		}) - 1;
 	return true;
 }
 
@@ -133,6 +154,7 @@ function finishAssistantViewerEntry(
 		const existing = result.viewerEntries[entryIndex];
 		if (existing?.type === "assistant-text" && existing.streaming) {
 			existing.streaming = false;
+			touchViewerEntryTimestamp(existing);
 			changed = true;
 		}
 	}
@@ -152,6 +174,7 @@ function appendSteerViewerEntry(
 		text,
 		streaming: false,
 		isError,
+		...createViewerEntryTimestamps(),
 	});
 	return true || assistantEntryChanged;
 }
@@ -172,6 +195,7 @@ function ensureToolCallViewerEntry(
 			Object.keys(args).length > 0
 		) {
 			entry.args = args;
+			touchViewerEntryTimestamp(entry);
 			return { record: existing, changed: true };
 		}
 		return { record: existing, changed: false };
@@ -182,6 +206,7 @@ function ensureToolCallViewerEntry(
 			toolCallId,
 			toolName,
 			args,
+			...createViewerEntryTimestamps(),
 		}) - 1;
 	const record: ViewerToolCallRecord = { callEntryIndex };
 	state.toolCalls.set(toolCallId, record);
@@ -221,6 +246,7 @@ function upsertToolResultViewerEntry(
 			existing.streaming = streaming;
 			existing.truncated = truncated;
 			existing.isError = isError;
+			touchViewerEntryTimestamp(existing);
 			return true;
 		}
 	}
@@ -233,6 +259,7 @@ function upsertToolResultViewerEntry(
 			streaming,
 			truncated,
 			isError,
+			...createViewerEntryTimestamps(),
 		}) - 1;
 	return true;
 }

--- a/extensions/pi-gremlins/viewer-body-cache.ts
+++ b/extensions/pi-gremlins/viewer-body-cache.ts
@@ -3,6 +3,7 @@ import {
 	aggregateUsage,
 	formatAgentSourceBadgeText,
 	formatStatusBadgeText,
+	formatViewerEntryTimestamp,
 	getAgentSourceSemantics,
 	getDerivedRenderData,
 	getResultVisibleRevision,
@@ -55,6 +56,16 @@ function formatViewerSourceBadge(
 	result: SingleResult,
 ): string {
 	return theme.fg("muted", formatAgentSourceBadgeText(result.agentSource));
+}
+
+function formatViewerEntryLabel(
+	label: string,
+	entry: Pick<ViewerEntry, "createdAt" | "updatedAt">,
+): string {
+	const timestamp = formatViewerEntryTimestamp(
+		entry.updatedAt ?? entry.createdAt,
+	);
+	return timestamp ? `${timestamp} ${label}` : label;
 }
 
 function pushViewerTextBlock(
@@ -128,7 +139,7 @@ function buildViewerEntryLines(
 			pushViewerTextBlock(
 				lines,
 				theme,
-				"assistant",
+				formatViewerEntryLabel("assistant", entry),
 				entry.text.trim() || "Awaiting assistant output.",
 				entry.streaming ? "warning" : "toolOutput",
 				entry.streaming ? [theme.fg("warning", "[live]")] : [],
@@ -137,7 +148,7 @@ function buildViewerEntryLines(
 		}
 		if (entry.type === "tool-call") {
 			lines.push(
-				theme.fg("muted", "tool call · ") +
+				theme.fg("muted", `${formatViewerEntryLabel("tool call", entry)} · `) +
 					formatToolCall(entry.toolName, entry.args, theme.fg.bind(theme)),
 			);
 			continue;
@@ -152,7 +163,7 @@ function buildViewerEntryLines(
 			pushViewerTextBlock(
 				lines,
 				theme,
-				entry.isError ? "steer error" : "steer",
+				formatViewerEntryLabel(entry.isError ? "steer error" : "steer", entry),
 				entry.text,
 				steerTone,
 				badges,
@@ -171,7 +182,7 @@ function buildViewerEntryLines(
 		pushViewerTextBlock(
 			lines,
 			theme,
-			toolResultLabel,
+			formatViewerEntryLabel(toolResultLabel, entry),
 			entry.toolName,
 			toolResultTone,
 			badges,


### PR DESCRIPTION
## Summary
- stamp viewer feed entries with createdAt/updatedAt metadata as child events arrive
- show compact HH:mm:ss timestamps in embedded feed rows and popup mission-control timelines
- cover timestamp creation and rendering with execution, embedded, and popup tests

## Verification
- npm run check

Closes #21