### PR TITLE
Add required gremlin intent field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **V1 SDK rewrite** (PRD-0002, ADR-0002): `pi-gremlins` now runs gremlins through isolated in-process Pi SDK child sessions instead of nested Pi CLI subprocesses.
-- Public tool contract now exposes one invocation shape only: `gremlins: [{ agent, context, cwd? }]` with `1..10` requests and parallel start for multi-gremlin runs.
+- Public tool contract now exposes one invocation shape only: `gremlins: [{ intent, agent, context, cwd? }]` with `1..10` requests and parallel start for multi-gremlin runs; `intent`, `agent`, and `context` are required non-empty strings.
 - Discovery now loads only markdown agent files with `agent_type: sub-agent` from `~/.pi/agent/agents` plus nearest project `.pi/agents`, with typed project definitions overriding same-name typed user definitions.
 - Live progress now stays inline in tool row and expands through Pi's standard `Ctrl+O` affordance.
 - Embedded rendering now uses stable gremlin ids (`g1`, `g2`, ...), cached line computation, and inline collapsed/expanded summaries built from shared v1 render components.
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New v1 runtime modules under `extensions/pi-gremlins/`: schema, definition parsing, discovery cache, prompt builder, isolated session factory, runner, scheduler, progress store, summary builder, and inline renderer.
+- Child prompt framing now separates caller intent from caller context so gremlins see delegation rationale apart from task details.
 - Focused v1 contract coverage for schema, discovery, session isolation, runner projection, scheduler cancellation, rendering, and entry-point execution.
 - `extensions/pi-gremlins/AGENTS_CUSTOM.md` override documenting current v1-only runtime boundaries until generated agent docs are refreshed.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Suggested GitHub About text:
 V1 contract:
 
 - one tool name: `pi-gremlins`
-- one input shape: `gremlins: [{ agent, context, cwd? }]`
+- one input shape: `gremlins: [{ intent, agent, context, cwd? }]`
 - array length `1..10`
 - one gremlin = single run
 - multiple gremlins = parallel run
@@ -74,7 +74,11 @@ Single summon:
 ```text
 pi-gremlins({
   gremlins: [
-    { agent: "researcher", context: "Summarize repo architecture" }
+    {
+      intent: "Get independent architecture read before editing runtime code",
+      agent: "researcher",
+      context: "Summarize repo architecture"
+    }
   ]
 })
 ```
@@ -84,9 +88,21 @@ Parallel swarm:
 ```text
 pi-gremlins({
   gremlins: [
-    { agent: "researcher", context: "Find auth flow" },
-    { agent: "reviewer", context: "Review recent changes" },
-    { agent: "writer", context: "Draft release note" }
+    {
+      intent: "Map auth implementation before parent changes code",
+      agent: "researcher",
+      context: "Find auth flow"
+    },
+    {
+      intent: "Catch risks in pending changes",
+      agent: "reviewer",
+      context: "Review recent changes"
+    },
+    {
+      intent: "Prepare concise user-facing release copy",
+      agent: "writer",
+      context: "Draft release note"
+    }
   ]
 })
 ```
@@ -96,20 +112,27 @@ Per-gremlin working directory override:
 ```text
 pi-gremlins({
   gremlins: [
-    { agent: "researcher", context: "Audit frontend auth code", cwd: "apps/web" }
+    {
+      intent: "Audit frontend auth before parent edits web app",
+      agent: "researcher",
+      context: "Audit frontend auth code",
+      cwd: "apps/web"
+    }
   ]
 })
 ```
 
 Runtime behavior:
 
+- `intent` is required and states why the parent is delegating or what outcome the gremlin should serve
+- `context` is required and carries concrete task details, constraints, paths, findings, and requested output
 - child sessions run in-process through Pi SDK
 - child sessions inherit parent system prompt snapshot only
 - no nested Pi CLI subprocesses
 - no temp prompt files
 - child sessions do not load extensions, skills, prompts, themes, or AGENTS files
 - collapsed tool row shows source, status, phase, and latest activity
-- expanded tool row shows task, cwd, model, thinking, latest text/tool data, usage, and errors
+- expanded tool row shows intent, task, cwd, model, thinking, latest text/tool data, usage, and errors
 
 ## Repo layout
 

--- a/docs/adr/0002-in-process-sdk-based-gremlin-runtime.md
+++ b/docs/adr/0002-in-process-sdk-based-gremlin-runtime.md
@@ -42,7 +42,7 @@ Pi's own documentation in `docs/sdk.md` explicitly recommends using `AgentSessio
 
 - Reliability: eliminate stuck nested Pi subprocesses as default failure class.
 - Performance: remove CLI startup, JSON serialization/parsing, temp file I/O, and extra process lifetime management.
