### PR TITLE
feat: expand collapsed gremlin feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discovery now loads user gremlins from `~/.pi/agent/agents` plus nearest project `.pi/agents` only, with project definitions overriding same-name user definitions.
 - Live progress now stays inline in tool row and expands through Pi's standard `Ctrl+O` affordance.
 - Embedded rendering now uses stable gremlin ids (`g1`, `g2`, ...), cached line computation, and inline collapsed/expanded summaries built from shared v1 render components.
-- Inline progress rendering now keeps collapsed rows compact, flattens multiline previews, prioritizes live tool activity over stale assistant prose, and adds clearer status/text/tool/result separation in tool-row output.
+- Inline progress rendering now shows collapsed gremlin context, the three latest activity rows, usage rows, flattened multiline previews, and clearer status/text/tool/result separation in tool-row output.
 - Pi SDK/runtime deps now target `0.69.0`, package/tool schemas now import `typebox` 1.x instead of `@sinclair/typebox`, and tool registration includes a localized TS inference workaround until upstream typings stop triggering `TS2589` deep-instantiation errors.
 - Gremlin runner usage now reports current context-window token usage from Pi SDK session context instead of summing cumulative per-turn `totalTokens`, preventing inflated `contextTokens` in multi-turn runs.
 - Runtime cache hot paths now use compact render cache keys, per-entry render segment reuse, and memoized discovery directory listings to reduce repeated string and filesystem churn during active gremlin runs.

--- a/extensions/pi-gremlins/gremlin-progress-store.ts
+++ b/extensions/pi-gremlins/gremlin-progress-store.ts
@@ -25,6 +25,8 @@ function createInitialEntry(
 		cwd: request.cwd,
 		currentPhase: "queued",
 		latestText: "",
+		activities: [],
+		usage: { turns: 0, input: 0, output: 0 },
 		startedAt: now,
 		revision: 0,
 	};
@@ -38,11 +40,20 @@ function cloneUsage(usage: GremlinInvocationEntry["usage"]) {
 	return usage ? Object.freeze({ ...usage }) : undefined;
 }
 
+function cloneActivities(activities: GremlinInvocationEntry["activities"]) {
+	return activities
+		? (Object.freeze(
+				activities.map((activity) => Object.freeze({ ...activity })),
+			) as GremlinInvocationEntry["activities"])
+		: undefined;
+}
+
 function createEntrySnapshot(
 	entry: GremlinInvocationEntry,
 ): GremlinInvocationEntry {
 	return Object.freeze({
 		...entry,
+		activities: cloneActivities(entry.activities),
 		usage: cloneUsage(entry.usage),
 	});
 }
@@ -148,6 +159,9 @@ export function createGremlinProgressStore(
 			const snapshot = snapshotEntry(entry);
 			return {
 				...snapshot,
+				activities: snapshot.activities
+					? snapshot.activities.map((activity) => ({ ...activity }))
+					: undefined,
 				usage: snapshot.usage ? { ...snapshot.usage } : undefined,
 			};
 		},

