### PR TITLE
Reduce render and discovery cache churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inline progress rendering now keeps collapsed rows compact, flattens multiline previews, prioritizes live tool activity over stale assistant prose, and adds clearer status/text/tool/result separation in tool-row output.
 - Pi SDK/runtime deps now target `0.69.0`, package/tool schemas now import `typebox` 1.x instead of `@sinclair/typebox`, and tool registration includes a localized TS inference workaround until upstream typings stop triggering `TS2589` deep-instantiation errors.
 - Gremlin runner usage now reports current context-window token usage from Pi SDK session context instead of summing cumulative per-turn `totalTokens`, preventing inflated `contextTokens` in multi-turn runs.
+- Runtime cache hot paths now use compact render cache keys, per-entry render segment reuse, and memoized discovery directory listings to reduce repeated string and filesystem churn during active gremlin runs.
 
 ### Added
 - New v1 runtime modules under `extensions/pi-gremlins/`: schema, definition parsing, discovery cache, prompt builder, isolated session factory, runner, scheduler, progress store, summary builder, and inline renderer.

--- a/extensions/pi-gremlins/gremlin-discovery.test.js
+++ b/extensions/pi-gremlins/gremlin-discovery.test.js
@@ -3,6 +3,23 @@ import * as fs from "node:fs";
 
 import { createWorkspace, writeAgentFile } from "./test-helpers.js";
 