-- Isolation correctness: child gremlins must receive only computed system prompt, gremlin markdown, and passed context.
+- Isolation correctness: child gremlins must receive only computed system prompt, gremlin markdown, passed intent, and passed context.
 - Scope reduction: architecture should match slimmed v1 surface, not legacy viewer/chain feature set.
 - Maintainability: smaller, testable module graph with no new god file.
 - Abort behavior: cancellation must be structured, deterministic, and easy to prove in tests.
@@ -120,7 +120,7 @@ Rationale: User asked for full rewrite because subprocess termination has been p
 - **packages/utils:** N/A. No standalone utils package in this repository.
 - **Migration/ops:**
   - No persistence or config migration.
-  - Public tool schema changes materially: old multi-mode params are removed in favor of `gremlins: [...]`.
+  - Public tool schema changes materially: old multi-mode params are removed in favor of `gremlins: [{ intent, agent, context, cwd? }, ...]`.
   - Legacy commands `/gremlins:view` and `/gremlins:steer` are removed as part of rewrite.
   - Extension entry remains under `./extensions/pi-gremlins`, but implementation beneath it is rewritten from scratch and legacy modules deleted after cutover verification.
 
@@ -159,3 +159,4 @@ This ADR intentionally supersedes ADR-0001. ADR-0001 optimized popup viewer and 
 ## Status History
 
 - 2026-04-22: Accepted; supersedes ADR-0001 in favor of SDK-based in-process child sessions and inline-only v1 UI
+- 2026-04-24: Noted required per-gremlin `intent` field as part of public v1 request contract and child prompt framing

--- a/docs/plans/pi-gremlins-v1-sdk-rewrite.md
+++ b/docs/plans/pi-gremlins-v1-sdk-rewrite.md
@@ -14,7 +14,7 @@ This plan does **not** patch current runtime again. It assumes full replacement.
 Target v1 surface:
 
 - one tool only: `pi-gremlins`
-- one input shape only: `gremlins: [{ agent, context, cwd? }, ...]`
+- one input shape only: `gremlins: [{ intent, agent, context, cwd? }, ...]`
 - array length `1..10`
 - if more than one gremlin requested, all start in parallel
 - load both user and nearest project gremlins automatically
