### PR TITLE
Require sub-agent frontmatter marker for gremlin discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **V1 SDK rewrite** (PRD-0002, ADR-0002): `pi-gremlins` now runs gremlins through isolated in-process Pi SDK child sessions instead of nested Pi CLI subprocesses.
 - Public tool contract now exposes one invocation shape only: `gremlins: [{ agent, context, cwd? }]` with `1..10` requests and parallel start for multi-gremlin runs.
-- Discovery now loads user gremlins from `~/.pi/agent/agents` plus nearest project `.pi/agents` only, with project definitions overriding same-name user definitions.
+- Discovery now loads only markdown agent files with `agent_type: sub-agent` from `~/.pi/agent/agents` plus nearest project `.pi/agents`, with typed project definitions overriding same-name typed user definitions.
 - Live progress now stays inline in tool row and expands through Pi's standard `Ctrl+O` affordance.
 - Embedded rendering now uses stable gremlin ids (`g1`, `g2`, ...), cached line computation, and inline collapsed/expanded summaries built from shared v1 render components.
 - Inline progress rendering now shows collapsed gremlin context, the three latest activity rows, usage rows, flattened multiline previews, and clearer status/text/tool/result separation in tool-row output.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,17 @@ Gremlin definitions load from:
 - `~/.pi/agent/agents`
 - nearest project `.pi/agents`
 
-If user and project define same gremlin name, project version wins.
+Only markdown files with `agent_type: sub-agent` frontmatter are loaded as gremlins. Untyped files and other agent types, such as `agent_type: primary`, are ignored.
+
+```yaml
+---
+name: researcher
+description: Research-focused gremlin
+agent_type: sub-agent
+---
+```
+
+If user and project define same gremlin name, project version wins among discovered sub-agent definitions.
 
 Important: UI label may show `Gremlins🧌` for human-facing branding. Actual package/runtime/tool identifier stays `pi-gremlins` for install and invocation wiring.
 

--- a/docs/prd/0002-pi-gremlins-v1-sdk-rewrite.md
+++ b/docs/prd/0002-pi-gremlins-v1-sdk-rewrite.md
@@ -14,7 +14,7 @@ Main user need is narrower than current implementation: summon 1-10 gremlins, gi
 
 V1 rewrite must keep premise and operator value, but deliberately cut scope until runtime is dependable and fast:
 
-- Gremlin definitions still come from user and project agent directories.
+- Gremlin definitions still come from user and project agent directories, gated by `agent_type: sub-agent` frontmatter.
 - One invocation shape only.
 - One to ten gremlins only.
 - More than one gremlin means true parallel execution.
@@ -51,7 +51,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - Discover gremlins from both:
   - `~/.pi/agent/agents/*.md`
   - nearest project `.pi/agents/*.md`
-- Resolve duplicate gremlin names with nearest project `.pi/agents` taking precedence over user-level definitions.
+- Resolve duplicate gremlin names with nearest project `.pi/agents` taking precedence over user-level definitions among typed sub-agent files.
 - One tool parameter shape only:
   - `gremlins: [{ agent, context, cwd? }, ...]`
   - array length constrained to `1..10`
@@ -87,8 +87,8 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 
 - [ ] Tool schema exposes exactly one invocation shape: `gremlins: [...]`, with minimum 1 and maximum 10 gremlin requests.
 - [ ] Public tool schema does not expose `agent`, `task`, `tasks`, `chain`, `agentScope`, or `confirmProjectAgents`.
-- [ ] Gremlin discovery loads only user-level `~/.pi/agent/agents` plus nearest project `.pi/agents` and does not load package-provided agent resources.
-- [ ] Duplicate gremlin names resolve deterministically with project-local definition winning over user-level definition.
+- [ ] Gremlin discovery loads only `agent_type: sub-agent` markdown files from user-level `~/.pi/agent/agents` plus nearest project `.pi/agents` and does not load package-provided agent resources.
+- [ ] Duplicate gremlin names resolve deterministically with project-local definition winning over user-level definition among typed sub-agent files.
 - [ ] Child gremlin sessions do not receive parent conversation history.
 - [ ] Child gremlin sessions do not load AGENTS files, extensions, prompts, skills, or themes from parent runtime.
 - [ ] Child gremlin sessions receive current computed system prompt snapshot, raw gremlin markdown contents, and supplied context only.
@@ -109,7 +109,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 ## Technical Surface
 
 - **Extension entry:** `extensions/pi-gremlins/index.ts` rewritten from zero to register only v1 tool and wire lifecycle cleanup.