+function createCountingFileSystem() {
+	const calls = { readdir: 0, stat: 0 };
+	return {
+		calls,
+		fileSystem: {
+			async readdir(dir) {
+				calls.readdir++;
+				return fs.promises.readdir(dir, { withFileTypes: true });
+			},
+			async stat(candidatePath) {
+				calls.stat++;
+				return fs.promises.stat(candidatePath);
+			},
+		},
+	};
+}
+
 let workspaceRoot = null;
 
 afterEach(() => {
@@ -107,6 +124,43 @@ describe("gremlin discovery v1 contract", () => {
 			"researcher",
 			"reviewer",
 		]);
+	});
+
+	test("reuses cached directory listings while detecting markdown file updates", async () => {
+		const { createGremlinDiscoveryCache } = await import("./gremlin-discovery.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		fs.mkdirSync(workspace.projectAgentsDir, { recursive: true });
+		const researcherPath = `${workspace.projectAgentsDir}/researcher.md`;
+		fs.writeFileSync(
+			researcherPath,
+			"---\nname: researcher\ndescription: first\n---\nfirst prompt body",
+			"utf-8",
+		);
+		const { calls, fileSystem } = createCountingFileSystem();
+		const discovery = createGremlinDiscoveryCache({
+			userAgentsDir: workspace.userAgentsDir,
+			fileSystem,
+		});
+
+		const first = await discovery.get(workspace.repoRoot);
+		const readdirAfterFirst = calls.readdir;
+		const second = await discovery.get(workspace.repoRoot);
+
+		expect(second).toBe(first);
+		expect(calls.readdir).toBe(readdirAfterFirst);
+
+		fs.writeFileSync(
+			researcherPath,
+			"---\nname: researcher\ndescription: second\n---\nsecond prompt body",
+			"utf-8",
+		);
+		fs.utimesSync(researcherPath, new Date(), new Date(Date.now() + 1000));
+		const third = await discovery.get(workspace.repoRoot);
+
+		expect(third).not.toBe(first);
+		expect(third.fingerprint).not.toBe(first.fingerprint);
+		expect(third.gremlins[0].rawMarkdown).toContain("second prompt body");
 	});
 
 	test("never loads package gremlins or any scope-toggle surface in v1 discovery", async () => {

--- a/extensions/pi-gremlins/gremlin-discovery.ts
+++ b/extensions/pi-gremlins/gremlin-discovery.ts
@@ -21,11 +21,29 @@ export interface GremlinDiscoveryCache {
 interface DirectoryFingerprint {
 	dir: string | null;
 	fingerprint: string;
+	files: string[];
+}
+
+interface DirectorySnapshot {
+	dir: string;
+	dirSignature: string;
+	files: string[];
+}
+
+export interface GremlinDiscoveryFileSystem {
+	readdir(dir: string): Promise<fs.Dirent[]>;
+	stat(candidatePath: string): Promise<fs.Stats>;
 }
 
 export interface GremlinDiscoveryOptions {
 	userAgentsDir?: string;
+	fileSystem?: GremlinDiscoveryFileSystem;
 }
+
+const nodeFileSystem: GremlinDiscoveryFileSystem = {
+	readdir: (dir) => readdir(dir, { withFileTypes: true }),
+	stat,
+};
 
 export function getUserGremlinsDir(options: GremlinDiscoveryOptions = {}): string {
 	return options.userAgentsDir ?? path.join(getAgentDir(), "agents");
@@ -50,9 +68,12 @@ export function findNearestProjectAgentsDir(cwd: string): string | null {
 	}
 }
 
-async function listMarkdownFiles(dir: string): Promise<string[]> {
+async function listMarkdownFiles(
+	dir: string,
+	fileSystem: GremlinDiscoveryFileSystem,
+): Promise<string[]> {
 	try {
-		const entries = await readdir(dir, { withFileTypes: true });
+		const entries = await fileSystem.readdir(dir);
 		return entries
 			.filter((entry) => entry.name.endsWith(".md"))
 			.filter((entry) => entry.isFile() || entry.isSymbolicLink())
@@ -63,35 +84,67 @@ async function listMarkdownFiles(dir: string): Promise<string[]> {
 	}
 }
 
-async function fingerprintDirectory(
-	dir: string | null,
-): Promise<DirectoryFingerprint> {
-	if (!dir) {
-		return { dir: null, fingerprint: "none" };
-	}
-	const files = await listMarkdownFiles(dir);
-	const parts = await Promise.all(
+function createDirectorySignature(dirStat: fs.Stats): string {
+	return [dirStat.mtimeMs, dirStat.ctimeMs, dirStat.size].join(":");
+}
+
+async function fingerprintKnownFiles(
+	files: string[],
+	fileSystem: GremlinDiscoveryFileSystem,
+): Promise<string[]> {
+	return Promise.all(
 		files.map(async (filePath) => {
 			try {
-				const fileStat = await stat(filePath);
+				const fileStat = await fileSystem.stat(filePath);
 				return `${path.basename(filePath)}:${fileStat.mtimeMs}`;
 			} catch {
 				return `${path.basename(filePath)}:missing`;
 			}
 		}),
 	);
-	return {
-		dir,
-		fingerprint: `${dir}|${parts.join(",")}`,
-	};
 }
 
-async function loadGremlinsFromDir(
+async function fingerprintDirectory(
 	dir: string | null,
+	snapshots: Map<string, DirectorySnapshot>,
+	fileSystem: GremlinDiscoveryFileSystem,
+): Promise<DirectoryFingerprint> {
+	if (!dir) {
+		return { dir: null, fingerprint: "none", files: [] };
+	}
+
+	let dirStat: fs.Stats;
+	try {
+		dirStat = await fileSystem.stat(dir);
+		if (!dirStat.isDirectory()) throw new Error("not a directory");
+	} catch {
+		snapshots.delete(dir);
+		return { dir, fingerprint: `${dir}|missing`, files: [] };
+	}
+
+	const dirSignature = createDirectorySignature(dirStat);
+	const cached = snapshots.get(dir);
+	if (cached && cached.dirSignature === dirSignature) {
+		const parts = await fingerprintKnownFiles(cached.files, fileSystem);
+		const fingerprint = `${dir}|${parts.join(",")}`;
+		return { dir, fingerprint, files: cached.files };
+	}
+
+	const files = await listMarkdownFiles(dir, fileSystem);
+	const parts = await fingerprintKnownFiles(files, fileSystem);
+	const fingerprint = `${dir}|${parts.join(",")}`;
+	snapshots.set(dir, {
+		dir,
+		dirSignature,
+		files,
+	});
+	return { dir, fingerprint, files };
+}
+
+async function loadGremlinsFromFiles(
+	files: string[],
 	source: "user" | "project",
 ): Promise<GremlinDefinition[]> {
-	if (!dir) return [];
-	const files = await listMarkdownFiles(dir);
 	const definitions = await Promise.all(
 		files.map((filePath) => loadGremlinDefinition(filePath, source)),
 	);
@@ -127,6 +180,8 @@ export function resolveGremlinByName(
 export function createGremlinDiscoveryCache(
 	options: GremlinDiscoveryOptions = {},
 ): GremlinDiscoveryCache {
+	const fileSystem = options.fileSystem ?? nodeFileSystem;
+	const directorySnapshots = new Map<string, DirectorySnapshot>();
 	let cachedResult: GremlinDiscoveryResult | null = null;
 	let cachedFingerprint: string | null = null;
 	let cachedProjectAgentsDir: string | null = null;
@@ -136,8 +191,16 @@ export function createGremlinDiscoveryCache(
 		async get(cwd: string) {
 			const userAgentsDir = getUserGremlinsDir(options);
 			const projectAgentsDir = findNearestProjectAgentsDir(cwd);
-			const userFingerprint = await fingerprintDirectory(userAgentsDir);
-			const projectFingerprint = await fingerprintDirectory(projectAgentsDir);
+			const userFingerprint = await fingerprintDirectory(
+				userAgentsDir,
+				directorySnapshots,
+				fileSystem,
+			);
+			const projectFingerprint = await fingerprintDirectory(
+				projectAgentsDir,
+				directorySnapshots,
+				fileSystem,
+			);
 			const fingerprint = [userFingerprint.fingerprint, projectFingerprint.fingerprint].join(
 				"::",
 			);
@@ -150,9 +213,12 @@ export function createGremlinDiscoveryCache(
 				return cachedResult;
 			}
 
-			const userGremlins = await loadGremlinsFromDir(userAgentsDir, "user");
-			const projectGremlins = await loadGremlinsFromDir(
-				projectAgentsDir,
+			const userGremlins = await loadGremlinsFromFiles(
+				userFingerprint.files,
+				"user",
+			);
+			const projectGremlins = await loadGremlinsFromFiles(
+				projectFingerprint.files,
 				"project",
 			);
 			cachedResult = {
@@ -166,6 +232,7 @@ export function createGremlinDiscoveryCache(
 			return cachedResult;
 		},
 		clear() {
+			directorySnapshots.clear();
 			cachedResult = null;
 			cachedFingerprint = null;
 			cachedProjectAgentsDir = null;

--- a/extensions/pi-gremlins/gremlin-render-components.ts
+++ b/extensions/pi-gremlins/gremlin-render-components.ts
@@ -29,25 +29,56 @@ function pushCacheEntry<T>(cache: Map<string, T>, key: string, value: T): T {
 	return value;
 }
 
-function createEntryCacheKey(prefix: string, entry: GremlinInvocationEntry): string {
+function hashString(value: string): string {
+	let hash = 2166136261;
+	for (let index = 0; index < value.length; index++) {
+		hash ^= value.charCodeAt(index);
+		hash = Math.imul(hash, 16777619);
+	}
+	return (hash >>> 0).toString(36);
+}
+
+function createTextCacheToken(value?: string): string {
+	if (!value) return "";
+	return `${value.length}:${hashString(value)}`;
+}
+
+function createUsageCacheToken(usage?: GremlinUsage): string {
+	if (!usage) return "";
+	return [
+		usage.turns,
+		usage.input,
+		usage.output,
+		usage.cacheRead ?? "",
+		usage.cacheWrite ?? "",
+		usage.contextTokens ?? "",
+		usage.cost ?? "",
+	].join(":");
+}
+
+export function createEntryCacheKey(
+	prefix: string,
+	entry: GremlinInvocationEntry,
+): string {
 	return [
 		prefix,
-		entry.gremlinId ?? "",
+		createTextCacheToken(entry.gremlinId),
 		String(entry.revision ?? ""),
-		entry.agent,
+		createTextCacheToken(entry.agent),
 		entry.source,
 		entry.status,
-		entry.context,
-		entry.cwd ?? "",
-		entry.model ?? "",
-		entry.thinking ?? "",
-		entry.currentPhase ?? "",
-		entry.latestText ?? "",
-		entry.latestToolCall ?? "",
-		entry.latestToolResult ?? "",
-		entry.errorMessage ?? "",
+		createTextCacheToken(entry.context),
+		createTextCacheToken(entry.cwd),
+		createTextCacheToken(entry.model),
+		createTextCacheToken(entry.thinking),
+		createTextCacheToken(entry.currentPhase),
+		createTextCacheToken(entry.latestText),
+		createTextCacheToken(entry.latestToolCall),
+		createTextCacheToken(entry.latestToolResult),
+		createTextCacheToken(entry.errorMessage),
 		entry.startedAt ? String(entry.startedAt) : "",
 		entry.finishedAt ? String(entry.finishedAt) : "",
+		createUsageCacheToken(entry.usage),
 	].join("\u001f");
 }
 

--- a/extensions/pi-gremlins/gremlin-rendering.test.js
+++ b/extensions/pi-gremlins/gremlin-rendering.test.js
@@ -229,6 +229,28 @@ describe("gremlin rendering v1 contract", () => {
 		expect(text).not.toContain("popup");
 	});
 
+	test("uses compact entry cache keys without embedding mutable text payloads", async () => {
+		const { createEntryCacheKey } = await import("./gremlin-render-components.ts");
+		const payload = "large mutable tool output ".repeat(400);
+
+		const key = createEntryCacheKey("collapsed", {
+			gremlinId: "g1",
+			agent: "researcher",
+			source: "project",
+			status: "active",
+			currentPhase: "tool:read",
+			latestText: payload,
+			latestToolCall: payload,
+			latestToolResult: payload,
+			context: "Find auth flow",
+			revision: 12,
+		});
+
+		expect(key).not.toContain(payload);
+		expect(key).not.toContain("large mutable tool output");
+		expect(key.length).toBeLessThan(256);
+	});
+
 	test("reuses cached line computation for identical revision and options", async () => {
 		const renderComponents = await import("./gremlin-render-components.ts");
 		const { renderGremlinInvocationText } = await import(
@@ -266,5 +288,74 @@ describe("gremlin rendering v1 contract", () => {
 		const renderA = renderGremlinInvocationText(details, { expanded: false, width: 90 });
 		const renderB = renderGremlinInvocationText(details, { expanded: false, width: 90 });
 		expect(renderA).toBe(renderB);
+	});
+
+	test("updates changed entry output while preserving unchanged entry text across revisions", async () => {
+		const { renderGremlinInvocationText } = await import(
+			"./gremlin-rendering.ts"
+		);
+		const unchangedEntry = {
+			gremlinId: "g2",
+			agent: "reviewer",
+			source: "user",
+			status: "active",
+			currentPhase: "settling",
+			latestText: "Review unchanged",
+			context: "Review auth flow",
+			revision: 4,
+		};
+		const before = renderGremlinInvocationText(
+			{
+				requestedCount: 2,
+				activeCount: 2,
+				completedCount: 0,
+				failedCount: 0,
+				canceledCount: 0,
+				gremlins: [
+					{
+						gremlinId: "g1",
+						agent: "researcher",
+						source: "project",
+						status: "active",
+						currentPhase: "tool:read",
+						latestText: "First result",
+						context: "Find auth flow",
+						revision: 1,
+					},
+					unchangedEntry,
+				],
+				revision: 4,
+			},
+			{ expanded: false, width: 120 },
+		);
+		const after = renderGremlinInvocationText(
+			{
+				requestedCount: 2,
+				activeCount: 2,
+				completedCount: 0,
+				failedCount: 0,
+				canceledCount: 0,
+				gremlins: [
+					{
+						gremlinId: "g1",
+						agent: "researcher",
+						source: "project",
+						status: "active",
+						currentPhase: "tool:read",
+						latestText: "Second result",
+						context: "Find auth flow",
+						revision: 2,
+					},
+					unchangedEntry,
+				],
+				revision: 5,
+			},
+			{ expanded: false, width: 120 },
+		);
+
+		expect(before).toContain("First result");
+		expect(after).toContain("Second result");
+		expect(after).not.toContain("First result");
+		expect(after).toContain("Review unchanged");
 	});
 });

--- a/extensions/pi-gremlins/gremlin-rendering.ts
+++ b/extensions/pi-gremlins/gremlin-rendering.ts
@@ -1,5 +1,6 @@
 import type { GremlinInvocationDetails } from "./gremlin-schema.js";
 import {
+	createEntryCacheKey,
 	formatBatchHeadline,
 	formatCollapsedGremlinLine,
 	formatExpandedGremlinLines,
@@ -16,7 +17,9 @@ export interface RenderGremlinInvocationOptions {
 }
 
 const RENDER_CACHE_LIMIT = 128;
+const RENDER_SEGMENT_CACHE_LIMIT = 256;
 const renderCache = new Map<string, string>();
+const renderSegmentCache = new Map<string, string>();
 
 function clampLine(line: string, width?: number): string {
 	if (!width || width <= 0 || line.length <= width) return line;
@@ -24,30 +27,36 @@ function clampLine(line: string, width?: number): string {
 	return `${line.slice(0, Math.max(0, width - 1))}…`;
 }
 
-function pushRenderCache(key: string, value: string): string {
-	renderCache.set(key, value);
-	if (renderCache.size <= RENDER_CACHE_LIMIT) return value;
-	const firstKey = renderCache.keys().next().value;
-	if (typeof firstKey === "string") renderCache.delete(firstKey);
+function pushLimitedCache(
+	cache: Map<string, string>,
+	limit: number,
+	key: string,
+	value: string,
+): string {
+	cache.set(key, value);
+	if (cache.size <= limit) return value;
+	const firstKey = cache.keys().next().value;
+	if (typeof firstKey === "string") cache.delete(firstKey);
 	return value;
+}
+
+function pushRenderCache(key: string, value: string): string {
+	return pushLimitedCache(renderCache, RENDER_CACHE_LIMIT, key, value);
+}
+
+function pushRenderSegmentCache(key: string, value: string): string {
+	return pushLimitedCache(
+		renderSegmentCache,
+		RENDER_SEGMENT_CACHE_LIMIT,
+		key,
+		value,
+	);
 }
 
 function getDetailsRevisionKey(details: GremlinInvocationDetails): string {
 	if (typeof details.revision === "number") return `details:${details.revision}`;
 	return details.gremlins
-		.map((entry, index) => {
-			const fallback = [
-				entry.gremlinId ?? `g${index + 1}`,
-				String(entry.revision ?? ""),
-				entry.status,
-				entry.currentPhase ?? "",
-				entry.latestText ?? "",
-				entry.latestToolCall ?? "",
-				entry.latestToolResult ?? "",
-				entry.errorMessage ?? "",
-			].join(":");
-			return fallback;
-		})
+		.map((entry) => createEntryCacheKey("details-entry", entry))
 		.join("|");
 }
 
@@ -67,31 +76,78 @@ function createRenderCacheKey(
 	].join("\u001f");
 }
 
-function buildCollapsedLines(details: GremlinInvocationDetails): string[] {
-	const lines = [formatBatchHeadline(details)];
-	if (details.gremlins.length === 0) {
-		lines.push("No gremlins requested.");
-	} else {
-		for (const entry of details.gremlins) {
-			lines.push(formatCollapsedGremlinLine(entry));
-		}
-	}
-	lines.push("Ctrl+O expands inline detail.");
-	return lines;
+function renderLines(lines: string[], width?: number): string {
+	return lines
+		.filter((line, index, array) => !(line === "" && array[index - 1] === ""))
+		.map((line) => clampLine(line, width))
+		.join("\n");
 }
 
-function buildExpandedLines(details: GremlinInvocationDetails): string[] {
-	const lines = [formatBatchHeadline(details)];
+function getStaticRenderSegment(line: string, width?: number): string {
+	const cacheKey = ["static", String(width ?? 0), line].join("\u001f");
+	const cached = renderSegmentCache.get(cacheKey);
+	if (cached) return cached;
+	return pushRenderSegmentCache(cacheKey, renderLines([line], width));
+}
+
+function getCollapsedEntrySegment(
+	entry: GremlinInvocationDetails["gremlins"][number],
+	width?: number,
+): string {
+	const cacheKey = [
+		"collapsed-entry",
+		String(width ?? 0),
+		createEntryCacheKey("collapsed-entry", entry),
+	].join("\u001f");
+	const cached = renderSegmentCache.get(cacheKey);
+	if (cached) return cached;
+	return pushRenderSegmentCache(
+		cacheKey,
+		renderLines([formatCollapsedGremlinLine(entry)], width),
+	);
+}
+
+function getExpandedEntrySegment(
+	entry: GremlinInvocationDetails["gremlins"][number],
+	width?: number,
+): string {
+	const cacheKey = [
+		"expanded-entry",
+		String(width ?? 0),
+		createEntryCacheKey("expanded-entry", entry),
+	].join("\u001f");
+	const cached = renderSegmentCache.get(cacheKey);
+	if (cached) return cached;
+	return pushRenderSegmentCache(
+		cacheKey,
+		renderLines(formatExpandedGremlinLines(entry), width),
+	);
+}
+
+function buildCollapsedText(details: GremlinInvocationDetails, width?: number): string {
+	const segments = [getStaticRenderSegment(formatBatchHeadline(details), width)];
 	if (details.gremlins.length === 0) {
-		lines.push("No gremlins requested.");
-		return lines;
+		segments.push(getStaticRenderSegment("No gremlins requested.", width));
+	} else {
+		for (const entry of details.gremlins) {
+			segments.push(getCollapsedEntrySegment(entry, width));
+		}
+	}
+	segments.push(getStaticRenderSegment("Ctrl+O expands inline detail.", width));
+	return segments.join("\n");
+}
+
+function buildExpandedText(details: GremlinInvocationDetails, width?: number): string {
+	const segments = [getStaticRenderSegment(formatBatchHeadline(details), width)];
+	if (details.gremlins.length === 0) {
+		segments.push(getStaticRenderSegment("No gremlins requested.", width));
+		return segments.join("\n");
 	}
 
-	for (const [index, entry] of details.gremlins.entries()) {
-		if (index > 0) lines.push("");
-		lines.push(...formatExpandedGremlinLines(entry));
+	for (const entry of details.gremlins) {
+		segments.push(getExpandedEntrySegment(entry, width));
 	}
-	return lines;
+	return segments.join("\n\n");
 }
 
 function getStatusColor(line: string): string | undefined {
@@ -152,12 +208,8 @@ export function renderGremlinInvocationText(
 	const cached = renderCache.get(cacheKey);
 	if (cached) return cached;
 
-	const lines = options.expanded
-		? buildExpandedLines(details)
-		: buildCollapsedLines(details);
-	const text = lines
-		.filter((line, index, array) => !(line === "" && array[index - 1] === ""))
-		.map((line) => clampLine(line, options.width))
-		.join("\n");
+	const text = options.expanded
+		? buildExpandedText(details, options.width)
+		: buildCollapsedText(details, options.width);
 	return pushRenderCache(cacheKey, text);
 }


### PR DESCRIPTION
## Summary
- Replace text-heavy gremlin render cache keys with compact hash/revision tokens
- Add per-entry render segment caching so unchanged rows reuse formatted/clamped output across invocation revisions
- Memoize discovery directory listings behind directory signatures while preserving markdown update invalidation
- Add regression coverage for compact keys, render stale-output behavior, and discovery cache reuse/update detection

## Verification
- npm run check

Closes #29