@@ -179,6 +179,7 @@ Keep repo convention of flat TS files under `extensions/pi-gremlins/`.
 pi-gremlins({
   gremlins: [
     {
+      intent: "Map auth flow before parent edits code",
       agent: "researcher",
       context: "Find auth flow and summarize entry points",
       cwd: "/optional/project/path"
@@ -202,7 +203,8 @@ Each child gremlin session must receive exactly these inputs:
 
 1. **computed system prompt snapshot** from parent turn via `ctx.getSystemPrompt()`
 2. **raw gremlin markdown contents** from resolved gremlin file
-3. **caller-supplied context string** from tool params
+3. **caller-supplied intent string** from tool params
+4. **caller-supplied context string** from tool params
 
 Everything else is intentionally excluded:
 
@@ -389,7 +391,7 @@ Per gremlin show:
   - `gremlin-session-factory.ts`
 - **Acceptance criteria:**
   - Child session receives parent computed system prompt snapshot.
-  - Child session prompt includes raw gremlin markdown and caller context only.
+  - Child session prompt includes raw gremlin markdown, caller intent, and caller context only.
   - Resource loader returns no extensions/skills/prompts/themes/AGENTS.
   - No temp prompt file write path exists.
   - No subprocess spawn path exists.

--- a/docs/prd/0002-pi-gremlins-v1-sdk-rewrite.md
+++ b/docs/prd/0002-pi-gremlins-v1-sdk-rewrite.md
@@ -18,7 +18,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - One invocation shape only.
 - One to ten gremlins only.
 - More than one gremlin means true parallel execution.
-- Each gremlin gets only current computed system prompt, its own markdown definition, and caller-supplied context.
+- Each gremlin gets only current computed system prompt, its own markdown definition, caller-supplied intent, and caller-supplied context.
 - No full parent conversation history.
 - No chain mode.
 - No popup viewer, no `/gremlins:view`, no targeted steering command.
@@ -53,7 +53,9 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
   - nearest project `.pi/agents/*.md`
 - Resolve duplicate gremlin names with nearest project `.pi/agents` taking precedence over user-level definitions among typed sub-agent files.
 - One tool parameter shape only:
-  - `gremlins: [{ agent, context, cwd? }, ...]`
+  - `gremlins: [{ intent, agent, context, cwd? }, ...]`
+  - `intent` is required delegation rationale or desired outcome
+  - `context` is required task detail, constraints, paths, findings, or requested output
   - array length constrained to `1..10`
 - If `gremlins.length === 1`, run one gremlin.
 - If `gremlins.length > 1`, start all gremlins in parallel with no hidden lower concurrency cap.
@@ -61,6 +63,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - Build child sessions with:
   - current computed parent system prompt snapshot
   - raw gremlin markdown contents
+  - caller-supplied intent string
   - caller-supplied context string
   - in-memory session manager
   - custom resource loader that disables inherited extensions, prompts, skills, themes, AGENTS files, and conversation history
@@ -85,13 +88,13 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 
 ## Acceptance Criteria
 
-- [ ] Tool schema exposes exactly one invocation shape: `gremlins: [...]`, with minimum 1 and maximum 10 gremlin requests.
+- [ ] Tool schema exposes exactly one invocation shape: `gremlins: [{ intent, agent, context, cwd? }, ...]`, with minimum 1 and maximum 10 gremlin requests.
 - [ ] Public tool schema does not expose `agent`, `task`, `tasks`, `chain`, `agentScope`, or `confirmProjectAgents`.
 - [ ] Gremlin discovery loads only `agent_type: sub-agent` markdown files from user-level `~/.pi/agent/agents` plus nearest project `.pi/agents` and does not load package-provided agent resources.
 - [ ] Duplicate gremlin names resolve deterministically with project-local definition winning over user-level definition among typed sub-agent files.
 - [ ] Child gremlin sessions do not receive parent conversation history.
 - [ ] Child gremlin sessions do not load AGENTS files, extensions, prompts, skills, or themes from parent runtime.
-- [ ] Child gremlin sessions receive current computed system prompt snapshot, raw gremlin markdown contents, and supplied context only.
+- [ ] Child gremlin sessions receive current computed system prompt snapshot, raw gremlin markdown contents, supplied intent, and supplied context only.
 - [ ] More than one gremlin request starts parallel execution immediately; runtime does not serialize by default and does not impose lower internal concurrency than requested gremlin count.
 - [ ] Abort from parent tool execution cancels every running gremlin session and leaves no active child sessions registered after completion.
 - [ ] Tool row shows inline live progress for every gremlin while execution is active.
@@ -124,6 +127,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
   - status
   - gremlin name
   - source badge
+  - delegation intent
   - current/latest activity
   - short terminal summary
 - Expanded view should add detail, not alternate navigation.
@@ -154,3 +158,4 @@ Primary references used for this PRD:
 ## Revision History
 
 - 2026-04-22: Draft created
+- 2026-04-24: V1 request contract updated to require per-gremlin `intent` separate from `context`

--- a/extensions/pi-gremlins/gremlin-progress-store.ts
+++ b/extensions/pi-gremlins/gremlin-progress-store.ts
@@ -18,6 +18,7 @@ function createInitialEntry(
 	const now = Date.now();
 	return {
 		gremlinId: `g${index + 1}`,
+		intent: request.intent ?? "",
 		agent: request.agent,
 		source: "unknown",
 		status: "queued",

--- a/extensions/pi-gremlins/gremlin-prompt.ts
+++ b/extensions/pi-gremlins/gremlin-prompt.ts
@@ -1,12 +1,14 @@
 export interface BuildGremlinPromptOptions {
 	parentSystemPrompt: string;
 	rawMarkdown: string;
+	intent: string;
 	context: string;
 }
 
 export function buildGremlinPrompt({
 	parentSystemPrompt,
 	rawMarkdown,
+	intent,
 	context,
 }: BuildGremlinPromptOptions): string {
 	return [
@@ -15,6 +17,9 @@ export function buildGremlinPrompt({
 		"",
 		"Gremlin definition markdown:",
 		rawMarkdown,
+		"",
+		"Caller intent:",
+		intent,
 		"",
 		"Caller context:",
 		context,

--- a/extensions/pi-gremlins/gremlin-render-components.ts
+++ b/extensions/pi-gremlins/gremlin-render-components.ts
@@ -85,6 +85,7 @@ export function createEntryCacheKey(
 		createTextCacheToken(entry.agent),
 		entry.source,
 		entry.status,
+		createTextCacheToken(entry.intent),
 		createTextCacheToken(entry.context),
 		createTextCacheToken(entry.cwd),
 		createTextCacheToken(entry.model),
@@ -244,6 +245,11 @@ function formatContextPreviewLines(context: string): string[] {
 		.map((line) => `task · ${line}`);
 }
 
+function formatIntentPreviewLine(intent?: string): string | undefined {
+	const preview = normalizePreviewText(intent);
+	return preview ? `intent · ${preview}` : undefined;
+}
+
 export function formatBatchHeadline(details: GremlinInvocationDetails): string {
 	return [
 		"Gremlins🧌",
@@ -261,6 +267,8 @@ export function formatCollapsedGremlinLines(entry: GremlinInvocationEntry): stri
 	if (cached) return cached;
 
 	const lines = [`[${formatGremlinStatus(entry.status)}] · ${formatGremlinIdentity(entry)}`];
+	const intentLine = formatIntentPreviewLine(entry.intent);
+	if (intentLine) lines.push(intentLine);
 	lines.push(...formatContextPreviewLines(entry.context));
 	lines.push(...getRecentActivityPreviews(entry).map(formatActivityPreviewLine));
 	const usage = formatUsageSummary(entry.usage);
@@ -276,6 +284,7 @@ export function formatExpandedGremlinLines(entry: GremlinInvocationEntry): strin
 
 	const lines = [
 		`[${formatGremlinStatus(entry.status)}] ${formatGremlinIdentity(entry)}`,
+		...dedupeParts([formatIntentPreviewLine(entry.intent)]),
 		`task · ${entry.context}`,
 	];
 	const metaLines = dedupeParts([

--- a/extensions/pi-gremlins/gremlin-rendering.test.js
+++ b/extensions/pi-gremlins/gremlin-rendering.test.js
@@ -17,6 +17,7 @@ describe("gremlin rendering v1 contract", () => {
 					{
 						gremlinId: "g1",
 						agent: "researcher",
+						intent: "Map auth architecture before parent edits",
 						source: "project",
 						status: "active",
 						currentPhase: "tool:read",
@@ -28,6 +29,7 @@ describe("gremlin rendering v1 contract", () => {
 					{
 						gremlinId: "g2",
 						agent: "reviewer",
+						intent: "Review auth findings independently",
 						source: "user",
 						status: "queued",
 						currentPhase: "prompting",
@@ -44,10 +46,12 @@ describe("gremlin rendering v1 contract", () => {
 
 		expect(text).toContain("Gremlins🧌 · requested:2 · active:1");
 		expect(text).toContain("[Active] · g1 researcher [project]");
+		expect(text).toContain("intent · Map auth architecture before parent edits");
 		expect(text).toContain("task · Find auth flow");
 		expect(text).toContain("latest · tool:read · Scanning auth entry points");
 		expect(text).toContain("usage · turns:1 · input:10 · output:4");
 		expect(text).toContain("[Queued] · g2 reviewer [user]");
+		expect(text).toContain("intent · Review auth findings independently");
 		expect(text).toContain("task · prompting · Review auth flow");
 		expect(text).toContain("Ctrl+O expands inline detail.");
 		expect(text).not.toContain("/gremlins:view");
@@ -245,6 +249,7 @@ describe("gremlin rendering v1 contract", () => {
 					{
 						gremlinId: "g1",
 						agent: "researcher",
+						intent: "Confirm auth entry before parent summarizes",
 						source: "project",
 						status: "completed",
 						currentPhase: "settling",
@@ -270,6 +275,7 @@ describe("gremlin rendering v1 contract", () => {
 		);
 
 		expect(text).toContain("[Completed] g1 researcher [project]");
+		expect(text).toContain("intent · Confirm auth entry before parent summarizes");
 		expect(text).toContain("task · Find auth flow");
 		expect(text).toContain("tool call · read apps/web/src/main.ts");
 		expect(text).toContain("tool result · import bootstrap from ./bootstrap");

--- a/extensions/pi-gremlins/gremlin-rendering.ts
+++ b/extensions/pi-gremlins/gremlin-rendering.ts
@@ -169,6 +169,7 @@ function styleLine(
 	if (line.startsWith("Gremlins🧌")) return theme.fg("accent", theme.bold(line));
 	if (line === "Ctrl+O expands inline detail.") return theme.fg("dim", line);
 	if (line === "No gremlins requested.") return theme.fg("muted", line);
+	if (line.startsWith("intent · ")) return theme.fg("muted", line);
 	if (line.startsWith("task · ")) return theme.fg("text", line);
 	if (line.startsWith("tool call · ")) return theme.fg("accent", line);
 	if (line.startsWith("tool result · ")) return theme.fg("toolOutput", line);

--- a/extensions/pi-gremlins/gremlin-runner.test.js
+++ b/extensions/pi-gremlins/gremlin-runner.test.js
@@ -40,6 +40,9 @@ describe("gremlin runner v1 contract", () => {
 			onPrompt: async ({ text, emit }) => {
 				expect(text).toContain("Parent system prompt snapshot:");
 				expect(text).toContain("raw gremlin body");
+				expect(text).toContain("Caller intent:");
+				expect(text).toContain("Inspect implementation independently");
+				expect(text).toContain("Caller context:");
 				expect(text).toContain("Inspect auth flow");
 				emit({ type: "agent_start" });
 				emit({ type: "turn_start" });
@@ -87,7 +90,7 @@ describe("gremlin runner v1 contract", () => {
 
 		const result = await runSingleGremlin({
 			gremlinId: "g1",
-			request: { agent: "researcher", context: "Inspect auth flow" },
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
 			definition: {
 				name: "researcher",
 				source: "project",
@@ -162,7 +165,7 @@ describe("gremlin runner v1 contract", () => {
 
 		const result = await runSingleGremlin({
 			gremlinId: "g1",
-			request: { agent: "researcher", context: "Inspect auth flow" },
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
 			definition: {
 				name: "researcher",
 				source: "project",
@@ -208,7 +211,7 @@ describe("gremlin runner v1 contract", () => {
 
 		const result = await runSingleGremlin({
 			gremlinId: "g1",
-			request: { agent: "researcher", context: "Inspect auth flow" },
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
 			definition: {
 				name: "researcher",
 				source: "project",
@@ -233,7 +236,7 @@ describe("gremlin runner v1 contract", () => {
 		let disposed = 0;
 		const result = await runSingleGremlin({
 			gremlinId: "g1",
-			request: { agent: "researcher", context: "Inspect auth flow" },
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
 			definition: {
 				name: "researcher",
 				source: "project",
@@ -265,7 +268,7 @@ describe("gremlin runner v1 contract", () => {
 		let createCalls = 0;
 		const result = await runSingleGremlin({
 			gremlinId: "g1",
-			request: { agent: "researcher", context: "Inspect auth flow" },
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
 			definition: {
 				name: "researcher",
 				source: "project",
@@ -301,7 +304,7 @@ describe("gremlin runner v1 contract", () => {
 
 		const canceledPromise = runSingleGremlin({
 			gremlinId: "g1",
-			request: { agent: "researcher", context: "Inspect auth flow" },
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
 			definition: {
 				name: "researcher",
 				source: "project",
@@ -327,7 +330,7 @@ describe("gremlin runner v1 contract", () => {
 		});
 		const failed = await runSingleGremlin({
 			gremlinId: "g2",
-			request: { agent: "reviewer", context: "Review diff" },
+			request: { intent: "Review implementation independently", agent: "reviewer", context: "Review diff" },
 			definition: {
 				name: "reviewer",
 				source: "user",
@@ -365,7 +368,7 @@ describe("gremlin runner v1 contract", () => {
 
 		const result = await runSingleGremlin({
 			gremlinId: "g1",
-			request: { agent: "researcher", context: "Inspect auth flow" },
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
 			definition: {
 				name: "researcher",
 				source: "project",

--- a/extensions/pi-gremlins/gremlin-runner.ts
+++ b/extensions/pi-gremlins/gremlin-runner.ts
@@ -107,6 +107,7 @@ function buildBaseResult(
 	return {
 		gremlinId,
 		agent: request.agent,
+		intent: request.intent,
 		source: definition.source,
 		status: "starting",
 		context: request.context,
@@ -185,6 +186,7 @@ export async function runSingleGremlin({
 		parentModel,
 		parentThinking,
 		gremlin: definition,
+		intent: request.intent,
 		context: request.context,
 		cwd: request.cwd,
 		modelRegistry,
@@ -250,6 +252,7 @@ export async function runSingleGremlin({
 			parentModel,
 			parentThinking,
 			gremlin: definition,
+			intent: request.intent,
 			context: request.context,
 			cwd: request.cwd,
 			modelRegistry,

--- a/extensions/pi-gremlins/gremlin-scheduler.test.js
+++ b/extensions/pi-gremlins/gremlin-scheduler.test.js
@@ -20,8 +20,8 @@ describe("gremlin scheduler v1 contract", () => {
 		const updates = [];
 		const batchPromise = runGremlinBatch({
 			gremlins: [
-				{ agent: "alpha", context: "Find alpha" },
-				{ agent: "beta", context: "Find beta" },
+				{ intent: "Find alpha independently", agent: "alpha", context: "Find alpha" },
+				{ intent: "Find beta independently", agent: "beta", context: "Find beta" },
 			],
 			onUpdate: (details) => updates.push(details),
 			runGremlin: async ({ gremlin, gremlinId, onUpdate }) => {
@@ -50,8 +50,8 @@ describe("gremlin scheduler v1 contract", () => {
 	test("publishes immutable snapshots with correct incremental status counts across updates", async () => {
 		const { createGremlinProgressStore } = await import("./gremlin-progress-store.ts");
 		const store = createGremlinProgressStore([
-			{ agent: "alpha", context: "Find alpha" },
-			{ agent: "beta", context: "Find beta" },
+			{ intent: "Find alpha independently", agent: "alpha", context: "Find alpha" },
+			{ intent: "Find beta independently", agent: "beta", context: "Find beta" },
 		]);
 
 		const queued = store.snapshot();
@@ -135,9 +135,9 @@ describe("gremlin scheduler v1 contract", () => {
 
 		const result = await runGremlinBatch({
 			gremlins: [
-				{ agent: "alpha", context: "Find alpha" },
-				{ agent: "beta", context: "Find beta" },
-				{ agent: "gamma", context: "Find gamma" },
+				{ intent: "Find alpha independently", agent: "alpha", context: "Find alpha" },
+				{ intent: "Find beta independently", agent: "beta", context: "Find beta" },
+				{ intent: "Find gamma independently", agent: "gamma", context: "Find gamma" },
 			],
 			runGremlin: async ({ gremlin, gremlinId }) => {
 				if (gremlin.agent === "alpha") {
@@ -168,8 +168,8 @@ describe("gremlin scheduler v1 contract", () => {
 
 		const batchPromise = runGremlinBatch({
 			gremlins: [
-				{ agent: "alpha", context: "Find alpha" },
-				{ agent: "beta", context: "Find beta" },
+				{ intent: "Find alpha independently", agent: "alpha", context: "Find alpha" },
+				{ intent: "Find beta independently", agent: "beta", context: "Find beta" },
 			],
 			signal: controller.signal,
 			onUpdate: (details) => updates.push(details),

--- a/extensions/pi-gremlins/gremlin-scheduler.ts
+++ b/extensions/pi-gremlins/gremlin-scheduler.ts
@@ -37,6 +37,7 @@ function createTerminalResult(
 	const errorMessage = error instanceof Error ? error.message : String(error);
 	return {
 		gremlinId,
+		intent: gremlin.intent ?? "",
 		agent: gremlin.agent,
 		source: "unknown",
 		status: aborted ? "canceled" : "failed",

--- a/extensions/pi-gremlins/gremlin-schema.test.js
+++ b/extensions/pi-gremlins/gremlin-schema.test.js
@@ -19,6 +19,7 @@ describe("gremlin schema v1 contract", () => {
 			maxItems: 10,
 		});
 		expect(tool.parameters.gremlins.value).toMatchObject({
+			intent: expect.objectContaining({ minLength: 1 }),
 			agent: expect.objectContaining({ minLength: 1 }),
 			context: expect.objectContaining({ minLength: 1 }),
 			cwd: expect.any(Object),
@@ -41,6 +42,8 @@ describe("gremlin schema v1 contract", () => {
 		const tool = createRegisteredTool();
 
 		expect(tool.description).toContain("gremlins");
+		expect(tool.description).toContain("intent is required");
+		expect(tool.description).toContain("context is required");
 		expect(tool.description).toContain("parallel");
 		expect(tool.description).not.toContain("Modes:");
 		expect(tool.description).not.toContain("chain");

--- a/extensions/pi-gremlins/gremlin-schema.ts
+++ b/extensions/pi-gremlins/gremlin-schema.ts
@@ -1,12 +1,16 @@
 import { Type } from "typebox";
 
 export const GremlinRequestSchema = Type.Object({
+	intent: Type.String({
+		description: "Why parent agent is spawning this gremlin",
+		minLength: 1,
+	}),
 	agent: Type.String({
 		description: "Name of gremlin to invoke",
 		minLength: 1,
 	}),
 	context: Type.String({
-		description: "Task or context for gremlin",
+		description: "Task details and working context for gremlin",
 		minLength: 1,
 	}),
 	cwd: Type.Optional(
@@ -33,6 +37,7 @@ export type GremlinStatus =
 	| "canceled";
 
 export interface GremlinRequest {
+	intent: string;
 	agent: string;
 	context: string;
 	cwd?: string;
@@ -66,6 +71,7 @@ export interface GremlinActivity {
 
 export interface GremlinInvocationEntry {
 	gremlinId?: string;
+	intent: string;
 	agent: string;
 	source: GremlinSource;
 	status: GremlinStatus;

--- a/extensions/pi-gremlins/gremlin-session-factory.test.js
+++ b/extensions/pi-gremlins/gremlin-session-factory.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 describe("gremlin session factory v1 contract", () => {
-	test("builds child session config from parent system prompt raw gremlin markdown and caller context only", async () => {
+	test("builds child session config from parent system prompt raw gremlin markdown caller intent and caller context only", async () => {
 		const { buildGremlinPrompt } = await import("./gremlin-prompt.ts");
 		const { buildGremlinSessionConfig } = await import(
 			"./gremlin-session-factory.ts"
@@ -17,10 +17,12 @@ describe("gremlin session factory v1 contract", () => {
 			"---",
 			"You are focused research gremlin.",
 		].join("\n");
+		const intent = "Map architecture before parent edits auth code";
 		const context = "Find auth flow entry points";
 		const prompt = buildGremlinPrompt({
 			parentSystemPrompt,
 			rawMarkdown,
+			intent,
 			context,
 		});
 		const config = buildGremlinSessionConfig({
@@ -37,11 +39,15 @@ describe("gremlin session factory v1 contract", () => {
 					tools: ["read", "grep"],
 				},
 			},
+			intent,
 			context,
 		});
 
 		expect(prompt).toContain(parentSystemPrompt);
 		expect(prompt).toContain(rawMarkdown);
+		expect(prompt).toContain("Caller intent:");
+		expect(prompt).toContain(intent);
+		expect(prompt).toContain("Caller context:");
 		expect(prompt).toContain(context);
 		expect(config).toMatchObject({
 			systemPrompt: parentSystemPrompt,
@@ -129,6 +135,7 @@ describe("gremlin session factory v1 contract", () => {
 					rawMarkdown: "---\nname: reviewer\nmodel: openai/missing\n---\nReview work",
 					frontmatter: { model: "openai/missing" },
 				},
+				intent: "Check model routing before session creation",
 				context: "Review diff",
 				modelRegistry,
 			}),
@@ -153,6 +160,7 @@ describe("gremlin session factory v1 contract", () => {
 				rawMarkdown: "---\nname: reviewer\n---\nReview work",
 				frontmatter: {},
 			},
+			intent: "Verify no subprocess path is used",
 			context: "Review diff",
 		});
 

--- a/extensions/pi-gremlins/gremlin-session-factory.ts
+++ b/extensions/pi-gremlins/gremlin-session-factory.ts
@@ -26,6 +26,7 @@ export interface BuildGremlinSessionConfigOptions {
 	parentModel?: string | Model<any>;
 	parentThinking?: ThinkingLevel;
 	gremlin: Pick<GremlinDefinition, "name" | "source" | "rawMarkdown" | "frontmatter">;
+	intent: string;
 	context: string;
 	cwd?: string;
 	modelRegistry?: ModelRegistry;
@@ -150,6 +151,7 @@ export function buildGremlinSessionConfig({
 	parentModel,
 	parentThinking,
 	gremlin,
+	intent,
 	context,
 	cwd,
 	modelRegistry,
@@ -171,6 +173,7 @@ export function buildGremlinSessionConfig({
 		prompt: buildGremlinPrompt({
 			parentSystemPrompt,
 			rawMarkdown: gremlin.rawMarkdown,
+			intent,
 			context,
 		}),
 		model: resolvedModel.label,

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -103,7 +103,7 @@ describe("pi-gremlins index execute v1", () => {
 		const ctx = createExecutionContext(workspace.repoRoot);
 		const result = await tool.execute(
 			"run-known-gremlin",
-			{ gremlins: [{ agent: "researcher", context: "Find auth flow" }] },
+			{ gremlins: [{ intent: "Map auth behavior before parent edits", agent: "researcher", context: "Find auth flow" }] },
 			undefined,
 			(update) => updates.push(update),
 			ctx,
@@ -162,7 +162,7 @@ describe("pi-gremlins index execute v1", () => {
 		const ctx = createExecutionContext(workspace.repoRoot);
 		await tool.execute(
 			"run-known-gremlin-tool-visibility",
-			{ gremlins: [{ agent: "researcher", context: "Find auth flow" }] },
+			{ gremlins: [{ intent: "Map auth behavior before parent edits", agent: "researcher", context: "Find auth flow" }] },
 			undefined,
 			(update) => updates.push(update),
 			ctx,
@@ -175,7 +175,7 @@ describe("pi-gremlins index execute v1", () => {
 		expect(toolPhaseUpdate.content[0].text).toContain("read apps/web/src/main.ts");
 	});
 
-	test("returns structured failures for empty agent context and invalid cwd", async () => {
+	test("returns structured failures for empty intent agent context and invalid cwd", async () => {
 		const workspace = createWorkspace();
 		setMockAgentDir(workspace.userRoot);
 		const { tool } = createExtensionHarness();
@@ -185,9 +185,11 @@ describe("pi-gremlins index execute v1", () => {
 			"invalid-gremlins",
 			{
 				gremlins: [
-					{ agent: " ", context: "Do work" },
-					{ agent: "researcher", context: " " },
+					{ intent: " ", agent: "researcher", context: "Do work" },
+					{ intent: "Validate agent name", agent: " ", context: "Do work" },
+					{ intent: "Validate context", agent: "researcher", context: " " },
 					{
+						intent: "Validate cwd",
 						agent: "researcher",
 						context: "Do work",
 						cwd: path.join(workspace.root, "missing"),
@@ -201,6 +203,10 @@ describe("pi-gremlins index execute v1", () => {
 
 		expect(result.isError).toBe(true);
 		expect(result.details.gremlins).toEqual([
+			expect.objectContaining({
+				status: "failed",
+				errorMessage: "Gremlin intent is required",
+			}),
 			expect.objectContaining({
 				status: "failed",
 				errorMessage: "Gremlin agent is required",
@@ -245,7 +251,7 @@ describe("pi-gremlins index execute v1", () => {
 			"relative-cwd",
 			{
 				gremlins: [
-					{ agent: "researcher", context: "Find auth flow", cwd: "child" },
+					{ intent: "Run auth research from child workspace", agent: "researcher", context: "Find auth flow", cwd: "child" },
 				],
 			},
 			undefined,
@@ -266,7 +272,7 @@ describe("pi-gremlins index execute v1", () => {
 
 		const result = await tool.execute(
 			"unknown-gremlin",
-			{ gremlins: [{ agent: "missing", context: "Do work" }] },
+			{ gremlins: [{ intent: "Verify missing gremlin handling", agent: "missing", context: "Do work" }] },
 			undefined,
 			undefined,
 			ctx,
@@ -297,7 +303,7 @@ describe("pi-gremlins index execute v1", () => {
 		const ctx = createExecutionContext(workspace.repoRoot);
 		const result = await tool.execute(
 			"unresolved-model",
-			{ gremlins: [{ agent: "researcher", context: "Find auth flow" }] },
+			{ gremlins: [{ intent: "Map auth behavior before parent edits", agent: "researcher", context: "Find auth flow" }] },
 			undefined,
 			undefined,
 			ctx,

--- a/extensions/pi-gremlins/index.render.test.js
+++ b/extensions/pi-gremlins/index.render.test.js
@@ -12,8 +12,8 @@ describe("pi-gremlins index render v1", () => {
 		expect(
 			tool.renderCall({
 				gremlins: [
-					{ agent: "researcher", context: "Find auth flow" },
-					{ agent: "reviewer", context: "Review auth flow" },
+					{ intent: "Map auth behavior before parent edits", agent: "researcher", context: "Find auth flow" },
+					{ intent: "Review auth findings independently", agent: "reviewer", context: "Review auth flow" },
 				],
 			}).text,
 		).toBe("🕯️🔥🕯️ Summoning the gremlins: researcher, reviewer");
@@ -44,6 +44,7 @@ describe("pi-gremlins index render v1", () => {
 					{
 						gremlinId: "g1",
 						agent: "researcher",
+						intent: "Map auth behavior before parent edits",
 						source: "project",
 						status: "active",
 						context: "Find auth flow",
@@ -54,6 +55,7 @@ describe("pi-gremlins index render v1", () => {
 					{
 						gremlinId: "g2",
 						agent: "reviewer",
+						intent: "Review auth findings independently",
 						source: "user",
 						status: "completed",
 						context: "Review auth flow",
@@ -75,6 +77,7 @@ describe("pi-gremlins index render v1", () => {
 
 		expect(collapsed).toContain("Gremlins🧌 · requested:2 · active:1 · completed:1");
 		expect(collapsed).toContain("[Active] · g1 researcher [project]");
+		expect(collapsed).toContain("intent · Map auth behavior before parent edits");
 		expect(collapsed).toContain("task · Find auth flow");
 		expect(collapsed).toContain("latest · tool:read · Scanning route handlers");
 		expect(collapsed).toContain("tool call · settling · read apps/web/src/main.ts");
@@ -85,6 +88,7 @@ describe("pi-gremlins index render v1", () => {
 		expect(collapsed).not.toContain("popup");
 
 		expect(expanded).toContain("[Completed] g2 reviewer [user]");
+		expect(expanded).toContain("intent · Review auth findings independently");
 		expect(expanded).toContain("task · Review auth flow");
 		expect(expanded).toContain("tool call · read apps/web/src/main.ts");
 		expect(expanded).toContain("usage · turns:2 · input:20 · output:8");

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -31,7 +31,11 @@ const BRAND_NAME = "Gremlins🧌";
 const TOOL_NAME = "pi-gremlins";
 const TOOL_DESCRIPTION = [
 	"Summon specialized gremlins with isolated context.",
-	"Input uses gremlins: [{ agent, context, cwd? }].",
+	"Input uses gremlins: [{ intent, agent, context, cwd? }].",
+	"intent is required: concise delegation rationale or desired outcome.",
+	"context is required: task details, constraints, paths, findings, and requested output.",
+	"Example intent: Get independent architecture read before editing runtime code.",
+	"Example context: Inspect extensions/pi-gremlins scheduler and runner flow; report risks and exact files to change.",
 	"One gremlin runs single invocation. Multiple gremlins start in parallel.",
 	"Gremlin definitions load from user and nearest project directories when agent_type is sub-agent.",
 	"Progress stays inline and expands with Ctrl+O.",
@@ -72,6 +76,7 @@ function resolveGremlinCwd(
 }
 
 function validateGremlinRequest(request: GremlinRequest): string | null {
+	if (!request.intent?.trim()) return "Gremlin intent is required";
 	if (!request.agent?.trim()) return "Gremlin agent is required";
 	if (!request.context?.trim()) return "Gremlin context is required";
 	if (!request.cwd) return null;
@@ -92,6 +97,7 @@ function createFailedGremlinResult(
 ) {
 	return {
 		gremlinId,
+		intent: request.intent ?? "",
 		agent: request.agent,
 		source: "unknown" as const,
 		status: "failed" as const,
@@ -158,7 +164,7 @@ export default function registerPiGremlins(pi: ExtensionAPI) {
 					content: [
 						{
 							type: "text",
-							text: "Invalid parameters. Provide gremlins: [{ agent, context, cwd? }, ...].",
+							text: "Invalid parameters. Provide gremlins: [{ intent, agent, context, cwd? }, ...].",
 						},
 					],
 					isError: true,


### PR DESCRIPTION
## Summary
- Require per-gremlin `intent` in the public `pi-gremlins` request schema
- Pass caller intent into child prompt framing separately from caller context
- Surface intent in inline/expanded render details and update README, PRD/ADR, plan, and changelog contract docs

## Verification
- `npm run check`

Closes #35