-- **Discovery:** new modules for gremlin definition loading, frontmatter parsing, both-scope resolution, and duplicate-name precedence.
+- **Discovery:** new modules for gremlin definition loading, frontmatter parsing, `agent_type: sub-agent` gating, both-scope resolution, and duplicate-name precedence.
 - **Child-session runtime:** new SDK-based session factory using `createAgentSession()`, in-memory session state, and custom `ResourceLoader`/system prompt override.
 - **Execution:** new scheduler and invocation controller for 1-10 gremlins, structured cancellation, event fan-in, and aggregate result handling.
 - **Rendering:** new inline collapsed/expanded renderer only; no overlay, popup, viewer snapshot, or steering UI.

--- a/extensions/pi-gremlins/gremlin-definition.ts
+++ b/extensions/pi-gremlins/gremlin-definition.ts
@@ -94,6 +94,9 @@ export function parseGremlinDefinition(
 	source: GremlinSource,
 ): GremlinDefinition | null {
 	const { frontmatter, body } = parseFrontmatterBlock(markdown);
+	const agentType = readScalar(frontmatter, "agent_type");
+	if (agentType !== "sub-agent") return null;
+
 	const name = readScalar(frontmatter, "name");
 	if (!name) return null;
 

--- a/extensions/pi-gremlins/gremlin-discovery.test.js
+++ b/extensions/pi-gremlins/gremlin-discovery.test.js
@@ -44,7 +44,7 @@ describe("gremlin discovery v1 contract", () => {
 		fs.mkdirSync(workspace.projectAgentsDir, { recursive: true });
 		fs.writeFileSync(
 			`${workspace.projectAgentsDir}/shared.md`,
-			"---\nname: shared\ndescription: project shared gremlin\n---\nproject prompt body",
+			"---\nname: shared\ndescription: project shared gremlin\nagent_type: sub-agent\n---\nproject prompt body",
 			"utf-8",
 		);
 		writeAgentFile(
@@ -76,6 +76,65 @@ describe("gremlin discovery v1 contract", () => {
 			});
 	});
 
+	test("skips agent files without sub-agent frontmatter marker", async () => {
+		const { createGremlinDiscoveryCache } = await import("./gremlin-discovery.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		fs.mkdirSync(workspace.projectAgentsDir, { recursive: true });
+		fs.writeFileSync(
+			`${workspace.projectAgentsDir}/untyped.md`,
+			"---\nname: untyped\ndescription: untyped agent\n---\nUntyped prompt body",
+			"utf-8",
+		);
+		fs.writeFileSync(
+			`${workspace.projectAgentsDir}/primary.md`,
+			"---\nname: primary\ndescription: primary agent\nagent_type: primary\n---\nPrimary prompt body",
+			"utf-8",
+		);
+		fs.writeFileSync(
+			`${workspace.projectAgentsDir}/sub-agent.md`,
+			"---\nname: sub-agent\ndescription: sub agent\nagent_type: sub-agent\n---\nSub-agent prompt body",
+			"utf-8",
+		);
+
+		const discovery = createGremlinDiscoveryCache({
+			userAgentsDir: workspace.userAgentsDir,
+		});
+		const result = await discovery.get(workspace.repoRoot);
+
+		expect(result.gremlins.map((gremlin) => gremlin.name)).toEqual([
+			"sub-agent",
+		]);
+	});
+
+	test("does not let untyped project file override typed user sub-agent", async () => {
+		const { createGremlinDiscoveryCache } = await import("./gremlin-discovery.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writeAgentFile(
+			workspace.userAgentsDir,
+			"shared.md",
+			"shared",
+			"user shared gremlin",
+		);
+		fs.mkdirSync(workspace.projectAgentsDir, { recursive: true });
+		fs.writeFileSync(
+			`${workspace.projectAgentsDir}/shared.md`,
+			"---\nname: shared\ndescription: untyped project shared\n---\nproject prompt body",
+			"utf-8",
+		);
+
+		const discovery = createGremlinDiscoveryCache({
+			userAgentsDir: workspace.userAgentsDir,
+		});
+		const result = await discovery.get(workspace.repoRoot);
+
+		expect(result.gremlins).toEqual([
+			expect.objectContaining({ name: "shared", source: "user" }),
+		]);
+		expect(result.gremlins[0].rawMarkdown).toContain("system prompt");
+	});
+
 	test("parses frontmatter metadata and invalidates cache when file set changes", async () => {
 		const { createGremlinDiscoveryCache } = await import("./gremlin-discovery.ts");
 		const workspace = createWorkspace();
@@ -87,6 +146,7 @@ describe("gremlin discovery v1 contract", () => {
 				"---",
 				"name: researcher",
 				"description: project researcher",
+				"agent_type: sub-agent",
 				"model: openai/gpt-5-mini",
 				"thinking: high",
 				"tools:",
@@ -113,7 +173,7 @@ describe("gremlin discovery v1 contract", () => {
 
 		fs.writeFileSync(
 			`${workspace.projectAgentsDir}/reviewer.md`,
-			"---\nname: reviewer\ndescription: project reviewer\n---\nReview prompt body",
+			"---\nname: reviewer\ndescription: project reviewer\nagent_type: sub-agent\n---\nReview prompt body",
 			"utf-8",
 		);
 		const second = await discovery.get(workspace.repoRoot);
@@ -134,7 +194,7 @@ describe("gremlin discovery v1 contract", () => {
 		const researcherPath = `${workspace.projectAgentsDir}/researcher.md`;
 		fs.writeFileSync(
 			researcherPath,
-			"---\nname: researcher\ndescription: first\n---\nfirst prompt body",
+			"---\nname: researcher\ndescription: first\nagent_type: sub-agent\n---\nfirst prompt body",
 			"utf-8",
 		);
 		const { calls, fileSystem } = createCountingFileSystem();
@@ -152,7 +212,7 @@ describe("gremlin discovery v1 contract", () => {
 
 		fs.writeFileSync(
 			researcherPath,
-			"---\nname: researcher\ndescription: second\n---\nsecond prompt body",
+			"---\nname: researcher\ndescription: second\nagent_type: sub-agent\n---\nsecond prompt body",
 			"utf-8",
 		);
 		fs.utimesSync(researcherPath, new Date(), new Date(Date.now() + 1000));
@@ -170,7 +230,7 @@ describe("gremlin discovery v1 contract", () => {
 		fs.mkdirSync(workspace.projectAgentsDir, { recursive: true });
 		fs.writeFileSync(
 			`${workspace.projectAgentsDir}/good.md`,
-			"---\nname: good\ndescription: good gremlin\n---\nGood prompt body",
+			"---\nname: good\ndescription: good gremlin\nagent_type: sub-agent\n---\nGood prompt body",
 			"utf-8",
 		);
 		fs.symlinkSync(
@@ -193,7 +253,7 @@ describe("gremlin discovery v1 contract", () => {
 		fs.mkdirSync(workspace.projectAgentsDir, { recursive: true });
 		fs.writeFileSync(
 			`${workspace.projectAgentsDir}/crlf.md`,
-			"---\r\nname: crlf\r\ndescription: CRLF gremlin\r\n---\r\nPrompt body",
+			"---\r\nname: crlf\r\ndescription: CRLF gremlin\r\nagent_type: sub-agent\r\n---\r\nPrompt body",
 			"utf-8",
 		);
 

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -8,7 +8,7 @@ function writeGremlinFile(dir, fileName, name, extraFrontmatter = "") {
 	fs.mkdirSync(dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(dir, fileName),
-		`---\nname: ${name}\ndescription: ${name} description\n${extraFrontmatter}---\n${name} system prompt`,
+		`---\nname: ${name}\ndescription: ${name} description\nagent_type: sub-agent\n${extraFrontmatter}---\n${name} system prompt`,
 		"utf-8",
 	);
 }

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -33,7 +33,7 @@ const TOOL_DESCRIPTION = [
 	"Summon specialized gremlins with isolated context.",
 	"Input uses gremlins: [{ agent, context, cwd? }].",
 	"One gremlin runs single invocation. Multiple gremlins start in parallel.",
-	"Gremlin definitions load from user and nearest project directories.",
+	"Gremlin definitions load from user and nearest project directories when agent_type is sub-agent.",
 	"Progress stays inline and expands with Ctrl+O.",
 ].join(" ");
 

--- a/extensions/pi-gremlins/test-helpers.js
+++ b/extensions/pi-gremlins/test-helpers.js
@@ -30,7 +30,7 @@ export function writeAgentFile(
 	fs.mkdirSync(dir, { recursive: true });
 	fs.writeFileSync(
 		path.join(dir, fileName),
-		`---\nname: ${name}\ndescription: ${description}\n---\nsystem prompt`,
+		`---\nname: ${name}\ndescription: ${description}\nagent_type: sub-agent\n---\nsystem prompt`,
 		"utf-8",
 	);
 }


### PR DESCRIPTION
## Summary
- require gremlin markdown definitions to opt in with agent_type: sub-agent
- update discovery fixtures and regression coverage for untyped and primary agents
- document the discovery contract in README, PRD, and changelog

## Verification
- npm run check

Closes #36