--- a/extensions/pi-gremlins/gremlin-render-components.ts
+++ b/extensions/pi-gremlins/gremlin-render-components.ts
@@ -1,4 +1,6 @@
 import type {
+	GremlinActivity,
+	GremlinActivityKind,
 	GremlinInvocationDetails,
 	GremlinInvocationEntry,
 	GremlinUsage,
@@ -6,7 +8,9 @@ import type {
 
 const ENTRY_CACHE_LIMIT = 256;
 const COLLAPSED_PREVIEW_LIMIT = 96;
-const collapsedLineCache = new Map<string, string>();
+const COLLAPSED_CONTEXT_LINE_LIMIT = 3;
+const COLLAPSED_ACTIVITY_LINE_LIMIT = 3;
+const collapsedLinesCache = new Map<string, string[]>();
 const expandedLinesCache = new Map<string, string[]>();
 
 function normalizeText(value?: string): string | undefined {
@@ -56,6 +60,20 @@ function createUsageCacheToken(usage?: GremlinUsage): string {
 	].join(":");
 }
 
+function createActivityCacheToken(activity: GremlinActivity): string {
+	return [
+		activity.kind,
+		createTextCacheToken(activity.phase),
+		createTextCacheToken(activity.text),
+		activity.sequence ?? "",
+		activity.timestamp ?? "",
+	].join(":");
+}
+
+function createActivitiesCacheToken(activities?: GremlinActivity[]): string {
+	return activities?.map(createActivityCacheToken).join("\u001e") ?? "";
+}
+
 export function createEntryCacheKey(
 	prefix: string,
 	entry: GremlinInvocationEntry,
@@ -76,6 +94,7 @@ export function createEntryCacheKey(
 		createTextCacheToken(entry.latestToolCall),
 		createTextCacheToken(entry.latestToolResult),
 		createTextCacheToken(entry.errorMessage),
+		createActivitiesCacheToken(entry.activities),
 		entry.startedAt ? String(entry.startedAt) : "",
 		entry.finishedAt ? String(entry.finishedAt) : "",
 		createUsageCacheToken(entry.usage),
@@ -133,71 +152,96 @@ export function formatGremlinIdentity(entry: GremlinInvocationEntry): string {
 	]).join(" ");
 }
 
-type GremlinActivityKind =
-	| "error"
-	| "tool-call"
-	| "tool-result"
-	| "text"
-	| "task"
-	| "idle";
-
 interface GremlinActivityPreview {
 	kind: GremlinActivityKind;
 	phase?: string;
 	text: string;
 }
 
-function getGremlinActivityPreview(
+function normalizeActivityPreview(
+	activity: GremlinActivity,
+): GremlinActivityPreview | undefined {
+	const text = normalizePreviewText(activity.text);
+	if (!text) return undefined;
+	return {
+		kind: activity.kind,
+		phase: normalizePreviewText(activity.phase),
+		text,
+	};
+}
+
+function getFallbackActivityPreviews(
 	entry: GremlinInvocationEntry,
-): GremlinActivityPreview {
+): GremlinActivityPreview[] {
 	const phase = normalizePreviewText(entry.currentPhase);
 	const latestText = normalizePreviewText(entry.latestText);
 	const latestToolCall = normalizePreviewText(entry.latestToolCall);
 	const latestToolResult = normalizePreviewText(entry.latestToolResult);
 	const errorMessage = normalizePreviewText(entry.errorMessage);
 	const context = normalizePreviewText(entry.context);
-	const inToolPhase = phase?.startsWith("tool:") ?? false;
+	const previews: GremlinActivityPreview[] = [];
 
 	if (errorMessage && (entry.status === "failed" || entry.status === "canceled")) {
-		return { kind: "error", phase, text: errorMessage };
-	}
-	if (inToolPhase && latestToolResult) {
-		return { kind: "tool-result", phase, text: latestToolResult };
-	}
-	if (inToolPhase && latestToolCall) {
-		return { kind: "tool-call", phase, text: latestToolCall };
+		previews.push({ kind: "error", phase, text: errorMessage });
 	}
 	if (latestText && latestText !== context) {
-		return { kind: "text", phase, text: latestText };
-	}
-	if (latestToolResult) {
-		return { kind: "tool-result", phase, text: latestToolResult };
+		previews.push({ kind: "text", phase, text: latestText });
 	}
 	if (latestToolCall) {
-		return { kind: "tool-call", phase, text: latestToolCall };
+		previews.push({ kind: "tool-call", phase, text: latestToolCall });
 	}
-	if (context) {
-		return { kind: "task", phase, text: context };
+	if (latestToolResult) {
+		previews.push({ kind: "tool-result", phase, text: latestToolResult });
 	}
-	return { kind: "idle", phase, text: "idle" };
+	if (context && previews.length === 0) {
+		previews.push({ kind: "task", phase, text: context });
+	}
+	if (previews.length === 0) {
+		previews.push({ kind: "idle", phase, text: "idle" });
+	}
+	return previews;
 }
 
-export function formatGremlinActivity(entry: GremlinInvocationEntry): string {
-	const preview = getGremlinActivityPreview(entry);
-	const label =
-		preview.kind === "error"
-			? "error"
-			: preview.kind === "tool-call"
-				? "tool"
-				: preview.kind === "tool-result"
-					? "result"
-					: preview.kind === "text"
-						? "text"
-						: preview.kind === "task"
-							? "task"
-							: undefined;
-	const parts = dedupeParts([preview.phase, label, preview.text]);
-	return parts.join(" · ") || "idle";
+function getRecentActivityPreviews(
+	entry: GremlinInvocationEntry,
+): GremlinActivityPreview[] {
+	const activityPreviews = (entry.activities ?? [])
+		.map(normalizeActivityPreview)
+		.filter((preview): preview is GremlinActivityPreview => Boolean(preview));
+	if (activityPreviews.length > 0) {
+		return activityPreviews.slice(-COLLAPSED_ACTIVITY_LINE_LIMIT);
+	}
+	return getFallbackActivityPreviews(entry).slice(0, COLLAPSED_ACTIVITY_LINE_LIMIT);
+}
+
+function getActivityLabel(kind: GremlinActivityKind): string {
+	switch (kind) {
+		case "error":
+			return "error";
+		case "tool-call":
+			return "tool call";
+		case "tool-result":
+			return "tool result";
+		case "text":
+			return "latest";
+		case "task":
+			return "task";
+		case "idle":
+			return "idle";
+	}
+}
+
+function formatActivityPreviewLine(preview: GremlinActivityPreview): string {
+	return dedupeParts([getActivityLabel(preview.kind), preview.phase, preview.text]).join(" · ");
+}
+
+function formatContextPreviewLines(context: string): string[] {
+	return context
+		.split(/\r?\n/)
+		.map((line) => normalizePreviewText(line))
+		.filter((line): line is string => Boolean(line))
+		.slice(0, COLLAPSED_CONTEXT_LINE_LIMIT)
+		.map((line) => `task · ${line}`);
 }
 
 export function formatBatchHeadline(details: GremlinInvocationDetails): string {
@@ -211,16 +255,18 @@ export function formatBatchHeadline(details: GremlinInvocationDetails): string {
 	].join(" · ");
 }
 
-export function formatCollapsedGremlinLine(entry: GremlinInvocationEntry): string {
+export function formatCollapsedGremlinLines(entry: GremlinInvocationEntry): string[] {
 	const cacheKey = createEntryCacheKey("collapsed", entry);
-	const cached = collapsedLineCache.get(cacheKey);
+	const cached = collapsedLinesCache.get(cacheKey);
 	if (cached) return cached;
-	const line = [
-		`[${formatGremlinStatus(entry.status)}]`,
-		formatGremlinIdentity(entry),
-		formatGremlinActivity(entry),
-	].join(" · ");
-	return pushCacheEntry(collapsedLineCache, cacheKey, line);
+
+	const lines = [`[${formatGremlinStatus(entry.status)}] · ${formatGremlinIdentity(entry)}`];
+	lines.push(...formatContextPreviewLines(entry.context));
+	lines.push(...getRecentActivityPreviews(entry).map(formatActivityPreviewLine));
+	const usage = formatUsageSummary(entry.usage);
+	if (usage) lines.push(`usage · ${usage}`);
+
+	return pushCacheEntry(collapsedLinesCache, cacheKey, lines);
 }
 
 export function formatExpandedGremlinLines(entry: GremlinInvocationEntry): string[] {

--- a/extensions/pi-gremlins/gremlin-rendering.test.js
+++ b/extensions/pi-gremlins/gremlin-rendering.test.js
@@ -43,8 +43,12 @@ describe("gremlin rendering v1 contract", () => {
 		);
 
 		expect(text).toContain("Gremlins🧌 · requested:2 · active:1");
-		expect(text).toContain("[Active] · g1 researcher [project] · tool:read · text · Scanning");
-		expect(text).toContain("[Queued] · g2 reviewer [user] · prompting · task · Review auth flow");
+		expect(text).toContain("[Active] · g1 researcher [project]");
+		expect(text).toContain("task · Find auth flow");
+		expect(text).toContain("latest · tool:read · Scanning auth entry points");
+		expect(text).toContain("usage · turns:1 · input:10 · output:4");
+		expect(text).toContain("[Queued] · g2 reviewer [user]");
+		expect(text).toContain("task · prompting · Review auth flow");
 		expect(text).toContain("Ctrl+O expands inline detail.");
 		expect(text).not.toContain("/gremlins:view");
 		expect(text).not.toContain("/gremlins:steer");
@@ -101,16 +105,15 @@ describe("gremlin rendering v1 contract", () => {
 		);
 
 		const lines = text.split("\n");
-		expect(lines).toHaveLength(5);
-		expect(lines[1]).toContain("g1 researcher");
-		expect(lines[2]).toContain("g2 researcher");
-		expect(lines[3]).toContain("g3 reviewer");
+		expect(lines).toContain("[Active] · g1 researcher [project]");
+		expect(lines).toContain("[Completed] · g2 researcher [user]");
+		expect(lines).toContain("[Starting] · g3 reviewer [project]");
 		for (const line of lines) {
 			expect(line.length).toBeLessThanOrEqual(42);
 		}
 	});
 
-	test("keeps collapsed preview to one visible line per gremlin even when tool output is multiline", async () => {
+	test("keeps multiline collapsed activity previews on one visible line", async () => {
 		const { renderGremlinInvocationText } = await import(
 			"./gremlin-rendering.ts"
 		);
@@ -140,9 +143,57 @@ describe("gremlin rendering v1 contract", () => {
 		);
 
 		const lines = text.split("\n");
-		expect(lines).toHaveLength(3);
-		expect(lines[1]).toContain("line one");
-		expect(lines[2]).toBe("Ctrl+O expands inline detail.");
+		expect(lines).toHaveLength(5);
+		expect(lines[1]).toBe("[Active] · g1 researcher [project]");
+		expect(lines[2]).toBe("task · Find auth flow");
+		expect(lines[3]).toBe("tool result · tool:read · line one line two line three");
+		expect(lines[4]).toBe("Ctrl+O expands inline detail.");
+	});
+
+	test("renders three context lines then three recent activities and usage in collapsed mode", async () => {
+		const { renderGremlinInvocationText } = await import(
+			"./gremlin-rendering.ts"
+		);
+
+		const text = renderGremlinInvocationText(
+			{
+				requestedCount: 1,
+				activeCount: 1,
+				completedCount: 0,
+				failedCount: 0,
+				canceledCount: 0,
+				gremlins: [
+					{
+						gremlinId: "g1",
+						agent: "researcher",
+						source: "project",
+						status: "active",
+						context: "Line one\nLine two\nLine three\nLine four",
+						activities: [
+							{ kind: "task", phase: "prompting", text: "Prompt sent", sequence: 1 },
+							{ kind: "text", phase: "streaming", text: "Planning", sequence: 2 },
+							{ kind: "tool-call", phase: "tool:read", text: "read src/index.ts", sequence: 3 },
+							{ kind: "tool-result", phase: "streaming", text: "read complete", sequence: 4 },
+						],
+						usage: { turns: 2, input: 20, output: 8 },
+						revision: 4,
+					},
+				],
+				revision: 4,
+			},
+			{ expanded: false, width: 120 },
+		);
+
+		const lines = text.split("\n");
+		expect(lines).toContain("task · Line one");
+		expect(lines).toContain("task · Line two");
+		expect(lines).toContain("task · Line three");
+		expect(text).not.toContain("Line four");
+		expect(text).not.toContain("Prompt sent");
+		expect(lines).toContain("latest · streaming · Planning");
+		expect(lines).toContain("tool call · tool:read · read src/index.ts");
+		expect(lines).toContain("tool result · streaming · read complete");
+		expect(lines).toContain("usage · turns:2 · input:20 · output:8");
 	});
 
 	test("surfaces live tool call in collapsed preview after assistant already emitted text", async () => {
@@ -277,8 +328,8 @@ describe("gremlin rendering v1 contract", () => {
 			revision: 7,
 		};
 
-		const collapsedA = renderComponents.formatCollapsedGremlinLine(entry);
-		const collapsedB = renderComponents.formatCollapsedGremlinLine(entry);
+		const collapsedA = renderComponents.formatCollapsedGremlinLines(entry);
+		const collapsedB = renderComponents.formatCollapsedGremlinLines(entry);
 		expect(collapsedA).toBe(collapsedB);
 
 		const expandedA = renderComponents.formatExpandedGremlinLines(entry);

--- a/extensions/pi-gremlins/gremlin-rendering.ts
+++ b/extensions/pi-gremlins/gremlin-rendering.ts
@@ -2,7 +2,7 @@ import type { GremlinInvocationDetails } from "./gremlin-schema.js";
 import {
 	createEntryCacheKey,
 	formatBatchHeadline,
-	formatCollapsedGremlinLine,
+	formatCollapsedGremlinLines,
 	formatExpandedGremlinLines,
 } from "./gremlin-render-components.js";
 
@@ -103,7 +103,7 @@ function getCollapsedEntrySegment(
 	if (cached) return cached;
 	return pushRenderSegmentCache(
 		cacheKey,
-		renderLines([formatCollapsedGremlinLine(entry)], width),
+		renderLines(formatCollapsedGremlinLines(entry), width),
 	);
 }
 
@@ -174,6 +174,7 @@ function styleLine(
 	if (line.startsWith("tool result · ")) return theme.fg("toolOutput", line);
 	if (line.startsWith("latest · ")) return theme.fg("text", line);
 	if (line.startsWith("error · ")) return theme.fg("error", line);
+	if (line.startsWith("idle · ")) return theme.fg("dim", line);
 	if (line.startsWith("usage · ")) return theme.fg("dim", line);
 	if (
 		line.startsWith("cwd · ") ||

--- a/extensions/pi-gremlins/gremlin-runner.test.js
+++ b/extensions/pi-gremlins/gremlin-runner.test.js
@@ -120,6 +120,11 @@ describe("gremlin runner v1 contract", () => {
 				contextTokens: 6,
 			},
 		});
+		expect(result.activities?.slice(-3)).toMatchObject([
+			{ kind: "tool-result", phase: "tool:read", text: "reading chunk" },
+			{ kind: "tool-result", phase: "streaming", text: "file contents" },
+			{ kind: "text", phase: "settling", text: "final answer" },
+		]);
 		expect(updates.some((update) => update.patch.currentPhase === "prompting")).toBe(
 			true,
 		);

--- a/extensions/pi-gremlins/gremlin-runner.ts
+++ b/extensions/pi-gremlins/gremlin-runner.ts
@@ -9,12 +9,19 @@ import {
 	buildGremlinSessionConfig,
 	createGremlinSession,
 } from "./gremlin-session-factory.js";
-import type { GremlinRequest, GremlinRunResult, GremlinUsage } from "./gremlin-schema.js";
+import type {
+	GremlinActivity,
+	GremlinRequest,
+	GremlinRunResult,
+	GremlinUsage,
+} from "./gremlin-schema.js";
 
 export interface GremlinRunnerUpdate {
 	gremlinId: string;
 	patch: Partial<GremlinRunResult>;
 }
+
+const ACTIVITY_HISTORY_LIMIT = 12;
 
 export interface RunSingleGremlinOptions {
 	gremlinId: string;
@@ -106,6 +113,7 @@ function buildBaseResult(
 		cwd: request.cwd,
 		currentPhase: "starting",
 		latestText: "",
+		activities: [],
 		usage: { turns: 0, input: 0, output: 0 },
 		startedAt: Date.now(),
 		revision: 0,
@@ -125,22 +133,52 @@ export async function runSingleGremlin({
 	createSession = createGremlinSession,
 }: RunSingleGremlinOptions): Promise<GremlinRunResult> {
 	const state = buildBaseResult(gremlinId, request, definition);
-	const publish = (patch: Partial<GremlinRunResult>) => {
-		Object.assign(state, patch, { revision: (state.revision ?? 0) + 1 });
-		onUpdate?.({ gremlinId, patch: { ...patch, revision: state.revision } });
+	let activitySequence = 0;
+	const addActivity = (activity: Omit<GremlinActivity, "sequence" | "timestamp">) => {
+		const nextActivity: GremlinActivity = {
+			...activity,
+			timestamp: Date.now(),
+			sequence: ++activitySequence,
+		};
+		const currentActivities = state.activities ?? [];
+		const previous = currentActivities[currentActivities.length - 1];
+		const nextActivities =
+			previous?.kind === nextActivity.kind && previous.phase === nextActivity.phase
+				? [...currentActivities.slice(0, -1), nextActivity]
+				: [...currentActivities, nextActivity];
+		return nextActivities.slice(-ACTIVITY_HISTORY_LIMIT);
+	};
+	const publish = (
+		patch: Partial<GremlinRunResult>,
+		activity?: Omit<GremlinActivity, "sequence" | "timestamp">,
+	) => {
+		const nextPatch = activity
+			? { ...patch, activities: addActivity(activity) }
+			: patch;
+		Object.assign(state, nextPatch, { revision: (state.revision ?? 0) + 1 });
+		onUpdate?.({ gremlinId, patch: { ...nextPatch, revision: state.revision } });
 	};
 
 	if (signal?.aborted) {
-		publish({
-			status: "canceled",
-			currentPhase: "settling",
-			errorMessage: "Gremlin run was aborted before start",
-			finishedAt: Date.now(),
-		});
+		const errorMessage = "Gremlin run was aborted before start";
+		publish(
+			{
+				status: "canceled",
+				currentPhase: "settling",
+				errorMessage,
+				finishedAt: Date.now(),
+			},
+			{ kind: "error", phase: "settling", text: errorMessage },
+		);
 		return { ...state };
 	}
 
-	publish({ status: "starting", currentPhase: "starting" });
+	publish({
+		source: definition.source,
+		status: "starting",
+		currentPhase: "starting",
+		usage: state.usage,
+	});
 
 	const sessionPlan = buildGremlinSessionConfig({
 		parentSystemPrompt,
@@ -193,40 +231,62 @@ export async function runSingleGremlin({
 				break;
 			case "message_update":
 				if (event.assistantMessageEvent?.type === "text_delta") {
-					publish({
-						status: "active",
-						currentPhase: "streaming",
-						latestText: appendLatestTextDelta(event.assistantMessageEvent.delta),
-					});
+					const latestText = appendLatestTextDelta(event.assistantMessageEvent.delta);
+					publish(
+						{
+							status: "active",
+							currentPhase: "streaming",
+							latestText,
+						},
+						{ kind: "text", phase: "streaming", text: latestText },
+					);
 				}
 				break;
-			case "tool_execution_start":
-				publish({
-					status: "active",
-					currentPhase: `tool:${event.toolName}`,
-					latestToolCall: formatToolCall(event.toolName, event.args),
-				});
+			case "tool_execution_start": {
+				const phase = `tool:${event.toolName}`;
+				const latestToolCall = formatToolCall(event.toolName, event.args);
+				publish(
+					{
+						status: "active",
+						currentPhase: phase,
+						latestToolCall,
+					},
+					{ kind: "tool-call", phase, text: latestToolCall },
+				);
 				break;
-			case "tool_execution_update":
-				publish({
-					status: "active",
-					currentPhase: `tool:${event.toolName}`,
-					latestToolResult: extractToolResultText(event.partialResult),
-				});
+			}
+			case "tool_execution_update": {
+				const phase = `tool:${event.toolName}`;
+				const latestToolResult = extractToolResultText(event.partialResult);
+				publish(
+					{
+						status: "active",
+						currentPhase: phase,
+						latestToolResult,
+					},
+					{ kind: "tool-result", phase, text: latestToolResult },
+				);
 				break;
-			case "tool_execution_end":
-				publish({
-					status: "active",
-					currentPhase: "streaming",
-					latestToolResult: extractToolResultText(event.result),
-				});
+			}
+			case "tool_execution_end": {
+				const latestToolResult = extractToolResultText(event.result);
+				publish(
+					{
+						status: "active",
+						currentPhase: "streaming",
+						latestToolResult,
+					},
+					{ kind: "tool-result", phase: "streaming", text: latestToolResult },
+				);
 				break;
+			}
 			case "message_end": {
 				const latestText = extractTextFromContent(event.message?.content);
-				publish({
-					status: "active",
+				const finalText = latestText || state.latestText;
+				const patch = {
+					status: "active" as const,
 					currentPhase: "settling",
-					latestText: latestText || state.latestText,
+					latestText: finalText,
 					usage: mergeUsage(
 						state.usage,
 						event.message,
@@ -236,7 +296,12 @@ export async function runSingleGremlin({
 						typeof event.message?.model === "string"
 							? event.message.model
 							: state.model,
-				});
+				};
+				if (latestText && latestText !== state.latestText) {
+					publish(patch, { kind: "text", phase: "settling", text: latestText });
+				} else {
+					publish(patch);
+				}
 				break;
 			}
 			case "agent_end":
@@ -247,11 +312,15 @@ export async function runSingleGremlin({
 
 	const handleAbort = async () => {
 		abortRequested = true;
-		publish({
-			status: "canceled",
-			currentPhase: "settling",
-			errorMessage: "Gremlin run was aborted",
-		});
+		const errorMessage = "Gremlin run was aborted";
+		publish(
+			{
+				status: "canceled",
+				currentPhase: "settling",
+				errorMessage,
+			},
+			{ kind: "error", phase: "settling", text: errorMessage },
+		);
 		await session.abort?.();
 	};
 	const abortListener = () => {
@@ -268,13 +337,16 @@ export async function runSingleGremlin({
 		});
 		return { ...state };
 	} catch (error) {
-		publish({
-			status: abortRequested || signal?.aborted ? "canceled" : "failed",
-			currentPhase: "settling",
-			errorMessage:
-				error instanceof Error ? error.message : String(error),
-			finishedAt: Date.now(),
-		});
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		publish(
+			{
+				status: abortRequested || signal?.aborted ? "canceled" : "failed",
+				currentPhase: "settling",
+				errorMessage,
+				finishedAt: Date.now(),
+			},
+			{ kind: "error", phase: "settling", text: errorMessage },
+		);
 		return { ...state };
 	} finally {
 		signal?.removeEventListener("abort", abortListener);

--- a/extensions/pi-gremlins/gremlin-scheduler.ts
+++ b/extensions/pi-gremlins/gremlin-scheduler.ts
@@ -34,6 +34,7 @@ function createTerminalResult(
 	error: unknown,
 	aborted: boolean,
 ): GremlinRunResult {
+	const errorMessage = error instanceof Error ? error.message : String(error);
 	return {
 		gremlinId,
 		agent: gremlin.agent,
@@ -42,7 +43,9 @@ function createTerminalResult(
 		context: gremlin.context,
 		cwd: gremlin.cwd,
 		currentPhase: "settling",
-		errorMessage: error instanceof Error ? error.message : String(error),
+		errorMessage,
+		activities: [{ kind: "error", phase: "settling", text: errorMessage }],
+		usage: { turns: 0, input: 0, output: 0 },
 		finishedAt: Date.now(),
 	};
 }

--- a/extensions/pi-gremlins/gremlin-schema.ts
+++ b/extensions/pi-gremlins/gremlin-schema.ts
@@ -42,6 +42,22 @@ export interface GremlinUsage {
 	contextTokens?: number;
 }
 
+export type GremlinActivityKind =
+	| "error"
+	| "tool-call"
+	| "tool-result"
+	| "text"
+	| "task"
+	| "idle";
+
+export interface GremlinActivity {
+	kind: GremlinActivityKind;
+	text: string;
+	phase?: string;
+	timestamp?: number;
+	sequence?: number;
+}
+
 export interface GremlinInvocationEntry {
 	gremlinId?: string;
 	agent: string;
@@ -56,6 +72,7 @@ export interface GremlinInvocationEntry {
 	latestToolCall?: string;
 	latestToolResult?: string;
 	errorMessage?: string;
+	activities?: GremlinActivity[];
 	usage?: GremlinUsage;
 	startedAt?: number;
 	finishedAt?: number;

--- a/extensions/pi-gremlins/gremlin-summary.ts
+++ b/extensions/pi-gremlins/gremlin-summary.ts
@@ -5,12 +5,12 @@ import type {
 } from "./gremlin-schema.js";
 import {
 	formatBatchHeadline,
-	formatCollapsedGremlinLine,
+	formatCollapsedGremlinLines,
 } from "./gremlin-render-components.js";
 
 const HEADLINE_CACHE_LIMIT = 64;
 const headlineCache = new Map<string, string>();
-const summaryLineCache = new WeakMap<GremlinInvocationEntry, { revision: number; line: string }>();
+const summaryLineCache = new WeakMap<GremlinInvocationEntry, { revision: number; lines: string[] }>();
 
 function pushCacheEntry<T>(cache: Map<string, T>, limit: number, key: string, value: T): T {
 	cache.set(key, value);
@@ -30,13 +30,13 @@ function getHeadlineCacheKey(details: GremlinInvocationDetails): string {
 	].join("\u001f");
 }
 
-function summarizeEntry(result: GremlinInvocationEntry): string {
+function summarizeEntry(result: GremlinInvocationEntry): string[] {
 	const entryRevision = result.revision ?? 0;
 	const cached = summaryLineCache.get(result);
-	if (cached?.revision === entryRevision) return cached.line;
-	const line = formatCollapsedGremlinLine(result);
-	summaryLineCache.set(result, { revision: entryRevision, line });
-	return line;
+	if (cached?.revision === entryRevision) return cached.lines;
+	const lines = formatCollapsedGremlinLines(result);
+	summaryLineCache.set(result, { revision: entryRevision, lines });
+	return lines;
 }
 
 function summarizeHeadline(details: GremlinInvocationDetails): string {
@@ -54,7 +54,7 @@ function summarizeHeadline(details: GremlinInvocationDetails): string {
 function buildSummaryLines(details: GremlinInvocationDetails): string[] {
 	const lines = [summarizeHeadline(details)];
 	for (const gremlin of details.gremlins) {
-		lines.push(summarizeEntry(gremlin));
+		lines.push(...summarizeEntry(gremlin));
 	}
 	return lines;
 }

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -16,7 +16,7 @@ describe("pi-gremlins index render v1", () => {
 					{ agent: "reviewer", context: "Review auth flow" },
 				],
 			}).text,
-		).toBe("Gremlins🧌 researcher, reviewer");
+		).toBe("🕯️🔥🕯️ Summoning the gremlins: researcher, reviewer");
 	});
 
 	test("falls back to plain text when result has no structured details", () => {
@@ -74,7 +74,12 @@ describe("pi-gremlins index render v1", () => {
 		const expanded = tool.renderResult(result, { expanded: true }).text;
 
 		expect(collapsed).toContain("Gremlins🧌 · requested:2 · active:1 · completed:1");
-		expect(collapsed).toContain("[Active] · g1 researcher [project] · tool:read · text · Scanning route handlers");
+		expect(collapsed).toContain("[Active] · g1 researcher [project]");
+		expect(collapsed).toContain("task · Find auth flow");
+		expect(collapsed).toContain("latest · tool:read · Scanning route handlers");
+		expect(collapsed).toContain("tool call · settling · read apps/web/src/main.ts");
+		expect(collapsed).toContain("tool result · settling · import bootstrap");
+		expect(collapsed).toContain("usage · turns:2 · input:20 · output:8");
 		expect(collapsed).toContain("Ctrl+O expands inline detail.");
 		expect(collapsed).not.toContain("/gremlins:view");
 		expect(collapsed).not.toContain("popup");

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -57,7 +57,7 @@ function getInvocationDetails(result: AgentToolResult<any>) {
 function renderCallText(params: { gremlins?: Array<{ agent?: string }> }): string {
 	const names = (params.gremlins ?? []).map((gremlin) => gremlin.agent).filter(Boolean);
 	if (names.length === 0) return BRAND_NAME;
-	return `${BRAND_NAME} ${names.join(", ")}`;
+	return `🕯️🔥🕯️ Summoning the gremlins: ${names.join(", ")}`;
 }
 
 export default function registerPiGremlins(pi: ExtensionAPI) {
@@ -138,6 +138,7 @@ export default function registerPiGremlins(pi: ExtensionAPI) {
 				runGremlin: async ({ gremlin: request, gremlinId, signal: childSignal, onUpdate: publishUpdate }) => {
 					const gremlin = resolveGremlinByName(discovered.gremlins, request.agent);
 					if (!gremlin) {
+						const errorMessage = `Unknown gremlin: ${request.agent}`;
 						return {
 							gremlinId,
 							agent: request.agent,
@@ -146,7 +147,9 @@ export default function registerPiGremlins(pi: ExtensionAPI) {
 							context: request.context,
 							cwd: request.cwd,
 							currentPhase: "settling",
-							errorMessage: `Unknown gremlin: ${request.agent}`,
+							errorMessage,
+							activities: [{ kind: "error", phase: "settling", text: errorMessage }],
+							usage: { turns: 0, input: 0, output: 0 },
 						};
 					}
 


### PR DESCRIPTION
## Summary
- Track recent gremlin activities so collapsed inline output can show last three events.
- Render up to three submitted context lines plus usage in collapsed mode.
- Update render/progress tests and changelog for expanded collapsed feed behavior.