### PR TITLE
Merge primary-agent selection into pi-gremlins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Primary-agent selection and pi-mohawk deprecation path** (PRD-0003, ADR-0003, issue #39): `pi-gremlins` now includes primary-agent discovery, `/mohawk` selection, `Ctrl+Shift+M` cycling, session-scoped state, status UX, and `before_agent_start` prompt injection previously owned by `pi-mohawk`.
 - **V1 SDK rewrite** (PRD-0002, ADR-0002): `pi-gremlins` now runs gremlins through isolated in-process Pi SDK child sessions instead of nested Pi CLI subprocesses.
 - Public tool contract now exposes one invocation shape only: `gremlins: [{ intent, agent, context, cwd? }]` with `1..10` requests and parallel start for multi-gremlin runs; `intent`, `agent`, and `context` are required non-empty strings.
 - Discovery now loads only markdown agent files with `agent_type: sub-agent` from `~/.pi/agent/agents` plus nearest project `.pi/agents`, with typed project definitions overriding same-name typed user definitions.
@@ -22,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened gremlin runtime reliability around child-session cleanup, abort handling, discovery file failures, request validation, CRLF gremlin frontmatter parsing, unresolved model selection, and parent-abort progress updates.
 
 ### Added
+- Shared role-aware agent parsing/discovery modules now load `agent_type: sub-agent` gremlins and `agent_type: primary` primary agents from user/project agent directories while preserving strict role separation and project-over-user precedence.
+- Primary-agent state and prompt helpers persist new selections as `pi-gremlins-primary-agent`, read legacy `pi-mohawk-primary-agent` entries for migration, and strip legacy prompt blocks before appending the selected primary markdown.
 - New v1 runtime modules under `extensions/pi-gremlins/`: schema, definition parsing, discovery cache, prompt builder, isolated session factory, runner, scheduler, progress store, summary builder, and inline renderer.
 - Child prompt framing now separates caller intent from caller context so gremlins see delegation rationale apart from task details.
 - Focused v1 contract coverage for schema, discovery, session isolation, runner projection, scheduler cancellation, rendering, and entry-point execution.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Gizmo](docs/gremlins.png)
 # Gremlins🧌 (`pi-gremlins`)
 
-Pi package. Adds `Gremlins🧌` user-facing tool branding for summoning specialized workers through isolated in-process Pi SDK child sessions.
+Pi package. Adds `Gremlins🧌` user-facing tool branding for summoning specialized workers through isolated in-process Pi SDK child sessions, plus primary-agent selection formerly provided by `pi-mohawk`.
 
 Suggested GitHub About text:
 
@@ -9,7 +9,7 @@ Suggested GitHub About text:
 
 ## What tool does
 
-`Gremlins🧌` runs one or more gremlins with isolated child-session context.
+`Gremlins🧌` runs one or more gremlins with isolated child-session context. Primary-agent controls select one parent-session agent role and inject its raw markdown into the parent system prompt before each turn.
 
 V1 contract:
 
@@ -26,12 +26,18 @@ V1 contract:
 - no scope toggles
 - inline progress only, expand with `Ctrl+O`
 
-Gremlin definitions load from:
+Agent definitions load from:
 
 - `~/.pi/agent/agents`
 - nearest project `.pi/agents`
 
-Only markdown files with `agent_type: sub-agent` frontmatter are loaded as gremlins. Untyped files and other agent types, such as `agent_type: primary`, are ignored.
+Roles stay separated by frontmatter:
+
+- `agent_type: sub-agent` files are gremlins that the `pi-gremlins` tool can summon.
+- `agent_type: primary` files are parent-session primary agents selected through `/mohawk` or `Ctrl+Shift+M`.
+- untyped files and other agent types are ignored.
+
+Gremlin example:
 
 ```yaml
 ---
@@ -41,7 +47,17 @@ agent_type: sub-agent
 ---
 ```
 
-If user and project define same gremlin name, project version wins among discovered sub-agent definitions.
+Primary-agent example:
+
+```yaml
+---
+name: Orchestrator
+description: Parent-session role
+agent_type: primary
+---
+```
+
+If user and project define same display name for the same role, nearest project version wins. Primary-agent display names fall back from frontmatter `name`, to first H1, to filename stem.
 
 Important: UI label may show `Gremlins🧌` for human-facing branding. Actual package/runtime/tool identifier stays `pi-gremlins` for install and invocation wiring.
 
@@ -134,6 +150,39 @@ Runtime behavior:
 - collapsed tool row shows source, status, phase, and latest activity
 - expanded tool row shows intent, task, cwd, model, thinking, latest text/tool data, usage, and errors
 
+## Primary agents
+
+Primary-agent support replaces the separate `pi-mohawk` extension inside `pi-gremlins`.
+
+Controls:
+
+- `/mohawk` opens a picker when UI exists.
+- `/mohawk` without UI writes `Primary agents: None, ...` into the transcript.
+- `/mohawk <name>` selects exact or single case-insensitive primary-agent match.
+- `/mohawk none` clears selection.
+- `Ctrl+Shift+M` cycles deterministically through `[None, ...sorted primary agents]`.
+- status key is `pi-gremlins-primary`; visible label is `Primary: <name|None>`.
+
+Session behavior:
+
+- selection is current-session branch state, not global config.
+- new entries are persisted as `pi-gremlins-primary-agent` with selected name, source, and file path only.
+- legacy `pi-mohawk-primary-agent` entries are read for migration; new writes use `pi-gremlins-primary-agent`.
+- raw primary-agent markdown is never stored in session entries.
+- missing selected primary agent resets to `None` and warns instead of injecting stale markdown.
+
+Prompt behavior:
+
+- selected primary-agent raw markdown is appended during `before_agent_start` inside `<!-- pi-gremlins primary agent:start -->` / `<!-- pi-gremlins primary agent:end -->`.
+- existing `pi-gremlins` and legacy `pi-mohawk` primary-agent blocks are stripped before appending to avoid duplicate injection.
+- `agent_type: sub-agent` gremlins are never injected as primary agents.
+
+Migration from `pi-mohawk`:
+
+- install updated `pi-gremlins` and use existing `/mohawk` / `Ctrl+Shift+M` controls.
+- after confirming primary-agent behavior works in `pi-gremlins`, disable or uninstall `pi-mohawk` to avoid duplicate command, shortcut, status, or prompt-hook behavior.
+- keep agent markdown in same user/project directories; no schema rename needed for `agent_type: primary`.
+
 ## Repo layout
 
 ```text
@@ -141,8 +190,13 @@ Runtime behavior:
 ├── extensions/pi-gremlins/
 │   ├── index.ts
 │   ├── gremlin-schema.ts
+│   ├── agent-definition.ts
 │   ├── gremlin-definition.ts
+│   ├── primary-agent-definition.ts
 │   ├── gremlin-discovery.ts
+│   ├── primary-agent-state.ts
+│   ├── primary-agent-controls.ts
+│   ├── primary-agent-prompt.ts
 │   ├── gremlin-prompt.ts
 │   ├── gremlin-session-factory.ts
 │   ├── gremlin-runner.ts

--- a/docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md
+++ b/docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md
@@ -1,0 +1,147 @@
+# ADR-0003: Unified Agent Discovery and Primary-Agent Prompt Injection in pi-gremlins
+
+- **Status:** Accepted
+- **Date:** 2026-04-25
+- **Decision Maker:** Magi Metal
+- **Related:** `extensions/pi-gremlins`, GitHub issue [#39](https://github.com/magimetal/pi-gremlins/issues/39), `docs/adr/0002-in-process-sdk-based-gremlin-runtime.md` (ADR-0002)
+- **Supersedes:** N/A
+
+## Context
+
+GitHub issue #39 proposes deprecating the separate `pi-mohawk` package by moving its primary-agent selection and prompt-injection behavior into `pi-gremlins`.
+
+Current package boundary:
+
+- `pi-gremlins` owns gremlin sub-agent delegation through the `pi-gremlins` tool, in-process SDK child sessions, isolated child prompt construction, and inline progress rendering.
+- `pi-mohawk` owns primary-agent discovery, selected primary-agent session state, `/mohawk` controls, status labeling, shortcut cycling, and `before_agent_start` system-prompt injection.
+
+Both packages inspect the same agent directories and parse similar markdown frontmatter, but they apply different role filters:
+
+- gremlins use `agent_type: sub-agent`;
+- primary agents use `agent_type: primary`.
+
+Keeping these behaviors split forces users to install and reason about two packages for one agent-orchestration workflow. Merging primary-agent behavior into `pi-gremlins` changes the extension/package boundary and adds a parent-session prompt mutation path beside existing gremlin child-session delegation, so the architecture decision needs to be explicit before implementation.
+
+ADR-0002 remains in force: gremlin execution stays in-process through SDK child sessions and must not reintroduce nested Pi CLI subprocess runtime, popup viewer surfaces, chain mode, targeted steering, package gremlin discovery, or scope toggles.
+
+## Decision Drivers
+
+- Package clarity: users should install one package, `pi-gremlins`, for primary-agent selection and gremlin delegation.
+- Runtime cohesion: primary-agent prompt mutation and gremlin child-session delegation both shape agent orchestration and should live in one extension entrypoint.
+- Discovery correctness: shared filesystem/frontmatter parsing should not blur `primary` and `sub-agent` roles.
+- Migration safety: existing `pi-mohawk` users need a compatibility path without preserving `pi-mohawk` as the long-term machine-facing package identity.
+- Session privacy: selected primary-agent state must persist only minimal identity, not raw markdown prompt content.
+- Compatibility containment: deprecated command/status affordances can exist as aliases, but new persisted state and internal keys should use `pi-gremlins` identity.
+- ADR-0002 compatibility: merged primary-agent behavior must not change the gremlin tool schema or child-session runtime architecture.
+
+## Options Considered
+
+### Option A: Keep `pi-mohawk` as a separate package
+
+- Pros:
+  - No migration work inside `pi-gremlins`.
+  - Existing `pi-mohawk` users keep current package, command, shortcut, and status behavior.
+  - Primary-agent prompt injection remains isolated from gremlin delegation code.
+- Cons:
+  - Users must install two packages for one orchestration experience.
+  - Agent markdown discovery and frontmatter parsing remain duplicated.
+  - Dual extension state increases command/status/hook conflict risk.
+  - `pi-gremlins` remains artificially limited to sub-agent delegation even though parent prompt selection is part of the same workflow.
+
+### Option B: Move `pi-mohawk` behavior into `pi-gremlins` but keep separate internals and legacy identity
+
+- Pros:
+  - Reduces package count for users.
+  - Preserves current `/mohawk` mental model with low behavior change.
+  - Faster port if code is copied with minimal adaptation.
+- Cons:
+  - Keeps duplicated discovery/parsing code inside one package.
+  - Preserves deprecated `pi-mohawk` identity in new session entries and internal status keys.
+  - Makes future maintenance harder because primary and sub-agent discovery can drift.
+  - Obscures that `pi-gremlins` is the surviving install/runtime identity.
+
+### Option C: Merge primary-agent support into `pi-gremlins` with shared role-aware discovery and `pi-gremlins`-owned state
+
+- Pros:
+  - Gives users one surviving package and one extension entrypoint.
+  - Shares agent markdown parsing, directory scanning, precedence, and cache invalidation.
+  - Keeps strict role separation: `primary` agents cannot be summoned as gremlins, and `sub-agent` gremlins cannot be injected as primary agents.
+  - Allows legacy `/mohawk` and shortcut compatibility while writing new state under `pi-gremlins` identity.
+  - Keeps ADR-0002 gremlin runtime intact while adding only the needed parent prompt hook.
+- Cons:
+  - Adds more responsibility to the `pi-gremlins` extension entrypoint and test matrix.
+  - Requires careful compatibility handling when both old `pi-mohawk` and new `pi-gremlins` are installed.
+  - Requires porting `pi-mohawk` test coverage into Bun conventions.
+
+## Decision
+
+Chosen: **Option C: Merge primary-agent support into `pi-gremlins` with shared role-aware discovery and `pi-gremlins`-owned state**.
+
+Rationale: issue #39 is a package-boundary correction, not just a code move. `pi-gremlins` becomes the single install/runtime package for agent orchestration, while `pi-mohawk` becomes deprecated after equivalent primary-agent behavior ships. The merged implementation should share discovery infrastructure across both agent roles, keep role filters strict, and preserve user-facing compatibility where it lowers migration risk.
+
+The implementation must follow these architectural constraints:
+
+- Keep the extension entrypoint at `./extensions/pi-gremlins`.
+- Register primary-agent controls and `before_agent_start` prompt injection from the `pi-gremlins` extension, beside the existing `pi-gremlins` tool registration.
+- Introduce shared markdown parsing/discovery infrastructure that accepts an explicit role filter and never loads untyped markdown into either role.
+- Preserve existing gremlin tool contract; do not add primary-agent selection to the `pi-gremlins` tool schema.
+- Persist new primary-agent selection entries as `pi-gremlins-primary-agent`.
+- During transition, read the latest valid current-branch selection from either `pi-gremlins-primary-agent` or legacy `pi-mohawk-primary-agent`, but write only `pi-gremlins-primary-agent` after any selection change.
+- Persist minimal selected identity only: selected name, source, and path. Do not persist raw markdown.
+- Keep `/mohawk`, `/mohawk <name>`, `/mohawk none`, and `ctrl+shift+m` as compatibility controls unless implementation discovers a hard Pi conflict.
+- Use a `pi-gremlins`-owned status key such as `pi-gremlins-primary`; keep the human-facing label `Primary: <name|None>`.
+- Delimit injected primary-agent markdown with `<!-- pi-gremlins primary agent:start -->` and `<!-- pi-gremlins primary agent:end -->`.
+- Strip any existing `pi-gremlins` primary-agent block before appending a new one to avoid duplicate injection. Also strip legacy `pi-mohawk` primary-agent blocks during migration to prevent double injection when old prompt content is present.
+
+## Consequences
+
+- **Positive:**
+  - `pi-gremlins` becomes the single package that users install for gremlin delegation and primary-agent selection.
+  - Shared discovery reduces duplicated filesystem/frontmatter behavior and keeps precedence policy consistent.
+  - Deprecated `pi-mohawk` session entries can be honored during transition without continuing to write old package identity.
+  - Parent prompt injection becomes explicit architecture in the surviving extension instead of an implicit cross-package side effect.
+  - Existing gremlin v1 runtime and tool schema remain stable.
+- **Negative:**
+  - `pi-gremlins` extension startup, session lifecycle, and tests become broader.
+  - If users run both packages simultaneously, command, shortcut, status, and prompt-hook conflicts are possible until deprecation docs tell them to disable or uninstall `pi-mohawk` after migration.
+  - Compatibility aliases keep the `mohawk` name visible in controls during migration.
+- **Follow-on constraints:**
+  - Future changes to primary-agent persisted state or prompt-injection delimiters require ADR review because they affect session compatibility and runtime prompt composition.
+  - Any future removal of `/mohawk` compatibility controls must be treated as a user-facing product decision, not hidden cleanup.
+  - Shared discovery must continue to enforce role separation and must not use primary-agent markdown as gremlin prompt material or gremlin markdown as primary-agent prompt material.
+
+## Implementation Impact
+
+- **apps/api:** N/A. Standalone Pi package, no `apps/api` workspace.
+- **apps/web:** N/A. No web frontend package.
+- **packages/shared:** N/A. No shared package contract change.
+- **packages/utils:** N/A. No standalone utils package in this repository.
+- **Migration/ops:**
+  - `pi-gremlins` remains the install/runtime package identity and extension entrypoint.
+  - `pi-mohawk` can be deprecated after `pi-gremlins` ships equivalent primary-agent selection, prompt injection, command, shortcut, and status behavior.
+  - Existing current-branch `pi-mohawk-primary-agent` entries are read as legacy input during transition, but new writes use `pi-gremlins-primary-agent` only.
+  - Documentation must warn that running both old `pi-mohawk` and new `pi-gremlins` can duplicate controls or prompt injection.
+
+## Verification
+
+- **Automated:**
+  - Focused Bun tests for shared agent definition parsing and strict `agent_type` role filtering.
+  - Focused Bun tests for primary-agent discovery precedence, symlink policy, exact/case-insensitive selection, ambiguous match rejection, and cache invalidation.
+  - Focused Bun tests for session state reconstruction from `pi-gremlins-primary-agent` and legacy `pi-mohawk-primary-agent` entries, with writes only to `pi-gremlins-primary-agent`.
+  - Focused Bun tests for `/mohawk` command behavior, `ctrl+shift+m` cycling, no-UI fallback messaging, and `Primary: <name|None>` status updates.
+  - Focused Bun tests for `before_agent_start` injection, duplicate block stripping, legacy block stripping, missing selected-agent reset, and no prompt mutation when selection is `None`.
+  - Full repository verification after implementation: `npm run typecheck`, `npm test`, and `npm run check`.
+- **Manual:**
+  - Install updated `pi-gremlins`, select a primary agent, send a prompt, and confirm selected primary markdown affects the parent agent.
+  - Run one or more gremlins while a primary agent is selected and confirm existing `pi-gremlins` tool behavior remains unchanged.
+  - Confirm migration docs tell users when to disable or uninstall `pi-mohawk`.
+
+## Notes
+
+This ADR does not add external dependencies. It records package and runtime boundary choices for issue #39 before implementation.
+
+ADR-0002 still governs gremlin execution architecture. If implementation pressure suggests restoring nested Pi subprocess execution, popup viewers, chain mode, targeted steering, package gremlin discovery, or scope toggles, stop and write a new ADR instead of folding those changes into issue #39.
+
+## Status History
+
+- 2026-04-25: Accepted; records issue #39 package-boundary decision to merge primary-agent selection and prompt injection into `pi-gremlins` while deprecating separate `pi-mohawk` package after equivalent behavior ships

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,3 +67,4 @@ Reference ADR IDs in changelog entries for significant changes:
 | 0000 | Template                                                         | Accepted | 2026-04-21 |
 | 0001 | Semantic Presentation Architecture for Pi Gremlins Viewer and Embedded Surfaces | Superseded by ADR-0002 | 2026-04-21 |
 | 0002 | In-Process SDK-Based Gremlin Runtime                             | Accepted | 2026-04-22 |
+| 0003 | Unified Agent Discovery and Primary-Agent Prompt Injection in pi-gremlins | Accepted | 2026-04-25 |

--- a/docs/plans/issue-39-fix.md
+++ b/docs/plans/issue-39-fix.md
@@ -1,0 +1,436 @@
+# Issue 39 Fix Plan: Merge Primary-Agent Selection into pi-gremlins
+
+## Objective
+
+Fix GitHub issue [#39](https://github.com/magimetal/pi-gremlins/issues/39) by moving `pi-mohawk` primary-agent discovery, selection, session state, status, shortcut, and prompt injection into `pi-gremlins`, then document the migration/deprecation path and open a PR with `Closes #39`.
+
+## Governance Inputs
+
+- PRD: `docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md` (`Draft` at planning time)
+- ADR: `docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md` (`Accepted`)
+- Prior architecture still binding: `docs/adr/0002-in-process-sdk-based-gremlin-runtime.md`
+- Issue source: `gh issue view 39`
+- Pi extension docs consulted for implementation constraints:
+  - `/Users/magimetal/.nvm/versions/node/v24.14.0/lib/node_modules/@mariozechner/pi-coding-agent/docs/extensions.md`
+  - `/Users/magimetal/.nvm/versions/node/v24.14.0/lib/node_modules/@mariozechner/pi-coding-agent/docs/session.md`
+  - `/Users/magimetal/.nvm/versions/node/v24.14.0/lib/node_modules/@mariozechner/pi-coding-agent/docs/keybindings.md`
+  - `/Users/magimetal/.nvm/versions/node/v24.14.0/lib/node_modules/@mariozechner/pi-coding-agent/docs/tui.md`
+
+## Key Decisions To Enforce
+
+- Keep package, extension entrypoint, tool name, and schema identity as `pi-gremlins`.
+- Do not change public gremlin schema: `gremlins: [{ agent, context, cwd? }]`.
+- Add primary-agent support beside existing gremlin delegation, not through the tool schema.
+- Use shared role-aware markdown parsing/discovery for `agent_type: primary` and `agent_type: sub-agent`.
+- Persist new primary selection entries as `pi-gremlins-primary-agent`.
+- Read legacy `pi-mohawk-primary-agent` entries during transition; write only `pi-gremlins-primary-agent`.
+- Persist only selected identity: name, source, path. Never persist raw markdown.
+- Keep `/mohawk`, `/mohawk <name>`, `/mohawk none`, and `ctrl+shift+m` as compatibility controls unless a hard Pi conflict appears.
+- Use status key `pi-gremlins-primary` and visible label `Primary: <name|None>`.
+- Delimit injected primary-agent markdown with:
+  - `<!-- pi-gremlins primary agent:start -->`
+  - `<!-- pi-gremlins primary agent:end -->`
+- Strip existing `pi-gremlins` and legacy `pi-mohawk` prompt blocks before appending new primary block.
+- Do not reintroduce nested Pi CLI subprocess runtime, chain mode, popup viewer, package discovery, steering, or scope toggles.
+
+## Assumptions
+
+- `pi-mohawk` source remains available at `/Users/magimetal/Dev/pi/pi-mohawk` for reference and test porting.
+- Current repo verification commands are authoritative from `package.json`: `npm run typecheck`, `npm test`, `npm run check`.
+- `pi.registerCommand`, `pi.registerShortcut`, `ctx.ui.setStatus`, `pi.appendEntry`, `ctx.sessionManager.getBranch()`, and `before_agent_start` are available from Pi extension API.
+- PRD-0003 must move from `Draft` to `Active` before runtime implementation begins.
+
+## Implementation Tasks
+
+### 1. Activate PRD scope before code
+
+**What**
+
+- Update `docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md` status from `Draft` to `Active`.
+- Update `docs/prd/README.md` index status for PRD-0003 from `Draft` to `Active`.
+- Cross-link PRD to ADR-0003 if current text still says the ADR is pending.
+
+**References**
+
+- `docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md`
+- `docs/prd/README.md`
+- `docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md`
+
+**Acceptance criteria**
+
+- PRD-0003 status is `Active`.
+- PRD README index shows PRD-0003 as `Active`.
+- PRD metadata or Technical Surface references ADR-0003 by path or number, not “pending ADR”.
+
+**Guardrails**
+
+- Do not change PRD scope beyond aligning status and ADR link.
+- Do not mark PRD completed until implementation and review pass.
+
+**Verification**
+
+- Read back PRD and PRD README.
+
+### 2. Introduce shared agent definition parsing
+
+**What**
+
+- Extract role-neutral markdown parsing from `gremlin-definition.ts` into a shared helper, for example `extensions/pi-gremlins/agent-definition.ts`.
+- Support role-specific loaders:
+  - gremlin/sub-agent loader keeps `agent_type: sub-agent` and requires frontmatter `name` as current behavior requires.
+  - primary-agent loader accepts only `agent_type: primary` and derives display name from frontmatter `name`, first H1, then filename stem.
+- Preserve raw markdown on loaded definitions for later prompt injection.
+- Preserve parsed gremlin frontmatter behavior for `description`, `model`, `thinking`, `tools`, and `body`.
+
+**References**
+
+- `extensions/pi-gremlins/gremlin-definition.ts`
+- new `extensions/pi-gremlins/agent-definition.ts` if extracted
+- possible new `extensions/pi-gremlins/primary-agent-definition.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/extensions/agent-definition.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/tests/agent-definition.test.ts`
+
+**Acceptance criteria**
+
+- Existing gremlin parsing output remains compatible for current callers.
+- Untyped markdown returns `null` for both roles.
+- `agent_type: primary` never parses as gremlin.
+- `agent_type: sub-agent` never parses as primary.
+- Primary display-name fallback order matches PRD: `name`, first H1, filename stem.
+- Raw markdown is available on primary definitions but is not persisted.
+
+**Guardrails**
+
+- Do not accept legacy role aliases such as `sub` or untyped markdown.
+- Do not remove current `GremlinDefinition` fields used by runner/session-factory code.
+- Do not use `as any`, `@ts-ignore`, or `@ts-expect-error` to hide typing issues.
+
+**Verification**
+
+- Add/port Bun tests for gremlin parsing stability, primary parsing, fallback names, malformed frontmatter, and role crossover rejection.
+- Focused command during implementation: `bun test extensions/pi-gremlins/*definition*.test.js`.
+
+### 3. Unify agent directory discovery by role
+
+**What**
+
+- Refactor `gremlin-discovery.ts` scanning/fingerprinting into shared role-aware discovery utilities.
+- Keep `createGremlinDiscoveryCache()` as existing gremlin-facing API.
+- Add primary discovery API, for example `createPrimaryAgentDiscoveryCache()`.
+- Support user agents directory from `path.join(getAgentDir(), "agents")` and nearest project `.pi/agents`.
+- Preserve current project-over-user precedence by display name.
+- Add primary-agent name resolution that distinguishes exact match, single case-insensitive match, ambiguous case-insensitive matches, and not-found.
+
+**References**
+
+- `extensions/pi-gremlins/gremlin-discovery.ts`
+- `extensions/pi-gremlins/gremlin-discovery.test.js`
+- possible new `extensions/pi-gremlins/agent-discovery.ts`
+- possible new `extensions/pi-gremlins/primary-agent-discovery.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/extensions/agent-discovery.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/tests/agent-discovery.test.ts`
+
+**Acceptance criteria**
+
+- Gremlin discovery still returns only `agent_type: sub-agent` definitions.
+- Primary discovery returns only `agent_type: primary` definitions.
+- Project definition wins over user definition with the same display name.
+- Sorted order is deterministic and used by shortcut cycling.
+- Primary resolution reports ambiguity without changing state.
+- Cache invalidation still responds to directory/file mtime changes and session lifecycle clears.
+- Primary symlink behavior follows ADR/PRD final decision; if preserving current gremlin symlink support, document role-specific behavior in tests.
+
+**Guardrails**
+
+- Do not expose primary agents through `resolveGremlinByName`.
+- Do not make gremlin discovery more permissive while extracting shared utilities.
+- Do not change `pi-gremlins` tool parameters or result shape.
+
+**Verification**
+
+- Port/adapt discovery tests from pi-mohawk into Bun.
+- Run focused discovery tests: `bun test extensions/pi-gremlins/gremlin-discovery.test.js extensions/pi-gremlins/*primary*discovery*.test.js`.
+
+### 4. Add primary-agent session state
+
+**What**
+
+- Add a primary-agent state module, for example `extensions/pi-gremlins/primary-agent-state.ts`.
+- On `session_start`, reconstruct selected state from `ctx.sessionManager.getBranch()`.
+- Read latest valid current-branch custom entry from either:
+  - `pi-gremlins-primary-agent`
+  - legacy `pi-mohawk-primary-agent`
+- On any new selection/change, persist with `pi-gremlins-primary-agent` only.
+- Store `None` explicitly so clearing survives branch reconstruction.
+- Store minimal identity: selected name, source, file path. Do not store raw markdown.
+
+**References**
+
+- `extensions/pi-gremlins/index.ts`
+- new `extensions/pi-gremlins/primary-agent-state.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/extensions/session-state.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/tests/session-state.test.ts`
+- Pi session docs: `docs/session.md` in pi package
+
+**Acceptance criteria**
+
+- Latest current-branch state wins.
+- Explicit `None` reconstructs as no selected primary agent.
+- Legacy `pi-mohawk-primary-agent` entry can initialize state.
+- New writes always use `pi-gremlins-primary-agent`.
+- Raw markdown never appears in persisted custom entry data.
+- Missing selected agent can be detected later and reset to `None`.
+
+**Guardrails**
+
+- Do not read abandoned branches via `getEntries()` when branch-specific state is required.
+- Do not persist prompt content or whole frontmatter objects.
+- Do not leak selection across unrelated new sessions.
+
+**Verification**
+
+- Port session-state tests to Bun.
+- Add tests for current-branch precedence, explicit `None`, legacy read, new write type, and no raw markdown persistence.
+
+### 5. Add command, picker/list fallback, shortcut, and status UX
+
+**What**
+
+- In `index.ts` or extracted module, register compatibility command `/mohawk`.
+- Support:
+  - `/mohawk` -> picker when `ctx.hasUI`; transcript-visible list when no UI.
+  - `/mohawk <name>` -> exact or unambiguous case-insensitive select.
+  - `/mohawk none` -> clear selected primary.
+- Register `ctrl+shift+m` shortcut to cycle `[None, ...sorted primary agents]`.
+- Update status after session start and every selection change with key `pi-gremlins-primary` and label `Primary: <name|None>`.
+- Use `ctx.ui.select` for picker unless implementation needs a custom TUI list; include `None` as first option.
+- Use `pi.sendMessage` or UI notification path for no-UI/fallback feedback, matching Pi extension command behavior.
+
+**References**
+
+- `extensions/pi-gremlins/index.ts`
+- possible new `extensions/pi-gremlins/primary-agent-controls.ts`
+- possible new `extensions/pi-gremlins/primary-agent-status.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/extensions/pi-mohawk.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/tests/pi-mohawk-extension.test.ts`
+- Pi docs: `extensions.md`, `keybindings.md`, `tui.md`
+
+**Acceptance criteria**
+
+- Exact command selection works.
+- Single case-insensitive command selection works.
+- Ambiguous case-insensitive selection leaves current state unchanged and reports exact-case options.
+- `/mohawk none` clears and persists `None`.
+- No-args command opens picker with UI.
+- No-args command without UI emits `Primary agents: None, ...` or equivalent transcript-visible names.
+- Shortcut cycles deterministically through `[None, ...sorted primary agents]`.
+- Status displays `Primary: None` or `Primary: <name>` after startup and changes.
+
+**Guardrails**
+
+- Do not remove `pi.registerTool(tool as any)` boundary or alter existing tool registration semantics.
+- Do not overload gremlin tool invocation with primary selection.
+- Do not make `/mohawk` write stale state when discovery fails.
+
+**Verification**
+
+- Port command/shortcut/status tests into Bun.
+- Focused test command: `bun test extensions/pi-gremlins/index.*.test.js extensions/pi-gremlins/*primary*control*.test.js`.
+
+### 6. Add prompt injection hook
+
+**What**
+
+- Register `before_agent_start` handler from `pi-gremlins` extension.
+- If selected primary is `None`, return no prompt change after stripping nothing from current prompt.
+- If selected primary exists, reload/resolve current definition by identity, strip old `pi-gremlins` and legacy `pi-mohawk` primary blocks, append selected raw markdown inside `pi-gremlins` delimiters, and return `{ systemPrompt }`.
+- If selected primary no longer exists, persist `None`, update status, warn user, and leave prompt unchanged except legacy duplicate block stripping only if implementation can do so safely.
+- Keep helper functions isolated, for example `extensions/pi-gremlins/primary-agent-prompt.ts`.
+
+**References**
+
+- `extensions/pi-gremlins/index.ts`
+- `extensions/pi-gremlins/gremlin-prompt.ts` for parent system prompt snapshot context
+- possible new `extensions/pi-gremlins/primary-agent-prompt.ts`
+- `/Users/magimetal/Dev/pi/pi-mohawk/tests/prompt-injection.test.ts`
+- Pi docs `extensions.md` section `before_agent_start`
+
+**Acceptance criteria**
+
+- `None` selection leaves parent system prompt unchanged.
+- Selected primary appends raw markdown exactly once inside `pi-gremlins` delimiters.
+- Repeated injection does not duplicate blocks.
+- Legacy `pi-mohawk` blocks are stripped to prevent double injection.
+- Missing selected agent resets state to `None`, warns user, and avoids injecting stale markdown.
+- Sub-agent markdown can never enter primary injection path.
+- Existing gremlin child prompt capture through `ctx.getSystemPrompt()` remains intact.
+
+**Guardrails**
+
+- Do not mutate provider payloads directly through `before_provider_request` for this feature.
+- Do not inject raw markdown from untyped files or `agent_type: sub-agent` files.
+- Do not store injected markdown in session custom entries.
+
+**Verification**
+
+- Port prompt-injection tests to Bun.
+- Add focused test for `before_agent_start` behavior in extension-level harness.
+- Manual post-implementation check: select primary, send prompt, confirm primary behavior affects parent; summon gremlin and confirm `pi-gremlins` tool behavior still works.
+
+### 7. Update docs, changelog, and migration guidance
+
+**What**
+
+- Update `README.md` to document both roles:
+  - `agent_type: primary` controls parent-session behavior.
+  - `agent_type: sub-agent` remains gremlin delegation.
+- Document discovery roots, precedence, commands, shortcut, status label, session scope, prompt injection block behavior at user level, and migration/deprecation guidance from `pi-mohawk`.
+- Warn users not to run both `pi-mohawk` and updated `pi-gremlins` after migration because controls/hooks can conflict.
+- Update `CHANGELOG.md` under Unreleased with issue #39, PRD-0003, ADR-0003, and high-level behavior.
+- If current workflow includes editing the separate pi-mohawk repo, do it only after equivalent pi-gremlins behavior is implemented and verified; otherwise leave a follow-up note in PR body.
+
+**References**
+
+- `README.md`
+- `CHANGELOG.md`
+- `docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md`
+- `docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md`
+- `/Users/magimetal/Dev/pi/pi-mohawk/README.md` only if explicitly in implementation scope
+- `/Users/magimetal/Dev/pi/pi-mohawk/CHANGELOG.md` only if explicitly in implementation scope
+
+**Acceptance criteria**
+
+- README accurately matches implemented command names, shortcut, status key/label, role filters, and migration behavior.
+- README does not imply primary agents can be summoned as gremlins or vice versa.
+- CHANGELOG cites PRD-0003 and ADR-0003.
+- Docs preserve machine-facing `pi-gremlins` identifiers.
+- Any pi-mohawk deprecation docs happen only after pi-gremlins equivalent behavior ships.
+
+**Guardrails**
+
+- Do not tell users to uninstall `pi-mohawk` before support is in pi-gremlins.
+- Do not rebrand package/tool/schema keys to `Gremlins🧌`.
+- Do not document behavior not covered by tests or implementation.
+
+**Verification**
+
+- Read back README and CHANGELOG.
+- Search docs for command/status/delimiter strings and confirm consistency with code.
+
+### 8. Full verification and dead-code cleanup
+
+**What**
+
+- Run focused tests during phases, then full repo verification.
+- Check TypeScript, Bun tests, and combined check.
+- Remove unused imports, unused exports, obsolete helper files, and copied pi-mohawk leftovers not intentionally retained as compatibility strings.
+- Confirm no primary-agent/sub-agent role crossover.
+
+**References**
+
+- `package.json`
+- `extensions/pi-gremlins/*.ts`
+- `extensions/pi-gremlins/*.test.js`
+- `README.md`
+- `CHANGELOG.md`
+
+**Acceptance criteria**
+
+- `npm run typecheck` passes.
+- `npm test` passes.
+- `npm run check` passes.
+- Focused primary-agent tests pass.
+- No unused imports/exports/files remain from implementation.
+- `rg "agent_type: primary|agent_type: sub-agent|pi-mohawk|mohawk|pi-gremlins-primary-agent|before_agent_start" extensions README.md CHANGELOG.md docs` shows only intentional references.
+- Public gremlin contract remains unchanged.
+- PRD-0003 acceptance criteria are traceable to implementation/tests.
+
+**Guardrails**
+
+- Do not run broad formatters that churn unrelated files.
+- Do not edit generated `AGENTS.md` files.
+- Do not modify `node_modules`.
+- Do not hide verification failures; fix or report blockers.
+
+**Verification commands**
+
+```bash
+npm run typecheck
+npm test
+npm run check
+rg "agent_type: primary|agent_type: sub-agent|pi-mohawk|mohawk|pi-gremlins-primary-agent|before_agent_start" extensions README.md CHANGELOG.md docs
+```
+
+### 9. Complete PRD lifecycle and PR workflow
+
+**What**
+
+- After implementation review passes, update PRD-0003 status to `Completed` and add Revision History entry summarizing delivered behavior.
+- Update `docs/prd/README.md` PRD-0003 status to `Completed`.
+- Verify ADR-0003 still matches implementation; if implementation deviated materially, update/supersede ADR before PR.
+- Commit on current branch using existing commit style.
+- Push current branch.
+- Create GitHub PR with title referencing issue #39 and body containing `Closes #39`.
+
+**References**
+
+- `docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md`
+- `docs/prd/README.md`
+- `docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md`
+- `CHANGELOG.md`
+- `git log --oneline -5` for commit style
+- `gh pr create`
+
+**Acceptance criteria**
+
+- PRD-0003 is `Completed` only after code/docs/tests pass review.
+- ADR-0003 decision remains accurate or is updated/superseded.
+- Commit includes runtime, tests, docs, changelog, and governance updates.
+- Branch is pushed.
+- PR exists and includes `Closes #39`.
+
+**Guardrails**
+
+- Do not commit before verification evidence exists.
+- Do not mark PRD completed before implementation acceptance criteria pass.
+- Do not create PR without linking `Closes #39`.
+
+**Verification**
+
+```bash
+git status --short
+git log --oneline -5
+gh pr create --fill --body-file <prepared-body-with-Closes-39>
+```
+
+## Verification Matrix
+
+| Area | Required evidence |
+| --- | --- |
+| Definition parsing | Focused Bun tests for role filters, primary fallback names, malformed/untyped ignored |
+| Discovery | Focused Bun tests for user/project precedence, role separation, cache invalidation, primary name resolution |
+| Session state | Focused Bun tests for current branch reconstruction, legacy read, new write type, explicit None, no raw markdown persistence |
+| Command/status/shortcut | Extension-level Bun tests for `/mohawk`, no-UI fallback, picker path, `ctrl+shift+m`, `Primary: ...` |
+| Prompt injection | Bun tests for delimiter append, duplicate stripping, legacy stripping, missing selected reset, `None` no-op |
+| Existing gremlin contract | Existing `npm test`, schema tests, execute/render tests, plus no schema changes |
+| Docs | Readback README, CHANGELOG, PRD/ADR links; string consistency search |
+| Full repo | `npm run typecheck`, `npm test`, `npm run check` |
+| Dead code | No unused imports/exports/files; intentional references only from `rg` sweep |
+| GitHub workflow | Commit, push, PR with `Closes #39` |
+
+## Risks / Unknowns
+
+- **Hook ordering risk:** `before_agent_start` prompt changes are chained by extension load order. Test helper should assert handler return value; manual runtime validation should confirm observed parent prompt behavior.
+- **Dual-package conflict risk:** Users running old `pi-mohawk` and new `pi-gremlins` may get duplicate commands/status/hooks. README and PR body must warn about this after migration support lands.
+- **Shortcut conflict risk:** `ctrl+shift+m` may conflict with user/system terminal behavior or future Pi bindings. Keep compatibility unless implementation finds a hard conflict; document any deviation.
+- **Symlink policy risk:** Current gremlin discovery accepts symlinks, pi-mohawk primary discovery ignored symlinks. Preserve existing gremlin behavior unless PRD/ADR explicitly changes it; test primary behavior chosen by implementation.
+- **Cross-repo deprecation risk:** Editing `/Users/magimetal/Dev/pi/pi-mohawk` is outside current repo. If PR scope cannot include it, document as follow-up instead of silently modifying external repo.
+
+## Plan Self-Review
+
+- References PRD-0003 and ADR-0003: yes.
+- Avoids code implementation during planning: yes.
+- Includes concrete files to inspect/change: yes.
+- Includes test, typecheck, full check, dead-code, changelog, commit, push, PR steps: yes.
+- Preserves existing `pi-gremlins` v1 tool contract: yes.
+- Enforces ADR-0002 runtime guardrails: yes.

--- a/docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md
+++ b/docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md
@@ -1,0 +1,138 @@
+# PRD-0003: Primary Agent Selection and pi-mohawk Deprecation
+
+- **Status:** Completed
+- **Date:** 2026-04-25
+- **Author:** Magi Metal
+- **Related:** `extensions/pi-gremlins`, `README.md`, `CHANGELOG.md`, GitHub issue [#39](https://github.com/magimetal/pi-gremlins/issues/39), [ADR-0003](../adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md)
+- **Supersedes:** None
+
+## Problem Statement
+
+`pi-mohawk` currently owns primary-agent selection, session state, command/shortcut UX, and system-prompt injection while `pi-gremlins` owns sub-agent delegation. Users who want both behaviors must install and reason about two separate packages even though both discover markdown agent definitions from the same user/project locations and both model agent roles with frontmatter.
+
+Issue #39 asks to deprecate `pi-mohawk` by moving primary-agent functionality into `pi-gremlins`. This is a user-facing package scope expansion: `pi-gremlins` becomes the combined agent-orchestration package for selecting one primary agent for the parent session and dispatching gremlin sub-agents for delegated work. Scope must protect the existing v1 gremlin tool contract while adding a compatible primary-agent path that gives current `pi-mohawk` users a clear migration target.
+
+## Product Goals
+
+- Make `pi-gremlins` the single install/runtime package for primary-agent selection plus gremlin delegation.
+- Preserve the existing `pi-gremlins` machine-facing package, extension, and tool identity.
+- Provide primary-agent controls that cover selection, clearing, cycling, status visibility, session reconstruction, and prompt injection.
+- Keep primary-agent and sub-agent roles strictly separated by `agent_type` frontmatter.
+- Give `pi-mohawk` users a compatibility path before documenting deprecation of the separate package.
+- Maintain v1 gremlin behavior and request schema while adding primary-agent support beside it.
+
+## User Stories
+
+- As an operator, I want to select a primary agent inside `pi-gremlins` so that the parent assistant follows a chosen role without installing `pi-mohawk`.
+- As an existing `pi-mohawk` user, I want familiar `/mohawk` and shortcut behavior to keep working during migration so that existing muscle memory is not broken immediately.
+- As an operator, I want selected primary-agent state to survive current-session branch reconstruction so that prompt behavior remains predictable across session events.
+- As a cautious user, I want primary agents and gremlin sub-agents separated by `agent_type` so that prompt-injected roles cannot accidentally be summoned as delegated gremlins, and gremlins cannot become primary agents.
+- As a maintainer, I want shared discovery/parsing where practical so that user/project precedence, markdown parsing, and typed role filtering do not diverge across two implementations.
+- As a package user, I want deprecation guidance for `pi-mohawk` only after equivalent behavior exists in `pi-gremlins` so that migration does not strand active workflows.
+
+## Scope
+
+### In Scope
+
+- Add primary-agent discovery to `pi-gremlins` from user-level `~/.pi/agent/agents/*.md` and nearest project `.pi/agents/*.md`.
+- Load selectable primary agents only from markdown files with `agent_type: primary`.
+- Preserve existing gremlin discovery for markdown files with `agent_type: sub-agent`.
+- Share agent definition parsing/discovery internals where practical while preserving strict role separation.
+- Resolve duplicate display names with nearest project definition taking precedence over user-level definition for typed primary agents.
+- Support exact and unambiguous case-insensitive primary-agent selection, with ambiguous case-insensitive matches rejected without changing state.
+- Add session-scoped selected primary-agent state in `pi-gremlins`, persisted as minimal identity data rather than raw markdown.
+- Add `before_agent_start` prompt injection for the selected primary agent using a clear delimited block.
+- Add user controls for selecting, clearing, listing/picking, and cycling primary agents.
+- Preserve or intentionally alias familiar `pi-mohawk` UX where accepted by design: `/mohawk`, `/mohawk <name>`, `/mohawk none`, `ctrl+shift+m`, and `Primary: <name|None>` status semantics.
+- Update `pi-gremlins` README and changelog with primary-agent behavior, migration notes, and PRD/ADR references.
+- After equivalent `pi-gremlins` behavior lands, update `pi-mohawk` documentation to mark that package deprecated and point users to `pi-gremlins`.
+- Port relevant `pi-mohawk` coverage into Bun tests under `extensions/pi-gremlins`.
+
+### Out of Scope / Non-Goals
+
+- Changing the `pi-gremlins` tool schema for gremlin delegation.
+- Renaming machine-facing package, extension, tool, schema, or runtime identifiers away from `pi-gremlins`.
+- Reintroducing chain mode, popup viewer, `/gremlins:view`, targeted steering, package gremlin discovery, or scope toggles.
+- Editing, creating, or deleting agent markdown definitions from the extension.
+- Loading untyped, malformed, or legacy-role markdown as primary agents or gremlins.
+- Persisting raw primary-agent markdown in session entries.
+- Persisting selected primary agent across unrelated new Pi sessions unless a later PRD explicitly expands scope.
+- Deprecating or telling users to uninstall `pi-mohawk` before `pi-gremlins` contains equivalent primary-agent behavior.
+- Pulling `pi-mohawk` package code wholesale without adapting to `pi-gremlins` runtime and test conventions.
+
+## Acceptance Criteria
+
+- [x] `pi-gremlins` discovers primary-agent markdown from user-level and nearest project agent directories only when frontmatter contains `agent_type: primary`.
+- [x] Existing gremlin discovery continues to load only `agent_type: sub-agent` definitions and the public gremlin request schema remains unchanged.
+- [x] Primary-agent and sub-agent definitions cannot cross roles: primary agents are not summonable as gremlins, and sub-agents are not selectable as primary agents.
+- [x] Duplicate primary-agent display names resolve deterministically with nearest project definition winning over user-level definition.
+- [x] Primary-agent display name fallback order matches existing `pi-mohawk` behavior: frontmatter `name`, first H1, then filename stem.
+- [x] Exact primary-agent command selection works.
+- [x] A single unambiguous case-insensitive primary-agent command selection works.
+- [x] Ambiguous case-insensitive primary-agent command selection leaves state unchanged and reports exact-case options.
+- [x] Clearing selection to `None` works through command UX and shortcut cycle state.
+- [x] No-argument command opens a picker when UI support exists.
+- [x] No-argument command without UI support emits a transcript-visible list of available primary agents.
+- [x] Shortcut cycling moves deterministically through `[None, ...sorted primary agents]`.
+- [x] Status UI reflects `Primary: <name|None>` after session start and after every primary-agent selection change.
+- [x] Selected primary-agent state is reconstructed from current-branch session entries.
+- [x] Session persistence stores minimal selected identity data and never stores raw markdown.
+- [x] Missing selected primary agent resets to `None`, warns the user, and avoids prompt injection.
+- [x] If legacy `pi-mohawk-primary-agent` session entries are supported by the final ADR, they are read for migration but new writes use a `pi-gremlins`-owned entry type.
+- [x] Selecting `None` leaves the parent system prompt unchanged.
+- [x] Selecting a primary agent appends its raw markdown inside a `pi-gremlins`-owned delimited block during `before_agent_start`.
+- [x] Repeated prompt injection does not duplicate the primary-agent block.
+- [x] Prompt injection never injects sub-agent markdown.
+- [x] README documents both roles: `agent_type: primary` for parent-session prompt control and `agent_type: sub-agent` for gremlin delegation.
+- [x] README documents implemented command names, shortcut behavior, status behavior, session scope, and `pi-mohawk` migration guidance.
+- [x] CHANGELOG references PRD-0003 and the related ADR for this scope.
+- [x] `pi-mohawk` deprecation documentation is updated only after equivalent `pi-gremlins` primary-agent behavior ships.
+- [x] Automated Bun coverage exists for primary-agent definition loading, discovery precedence, selection resolution, session state, command/shortcut/status behavior, prompt injection, and no role crossover.
+
+## Technical Surface
+
+- **Discovery and definitions:** `extensions/pi-gremlins/gremlin-definition.ts`, `extensions/pi-gremlins/gremlin-discovery.ts`, and new shared agent-definition/discovery helpers as needed for both `primary` and `sub-agent` roles.
+- **Session state:** new primary-agent state module under `extensions/pi-gremlins` using a `pi-gremlins`-owned custom session entry type and minimal identity persistence.
+- **Extension hooks and controls:** `extensions/pi-gremlins/index.ts` or extracted modules for command registration, shortcut handling, status updates, session lifecycle loading, and `before_agent_start` prompt mutation.
+- **Prompt handling:** primary-agent prompt block helpers that append selected markdown exactly once and avoid duplicate or stale blocks.
+- **Docs:** `README.md`, `CHANGELOG.md`, and later `pi-mohawk` README/changelog deprecation notes after support ships.
+- **Tests:** Bun tests beside `extensions/pi-gremlins` modules, porting relevant `pi-mohawk` coverage from definition, discovery, session-state, extension command/status, and prompt-injection tests.
+- **Related ADRs:** [ADR-0003](../adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md) for unified agent discovery, prompt injection, session entry compatibility, compatibility command/status naming, and dual-package conflict handling.
+
+## UX Notes
+
+- Compatibility matters, but `pi-gremlins` remains the package identity. Human-facing copy may explain the migration; machine-facing identifiers stay `pi-gremlins` unless explicitly retained as compatibility aliases.
+- Primary-agent status should stay concise: `Primary: None` or `Primary: <name>`.
+- Command feedback must be transcript-visible when no picker/UI path exists so terminal-only users can recover available names.
+- Ambiguous name errors should list exact-case matching options and avoid changing current state.
+- The picker/list should include `None` as a first-class clear option.
+- Migration docs should tell users not to run both packages together once `pi-gremlins` support exists, because duplicate commands, shortcuts, status, or prompt injection can conflict.
+
+## Rollout / Sequencing Notes
+
+1. **Governance first.** Create PRD-0003 and a related ADR before runtime implementation.
+2. **Shared parsing/discovery second.** Establish strict typed role loading without changing the gremlin tool contract.
+3. **State and controls third.** Add primary-agent session state, command handling, shortcut cycling, and status updates.
+4. **Prompt injection fourth.** Add `before_agent_start` mutation after state and discovery behavior are testable.
+5. **Docs and deprecation fifth.** Document `pi-gremlins` primary-agent behavior, then deprecate `pi-mohawk` docs only after equivalent support ships.
+6. **Full verification last.** Run focused Bun tests during phases and full repo checks after implementation.
+
+## Open Questions
+
+- Should `pi-gremlins` support a new branded primary-agent command alias in addition to `/mohawk`, and if so what exact name should be documented as canonical?
+- Should legacy `pi-mohawk-primary-agent` session entries be read during migration, or should migration start clean with only new `pi-gremlins` session entries?
+- Should the implementation strip old `pi-mohawk` prompt delimiters to prevent double injection when both packages are installed during transition?
+- Should primary-agent discovery keep `pi-mohawk` symlink-ignoring behavior while gremlin discovery preserves existing `pi-gremlins` behavior, or should both roles share one symlink policy?
+- What exact status key should `pi-gremlins` use for the primary-agent label while keeping user-visible status text compatible?
+
+## Completion Summary
+
+Implemented primary-agent support in `pi-gremlins` for GitHub issue #39. Delivered role-aware agent definition loading and discovery, strict `agent_type: primary` / `agent_type: sub-agent` separation, primary-agent selection through `/mohawk` compatibility controls, shortcut cycling, status updates, current-branch session reconstruction, legacy `pi-mohawk-primary-agent` read compatibility, new `pi-gremlins-primary-agent` writes, and `before_agent_start` prompt injection with duplicate/legacy block stripping.
+
+Docs now describe both agent roles, migration behavior, command/status semantics, session scope, prompt block behavior, and PRD/ADR references. Verification required for completion passed before this status change: `npm run typecheck`, `npm test`, and `npm run check`.
+
+## Revision History
+
+- 2026-04-25: Marked Completed after implementation review PASS; recorded delivered primary-agent behavior and verification evidence.
+- 2026-04-25: Activated for implementation after ADR-0003 acceptance; replaced placeholder ADR references with concrete ADR link.
+- 2026-04-25: Draft created for GitHub issue #39 product scope.

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -85,3 +85,4 @@ Maintain in `docs/prd/README.md`:
 | 0000 | Template                                                  | Active | 2026-04-21 |
 | 0001 | Pi Gremlins Immersive Theming and Viewer UX Overhaul      | Completed | 2026-04-21 |
 | 0002 | Pi Gremlins V1 SDK Rewrite                                | Draft | 2026-04-22 |
+| 0003 | Primary Agent Selection and pi-mohawk Deprecation         | Completed | 2026-04-25 |

--- a/extensions/pi-gremlins/agent-definition.ts
+++ b/extensions/pi-gremlins/agent-definition.ts
@@ -1,0 +1,118 @@
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+
+export type AgentSource = "user" | "project";
+export type AgentRole = "primary" | "sub-agent";
+
+export interface AgentFrontmatter {
+	name?: string;
+	description?: string;
+	agent_type?: string;
+	model?: string;
+	thinking?: string;
+	tools?: string[];
+	body?: string;
+	[key: string]: unknown;
+}
+
+export interface ParsedAgentMarkdown {
+	frontmatter: Record<string, string | string[]>;
+	body: string;
+	hasFrontmatter: boolean;
+}
+
+export interface BaseAgentDefinition {
+	name: string;
+	description?: string;
+	source: AgentSource;
+	filePath: string;
+	rawMarkdown: string;
+	frontmatter: AgentFrontmatter;
+}
+
+export function normalizeScalarValue(value: string): string {
+	return value.replace(/^[ '\"]|[ '\"]$/g, "").trim();
+}
+
+export function parseAgentMarkdown(markdown: string): ParsedAgentMarkdown {
+	const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+	if (!match) {
+		return { frontmatter: {}, body: markdown, hasFrontmatter: false };
+	}
+
+	const frontmatter: Record<string, string | string[]> = {};
+	let currentListKey: string | null = null;
+	for (const rawLine of match[1].split(/\r?\n/)) {
+		const line = rawLine.trimEnd();
+		if (!line.trim()) continue;
+
+		const listItemMatch = line.match(/^\s*-\s+(.*)$/);
+		if (listItemMatch && currentListKey) {
+			const current = frontmatter[currentListKey];
+			const nextValue = normalizeScalarValue(listItemMatch[1]);
+			frontmatter[currentListKey] = Array.isArray(current)
+				? [...current, nextValue]
+				: [nextValue];
+			continue;
+		}
+
+		const separatorIndex = line.indexOf(":");
+		if (separatorIndex === -1) {
+			currentListKey = null;
+			continue;
+		}
+
+		const key = line.slice(0, separatorIndex).trim();
+		const rawValue = line.slice(separatorIndex + 1).trim();
+		if (!key) {
+			currentListKey = null;
+			continue;
+		}
+		if (!rawValue) {
+			frontmatter[key] = [];
+			currentListKey = key;
+			continue;
+		}
+
+		frontmatter[key] = normalizeScalarValue(rawValue);
+		currentListKey = null;
+	}
+
+	return { frontmatter, body: match[2], hasFrontmatter: true };
+}
+
+export function readScalar(
+	frontmatter: Record<string, string | string[]>,
+	key: string,
+): string | undefined {
+	const value = frontmatter[key];
+	return typeof value === "string" ? normalizeScalarValue(value) : undefined;
+}
+
+export function parseTools(value: string | string[] | undefined): string[] | undefined {
+	if (!value) return undefined;
+	const tools = (Array.isArray(value) ? value : value.split(","))
+		.map((tool) => normalizeScalarValue(tool))
+		.filter(Boolean);
+	return tools.length > 0 ? tools : undefined;
+}
+
+export function readFirstHeading(body: string): string | undefined {
+	for (const rawLine of body.split(/\r?\n/)) {
+		const match = rawLine.match(/^#\s+(.+)$/);
+		if (match) {
+			const heading = match[1].trim();
+			if (heading) return heading;
+		}
+	}
+	return undefined;
+}
+
+export function filenameStem(filePath: string): string | undefined {
+	const stem = path.basename(filePath, path.extname(filePath)).trim();
+	return stem || undefined;
+}
+
+export async function readAgentMarkdown(filePath: string): Promise<string> {
+	return readFile(filePath, "utf-8");
+}

--- a/extensions/pi-gremlins/gremlin-definition.ts
+++ b/extensions/pi-gremlins/gremlin-definition.ts
@@ -1,14 +1,20 @@
-import { readFile } from "node:fs/promises";
-import type { GremlinSource } from "./gremlin-schema.js";
+import type { AgentSource, AgentFrontmatter } from "./agent-definition.js";
+import {
+	parseAgentMarkdown,
+	parseTools,
+	readAgentMarkdown,
+	readScalar,
+} from "./agent-definition.js";
 
-export interface GremlinFrontmatter {
+export type GremlinSource = AgentSource;
+
+export interface GremlinFrontmatter extends AgentFrontmatter {
 	name?: string;
 	description?: string;
 	model?: string;
 	thinking?: string;
 	tools?: string[];
 	body?: string;
-	[key: string]: unknown;
 }
 
 export interface GremlinDefinition {
@@ -20,80 +26,12 @@ export interface GremlinDefinition {
 	frontmatter: GremlinFrontmatter;
 }
 
-interface ParsedFrontmatterBlock {
-	frontmatter: Record<string, string | string[]>;
-	body: string;
-}
-
-function normalizeScalarValue(value: string): string {
-	return value.replace(/^['"]|['"]$/g, "").trim();
-}
-
-function parseFrontmatterBlock(markdown: string): ParsedFrontmatterBlock {
-	const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
-	if (!match) {
-		return { frontmatter: {}, body: markdown };
-	}
-
-	const frontmatter: Record<string, string | string[]> = {};
-	let currentListKey: string | null = null;
-	for (const rawLine of match[1].split(/\r?\n/)) {
-		const line = rawLine.trimEnd();
-		if (!line.trim()) continue;
-		const listItemMatch = line.match(/^\s*-\s+(.*)$/);
-		if (listItemMatch && currentListKey) {
-			const current = frontmatter[currentListKey];
-			const nextValue = normalizeScalarValue(listItemMatch[1]);
-			frontmatter[currentListKey] = Array.isArray(current)
-				? [...current, nextValue]
-				: [nextValue];
-			continue;
-		}
-
-		const separatorIndex = line.indexOf(":");
-		if (separatorIndex === -1) {
-			currentListKey = null;
-			continue;
-		}
-
-		const key = line.slice(0, separatorIndex).trim();
-		const rawValue = line.slice(separatorIndex + 1).trim();
-		if (!key) {
-			currentListKey = null;
-			continue;
-		}
-		if (!rawValue) {
-			frontmatter[key] = [];
-			currentListKey = key;
-			continue;
-		}
-
-		frontmatter[key] = normalizeScalarValue(rawValue);
-		currentListKey = null;
-	}
-
-	return { frontmatter, body: match[2] };
-}
-
-function parseTools(value: string | string[] | undefined): string[] | undefined {
-	if (!value) return undefined;
-	const tools = (Array.isArray(value) ? value : value.split(","))
-		.map((tool) => normalizeScalarValue(tool))
-		.filter(Boolean);
-	return tools.length > 0 ? tools : undefined;
-}
-
-function readScalar(frontmatter: Record<string, string | string[]>, key: string) {
-	const value = frontmatter[key];
-	return typeof value === "string" ? normalizeScalarValue(value) : undefined;
-}
-
 export function parseGremlinDefinition(
 	markdown: string,
 	filePath: string,
 	source: GremlinSource,
 ): GremlinDefinition | null {
-	const { frontmatter, body } = parseFrontmatterBlock(markdown);
+	const { frontmatter, body } = parseAgentMarkdown(markdown);
 	const agentType = readScalar(frontmatter, "agent_type");
 	if (agentType !== "sub-agent") return null;
 
@@ -108,6 +46,7 @@ export function parseGremlinDefinition(
 		rawMarkdown: markdown,
 		frontmatter: {
 			...frontmatter,
+			agent_type: agentType,
 			description: readScalar(frontmatter, "description"),
 			model: readScalar(frontmatter, "model"),
 			thinking: readScalar(frontmatter, "thinking"),
@@ -121,6 +60,6 @@ export async function loadGremlinDefinition(
 	filePath: string,
 	source: GremlinSource,
 ): Promise<GremlinDefinition | null> {
-	const rawMarkdown = await readFile(filePath, "utf-8");
+	const rawMarkdown = await readAgentMarkdown(filePath);
 	return parseGremlinDefinition(rawMarkdown, filePath, source);
 }

--- a/extensions/pi-gremlins/gremlin-discovery.ts
+++ b/extensions/pi-gremlins/gremlin-discovery.ts
@@ -2,10 +2,15 @@ import * as fs from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { AgentSource } from "./agent-definition.js";
 import {
 	loadGremlinDefinition,
 	type GremlinDefinition,
 } from "./gremlin-definition.js";
+import {
+	loadPrimaryAgentDefinition,
+	type PrimaryAgentDefinition,
+} from "./primary-agent-definition.js";
 
 export interface GremlinDiscoveryResult {
 	gremlins: GremlinDefinition[];
@@ -15,6 +20,17 @@ export interface GremlinDiscoveryResult {
 
 export interface GremlinDiscoveryCache {
 	get(cwd: string): Promise<GremlinDiscoveryResult>;
+	clear(): void;
+}
+
+export interface PrimaryAgentDiscoveryResult {
+	agents: PrimaryAgentDefinition[];
+	projectAgentsDir: string | null;
+	fingerprint: string;
+}
+
+export interface PrimaryAgentDiscoveryCache {
+	get(cwd: string): Promise<PrimaryAgentDiscoveryResult>;
 	clear(): void;
 }
 
@@ -30,22 +46,28 @@ interface DirectorySnapshot {
 	files: string[];
 }
 
-export interface GremlinDiscoveryFileSystem {
+export interface AgentDiscoveryFileSystem {
 	readdir(dir: string): Promise<fs.Dirent[]>;
 	stat(candidatePath: string): Promise<fs.Stats>;
 }
 
-export interface GremlinDiscoveryOptions {
+export interface AgentDiscoveryOptions {
 	userAgentsDir?: string;
-	fileSystem?: GremlinDiscoveryFileSystem;
+	fileSystem?: AgentDiscoveryFileSystem;
+	includeSymlinks?: boolean;
 }
 
-const nodeFileSystem: GremlinDiscoveryFileSystem = {
+export type PrimaryAgentNameResolution =
+	| { status: "found"; agent: PrimaryAgentDefinition }
+	| { status: "not-found" }
+	| { status: "ambiguous"; matches: PrimaryAgentDefinition[] };
+
+const nodeFileSystem: AgentDiscoveryFileSystem = {
 	readdir: (dir) => readdir(dir, { withFileTypes: true }),
 	stat,
 };
 
-export function getUserGremlinsDir(options: GremlinDiscoveryOptions = {}): string {
+export function getUserGremlinsDir(options: AgentDiscoveryOptions = {}): string {
 	return options.userAgentsDir ?? path.join(getAgentDir(), "agents");
 }
 
@@ -70,13 +92,14 @@ export function findNearestProjectAgentsDir(cwd: string): string | null {
 
 async function listMarkdownFiles(
 	dir: string,
-	fileSystem: GremlinDiscoveryFileSystem,
+	fileSystem: AgentDiscoveryFileSystem,
+	includeSymlinks: boolean,
 ): Promise<string[]> {
 	try {
 		const entries = await fileSystem.readdir(dir);
 		return entries
 			.filter((entry) => entry.name.endsWith(".md"))
-			.filter((entry) => entry.isFile() || entry.isSymbolicLink())
+			.filter((entry) => entry.isFile() || (includeSymlinks && entry.isSymbolicLink()))
 			.map((entry) => path.join(dir, entry.name))
 			.sort();
 	} catch {
@@ -90,13 +113,13 @@ function createDirectorySignature(dirStat: fs.Stats): string {
 
 async function fingerprintKnownFiles(
 	files: string[],
-	fileSystem: GremlinDiscoveryFileSystem,
+	fileSystem: AgentDiscoveryFileSystem,
 ): Promise<string[]> {
 	return Promise.all(
 		files.map(async (filePath) => {
 			try {
 				const fileStat = await fileSystem.stat(filePath);
-				return `${path.basename(filePath)}:${fileStat.mtimeMs}`;
+				return `${path.basename(filePath)}:${fileStat.mtimeMs}:${fileStat.size}`;
 			} catch {
 				return `${path.basename(filePath)}:missing`;
 			}
@@ -107,7 +130,8 @@ async function fingerprintKnownFiles(
 async function fingerprintDirectory(
 	dir: string | null,
 	snapshots: Map<string, DirectorySnapshot>,
-	fileSystem: GremlinDiscoveryFileSystem,
+	fileSystem: AgentDiscoveryFileSystem,
+	includeSymlinks: boolean,
 ): Promise<DirectoryFingerprint> {
 	if (!dir) {
 		return { dir: null, fingerprint: "none", files: [] };
@@ -130,7 +154,7 @@ async function fingerprintDirectory(
 		return { dir, fingerprint, files: cached.files };
 	}
 
-	const files = await listMarkdownFiles(dir, fileSystem);
+	const files = await listMarkdownFiles(dir, fileSystem, includeSymlinks);
 	const parts = await fingerprintKnownFiles(files, fileSystem);
 	const fingerprint = `${dir}|${parts.join(",")}`;
 	snapshots.set(dir, {
@@ -143,7 +167,7 @@ async function fingerprintDirectory(
 
 async function loadGremlinsFromFiles(
 	files: string[],
-	source: "user" | "project",
+	source: AgentSource,
 ): Promise<GremlinDefinition[]> {
 	const definitions = await Promise.all(
 		files.map(async (filePath) => {
@@ -157,13 +181,29 @@ async function loadGremlinsFromFiles(
 	return definitions.filter((definition): definition is GremlinDefinition => Boolean(definition));
 }
 
-function mergeGremlins(
-	userGremlins: GremlinDefinition[],
-	projectGremlins: GremlinDefinition[],
-): GremlinDefinition[] {
-	const merged = new Map<string, GremlinDefinition>();
-	for (const gremlin of userGremlins) merged.set(gremlin.name, gremlin);
-	for (const gremlin of projectGremlins) merged.set(gremlin.name, gremlin);
+async function loadPrimaryAgentsFromFiles(
+	files: string[],
+	source: AgentSource,
+): Promise<PrimaryAgentDefinition[]> {
+	const definitions = await Promise.all(
+		files.map(async (filePath) => {
+			try {
+				return await loadPrimaryAgentDefinition(filePath, source);
+			} catch {
+				return null;
+			}
+		}),
+	);
+	return definitions.filter((definition): definition is PrimaryAgentDefinition => Boolean(definition));
+}
+
+function mergeByName<T extends { name: string }>(
+	userDefinitions: T[],
+	projectDefinitions: T[],
+): T[] {
+	const merged = new Map<string, T>();
+	for (const definition of userDefinitions) merged.set(definition.name, definition);
+	for (const definition of projectDefinitions) merged.set(definition.name, definition);
 	return Array.from(merged.values()).sort((left, right) =>
 		left.name.localeCompare(right.name),
 	);
@@ -183,29 +223,60 @@ export function resolveGremlinByName(
 	);
 }
 
-export function createGremlinDiscoveryCache(
-	options: GremlinDiscoveryOptions = {},
-): GremlinDiscoveryCache {
-	const fileSystem = options.fileSystem ?? nodeFileSystem;
+export function resolvePrimaryAgentByName(
+	agents: PrimaryAgentDefinition[],
+	requestedName: string,
+): PrimaryAgentNameResolution {
+	const exactMatch = agents.find((agent) => agent.name === requestedName);
+	if (exactMatch) return { status: "found", agent: exactMatch };
+
+	const normalizedRequestedName = requestedName.toLowerCase();
+	const matches = agents.filter(
+		(agent) => agent.name.toLowerCase() === normalizedRequestedName,
+	);
+	if (matches.length === 1) return { status: "found", agent: matches[0] };
+	if (matches.length > 1) return { status: "ambiguous", matches };
+	return { status: "not-found" };
+}
+
+interface RoleDiscoveryCache<TResult> {
+	get(cwd: string): Promise<TResult>;
+	clear(): void;
+}
+
+function createRoleDiscoveryCache<T extends { name: string }, TResult>(options: {
+	discoveryOptions?: AgentDiscoveryOptions;
+	includeSymlinks: boolean;
+	loadDefinitions: (files: string[], source: AgentSource) => Promise<T[]>;
+	toResult: (args: {
+		definitions: T[];
+		projectAgentsDir: string | null;
+		fingerprint: string;
+	}) => TResult;
+}): RoleDiscoveryCache<TResult> {
+	const discoveryOptions = options.discoveryOptions ?? {};
+	const fileSystem = discoveryOptions.fileSystem ?? nodeFileSystem;
 	const directorySnapshots = new Map<string, DirectorySnapshot>();
-	let cachedResult: GremlinDiscoveryResult | null = null;
+	let cachedResult: TResult | null = null;
 	let cachedFingerprint: string | null = null;
 	let cachedProjectAgentsDir: string | null = null;
 	let cachedUserAgentsDir: string | null = null;
 
 	return {
 		async get(cwd: string) {
-			const userAgentsDir = getUserGremlinsDir(options);
+			const userAgentsDir = getUserGremlinsDir(discoveryOptions);
 			const projectAgentsDir = findNearestProjectAgentsDir(cwd);
 			const userFingerprint = await fingerprintDirectory(
 				userAgentsDir,
 				directorySnapshots,
 				fileSystem,
+				options.includeSymlinks,
 			);
 			const projectFingerprint = await fingerprintDirectory(
 				projectAgentsDir,
 				directorySnapshots,
 				fileSystem,
+				options.includeSymlinks,
 			);
 			const fingerprint = [userFingerprint.fingerprint, projectFingerprint.fingerprint].join(
 				"::",
@@ -219,19 +290,19 @@ export function createGremlinDiscoveryCache(
 				return cachedResult;
 			}
 
-			const userGremlins = await loadGremlinsFromFiles(
+			const userDefinitions = await options.loadDefinitions(
 				userFingerprint.files,
 				"user",
 			);
-			const projectGremlins = await loadGremlinsFromFiles(
+			const projectDefinitions = await options.loadDefinitions(
 				projectFingerprint.files,
 				"project",
 			);
-			cachedResult = {
-				gremlins: mergeGremlins(userGremlins, projectGremlins),
+			cachedResult = options.toResult({
+				definitions: mergeByName(userDefinitions, projectDefinitions),
 				projectAgentsDir,
 				fingerprint,
-			};
+			});
 			cachedFingerprint = fingerprint;
 			cachedProjectAgentsDir = projectAgentsDir;
 			cachedUserAgentsDir = userAgentsDir;
@@ -245,4 +316,34 @@ export function createGremlinDiscoveryCache(
 			cachedUserAgentsDir = null;
 		},
 	};
+}
+
+export function createGremlinDiscoveryCache(
+	options: AgentDiscoveryOptions = {},
+): GremlinDiscoveryCache {
+	return createRoleDiscoveryCache<GremlinDefinition, GremlinDiscoveryResult>({
+		discoveryOptions: options,
+		includeSymlinks: options.includeSymlinks ?? true,
+		loadDefinitions: loadGremlinsFromFiles,
+		toResult: ({ definitions, projectAgentsDir, fingerprint }) => ({
+			gremlins: definitions,
+			projectAgentsDir,
+			fingerprint,
+		}),
+	}) as GremlinDiscoveryCache;
+}
+
+export function createPrimaryAgentDiscoveryCache(
+	options: AgentDiscoveryOptions = {},
+): PrimaryAgentDiscoveryCache {
+	return createRoleDiscoveryCache<PrimaryAgentDefinition, PrimaryAgentDiscoveryResult>({
+		discoveryOptions: options,
+		includeSymlinks: options.includeSymlinks ?? false,
+		loadDefinitions: loadPrimaryAgentsFromFiles,
+		toResult: ({ definitions, projectAgentsDir, fingerprint }) => ({
+			agents: definitions,
+			projectAgentsDir,
+			fingerprint,
+		}),
+	}) as PrimaryAgentDiscoveryCache;
 }

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -35,11 +35,14 @@ describe("pi-gremlins index execute v1", () => {
 		resetV1ContractHarness();
 	});
 
-	test("registers only tool and no legacy viewer or steering commands", () => {
-		const { tool, commands } = createExtensionHarness();
+	test("registers tool plus primary-agent compatibility command with no legacy viewer or steering commands", () => {
+		const { tool, commands, shortcuts } = createExtensionHarness();
 
 		expect(tool.name).toBe("pi-gremlins");
-		expect(Array.from(commands.keys())).toEqual([]);
+		expect(Array.from(commands.keys())).toEqual(["mohawk"]);
+		expect(commands.has("gremlins:view")).toBe(false);
+		expect(commands.has("gremlins:steer")).toBe(false);
+		expect(Array.from(shortcuts.keys())).toEqual(["ctrl+shift+m"]);
 	});
 
 	test("rejects legacy parameter shapes at execute boundary", async () => {

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -12,7 +12,10 @@ import {
 import { Text } from "@mariozechner/pi-tui";
 import {
 	createGremlinDiscoveryCache,
+	createPrimaryAgentDiscoveryCache,
 	resolveGremlinByName,
+	type GremlinDiscoveryCache,
+	type PrimaryAgentDiscoveryCache,
 } from "./gremlin-discovery.js";
 import {
 	renderGremlinInvocationText,
@@ -26,6 +29,19 @@ import {
 } from "./gremlin-schema.js";
 import { runGremlinBatch } from "./gremlin-scheduler.js";
 import { buildGremlinProgressSummary } from "./gremlin-summary.js";
+import {
+	cyclePrimaryAgent,
+	notifyPrimaryAgent,
+	PRIMARY_SHORTCUT,
+	runMohawkCommand,
+	updatePrimaryAgentStatus,
+} from "./primary-agent-controls.js";
+import { applyPrimaryAgentPromptInjection } from "./primary-agent-prompt.js";
+import {
+	createInitialPrimaryAgentState,
+	reconstructPrimaryAgentStateFromBranch,
+	type PrimaryAgentState,
+} from "./primary-agent-state.js";
 
 const BRAND_NAME = "Gremlins🧌";
 const TOOL_NAME = "pi-gremlins";
@@ -111,156 +127,228 @@ function createFailedGremlinResult(
 	};
 }
 
-export default function registerPiGremlins(pi: ExtensionAPI) {
-	const discovery = createGremlinDiscoveryCache({
-		userAgentsDir: path.join(getAgentDir(), "agents"),
-	});
+export interface PiGremlinsExtensionOptions {
+	discoveryCache?: GremlinDiscoveryCache;
+	primaryAgentDiscoveryCache?: PrimaryAgentDiscoveryCache;
+}
 
-	pi.on("session_start", () => {
-		discovery.clear();
-	});
-
-	pi.on("session_shutdown", () => {
-		discovery.clear();
-	});
-
-	type PiGremlinsArgs = { gremlins: GremlinRequest[] };
-	const tool = {
-		name: TOOL_NAME,
-		label: BRAND_NAME,
-		description: TOOL_DESCRIPTION,
-		parameters: PiGremlinsParams,
-
-		renderCall(params: PiGremlinsArgs) {
-			return new Text(renderCallText(params));
-		},
-
-		renderResult(
-			result: AgentToolResult<GremlinInvocationDetails>,
-			options: Parameters<typeof styleGremlinInvocationText>[2],
-			theme: Parameters<typeof styleGremlinInvocationText>[1],
-		) {
-			if (!result.details) {
-				const firstContent = result.content?.[0];
-				const fallbackText =
-					firstContent && "text" in firstContent ? firstContent.text : "";
-				return new Text(fallbackText);
-			}
-			const text = renderGremlinInvocationText(getInvocationDetails(result), {
-				expanded: options.expanded,
+export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = {}) {
+	return function registerPiGremlins(pi: ExtensionAPI) {
+		const agentsDir = path.join(getAgentDir(), "agents");
+		const discovery =
+			options.discoveryCache ??
+			createGremlinDiscoveryCache({
+				userAgentsDir: agentsDir,
 			});
-			return new Text(styleGremlinInvocationText(text, theme, options));
-		},
+		const primaryAgentDiscovery =
+			options.primaryAgentDiscoveryCache ??
+			createPrimaryAgentDiscoveryCache({
+				userAgentsDir: agentsDir,
+			});
+		let primaryAgentState: PrimaryAgentState = createInitialPrimaryAgentState();
 
-		async execute(
-			_toolCallId: string,
-			params: PiGremlinsArgs,
-			signal: AbortSignal | undefined,
-			onUpdate: AgentToolUpdateCallback<GremlinInvocationDetails> | undefined,
-			ctx: ExtensionContext,
-		) {
-			if (!Array.isArray(params.gremlins) || params.gremlins.length === 0) {
+		pi.on("session_start", async (_event, ctx) => {
+			discovery.clear();
+			primaryAgentDiscovery.clear();
+			const { agents } = await primaryAgentDiscovery.get(ctx.cwd);
+			primaryAgentState = reconstructPrimaryAgentStateFromBranch(
+				ctx.sessionManager.getBranch(),
+				agents,
+			);
+			updatePrimaryAgentStatus(ctx, primaryAgentState);
+			if (primaryAgentState.missingSelectedName) {
+				notifyPrimaryAgent(
+					ctx,
+					`Primary agent unavailable, reset to None: ${primaryAgentState.missingSelectedName}`,
+					"warning",
+				);
+			}
+		});
+
+		pi.on("session_shutdown", () => {
+			discovery.clear();
+			primaryAgentDiscovery.clear();
+		});
+
+		pi.registerCommand("mohawk", {
+			description: "Select current-session primary agent",
+			handler: async (args, ctx) => {
+				primaryAgentState = await runMohawkCommand(
+					pi,
+					ctx,
+					primaryAgentState,
+					primaryAgentDiscovery,
+					args,
+				);
+			},
+		});
+
+		pi.registerShortcut(PRIMARY_SHORTCUT, {
+			description: "Cycle primary agent",
+			handler: async (ctx) => {
+				primaryAgentState = await cyclePrimaryAgent(
+					pi,
+					ctx,
+					primaryAgentState,
+					primaryAgentDiscovery,
+				);
+			},
+		});
+
+		pi.on("before_agent_start", async (event, ctx) => {
+			const injection = await applyPrimaryAgentPromptInjection({
+				pi,
+				event,
+				ctx,
+				state: primaryAgentState,
+				discoveryCache: primaryAgentDiscovery,
+				updateStatus: updatePrimaryAgentStatus,
+				notify: notifyPrimaryAgent,
+			});
+			primaryAgentState = injection.state;
+			return injection.result;
+		});
+
+		type PiGremlinsArgs = { gremlins: GremlinRequest[] };
+		const tool = {
+			name: TOOL_NAME,
+			label: BRAND_NAME,
+			description: TOOL_DESCRIPTION,
+			parameters: PiGremlinsParams,
+
+			renderCall(params: PiGremlinsArgs) {
+				return new Text(renderCallText(params));
+			},
+
+			renderResult(
+				result: AgentToolResult<GremlinInvocationDetails>,
+				options: Parameters<typeof styleGremlinInvocationText>[2],
+				theme: Parameters<typeof styleGremlinInvocationText>[1],
+			) {
+				if (!result.details) {
+					const firstContent = result.content?.[0];
+					const fallbackText =
+						firstContent && "text" in firstContent ? firstContent.text : "";
+					return new Text(fallbackText);
+				}
+				const text = renderGremlinInvocationText(getInvocationDetails(result), {
+					expanded: options.expanded,
+				});
+				return new Text(styleGremlinInvocationText(text, theme, options));
+			},
+
+			async execute(
+				_toolCallId: string,
+				params: PiGremlinsArgs,
+				signal: AbortSignal | undefined,
+				onUpdate: AgentToolUpdateCallback<GremlinInvocationDetails> | undefined,
+				ctx: ExtensionContext,
+			) {
+				if (!Array.isArray(params.gremlins) || params.gremlins.length === 0) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: "Invalid parameters. Provide gremlins: [{ intent, agent, context, cwd? }, ...].",
+							},
+						],
+						isError: true,
+						details: normalizeInvocationDetails(),
+					};
+				}
+				const discovered = await discovery.get(ctx.cwd);
+				const batch = await runGremlinBatch({
+					gremlins: params.gremlins,
+					signal,
+					onUpdate: (details) => {
+						onUpdate?.({
+							content: [
+								{
+									type: "text",
+									text: buildGremlinProgressSummary(details),
+								},
+							],
+							details,
+						});
+					},
+					runGremlin: async ({
+						gremlin: rawRequest,
+						gremlinId,
+						signal: childSignal,
+						onUpdate: publishUpdate,
+					}) => {
+						const resolvedCwd = resolveGremlinCwd(rawRequest.cwd, ctx.cwd);
+						const request = resolvedCwd
+							? { ...rawRequest, cwd: resolvedCwd }
+							: rawRequest;
+						const validationError = validateGremlinRequest(request);
+						if (validationError) {
+							return createFailedGremlinResult(request, gremlinId, validationError);
+						}
+
+						const gremlin = resolveGremlinByName(discovered.gremlins, request.agent);
+						if (!gremlin) {
+							return createFailedGremlinResult(
+								request,
+								gremlinId,
+								`Unknown gremlin: ${request.agent}`,
+							);
+						}
+
+						return runSingleGremlin({
+							gremlinId,
+							request,
+							definition: gremlin,
+							parentSystemPrompt: ctx.getSystemPrompt(),
+							parentModel: ctx.model,
+							modelRegistry: ctx.modelRegistry,
+							signal: childSignal,
+							onUpdate: ({ patch }) => publishUpdate?.(patch),
+						});
+					},
+				});
+
+				const details = normalizeInvocationDetails({
+					requestedCount: params.gremlins.length,
+					activeCount: batch.results.filter(
+						(result) =>
+							result.status === "queued" ||
+							result.status === "starting" ||
+							result.status === "active",
+					).length,
+					completedCount: batch.results.filter(
+						(result) => result.status === "completed",
+					).length,
+					failedCount: batch.results.filter((result) => result.status === "failed")
+						.length,
+					canceledCount: batch.results.filter(
+						(result) => result.status === "canceled",
+					).length,
+					gremlins: batch.results,
+				});
+				const partial: AgentToolResult<GremlinInvocationDetails> = {
+					content: [{ type: "text", text: batch.summary }],
+					details,
+				};
+				onUpdate?.(partial);
+
 				return {
 					content: [
 						{
 							type: "text",
-							text: "Invalid parameters. Provide gremlins: [{ intent, agent, context, cwd? }, ...].",
+							text: batch.summary,
 						},
 					],
-					isError: true,
-					details: normalizeInvocationDetails(),
+					details,
+					...(batch.anyError ? { isError: true } : {}),
 				};
-			}
-			const discovered = await discovery.get(ctx.cwd);
-			const batch = await runGremlinBatch({
-				gremlins: params.gremlins,
-				signal,
-				onUpdate: (details) => {
-					onUpdate?.({
-						content: [
-							{
-								type: "text",
-								text: buildGremlinProgressSummary(details),
-							},
-						],
-						details,
-					});
-				},
-				runGremlin: async ({
-					gremlin: rawRequest,
-					gremlinId,
-					signal: childSignal,
-					onUpdate: publishUpdate,
-				}) => {
-					const resolvedCwd = resolveGremlinCwd(rawRequest.cwd, ctx.cwd);
-					const request = resolvedCwd
-						? { ...rawRequest, cwd: resolvedCwd }
-						: rawRequest;
-					const validationError = validateGremlinRequest(request);
-					if (validationError) {
-						return createFailedGremlinResult(request, gremlinId, validationError);
-					}
+			},
+		};
 
-					const gremlin = resolveGremlinByName(discovered.gremlins, request.agent);
-					if (!gremlin) {
-						return createFailedGremlinResult(
-							request,
-							gremlinId,
-							`Unknown gremlin: ${request.agent}`,
-						);
-					}
-
-					return runSingleGremlin({
-						gremlinId,
-						request,
-						definition: gremlin,
-						parentSystemPrompt: ctx.getSystemPrompt(),
-						parentModel: ctx.model,
-						modelRegistry: ctx.modelRegistry,
-						signal: childSignal,
-						onUpdate: ({ patch }) => publishUpdate?.(patch),
-					});
-				},
-			});
-
-			const details = normalizeInvocationDetails({
-				requestedCount: params.gremlins.length,
-				activeCount: batch.results.filter(
-					(result) =>
-						result.status === "queued" ||
-						result.status === "starting" ||
-						result.status === "active",
-				).length,
-				completedCount: batch.results.filter(
-					(result) => result.status === "completed",
-				).length,
-				failedCount: batch.results.filter((result) => result.status === "failed")
-					.length,
-				canceledCount: batch.results.filter(
-					(result) => result.status === "canceled",
-				).length,
-				gremlins: batch.results,
-			});
-			const partial: AgentToolResult<GremlinInvocationDetails> = {
-				content: [{ type: "text", text: batch.summary }],
-				details,
-			};
-			onUpdate?.(partial);
-
-			return {
-				content: [
-					{
-						type: "text",
-						text: batch.summary,
-					},
-				],
-				details,
-				...(batch.anyError ? { isError: true } : {}),
-			};
-		},
+		// FIXME: Cast kept because pi 0.69.0 + TypeBox 1.x triggers TS2589 deep-instantiation at registerTool().
+		// Keep unsoundness pinned to registration boundary. Revisit after upstream typings or TS inference improves.
+		pi.registerTool(tool as any);
 	};
-
-	// FIXME: Cast kept because pi 0.69.0 + TypeBox 1.x triggers TS2589 deep-instantiation at registerTool().
-	// Keep unsoundness pinned to registration boundary. Revisit after upstream typings or TS inference improves.
-	pi.registerTool(tool as any);
 }
+
+export default createPiGremlinsExtension();

--- a/extensions/pi-gremlins/primary-agent-controls.ts
+++ b/extensions/pi-gremlins/primary-agent-controls.ts
@@ -1,0 +1,153 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
+import {
+	resolvePrimaryAgentByName,
+	type PrimaryAgentDiscoveryCache,
+} from "./gremlin-discovery.js";
+import type { PrimaryAgentDefinition } from "./primary-agent-definition.js";
+import {
+	hasSelectionChanged,
+	PRIMARY_AGENT_ENTRY_TYPE,
+	selectAgentInState,
+	toSessionEntryData,
+	type PrimaryAgentState,
+} from "./primary-agent-state.js";
+
+export const PRIMARY_STATUS_KEY = "pi-gremlins-primary";
+export const PRIMARY_SHORTCUT = "ctrl+shift+m";
+
+export function formatPrimaryAgentStatus(selectedName: string | null): string {
+	return `Primary: ${selectedName ?? "None"}`;
+}
+
+export function updatePrimaryAgentStatus(
+	ctx: ExtensionContext,
+	state: PrimaryAgentState,
+): void {
+	ctx.ui.setStatus(PRIMARY_STATUS_KEY, formatPrimaryAgentStatus(state.selectedName));
+}
+
+export function notifyPrimaryAgent(
+	ctx: ExtensionContext,
+	message: string,
+	type: "info" | "warning" | "error" = "info",
+): void {
+	ctx.ui.notify(message, type);
+}
+
+function sendTranscriptMessage(pi: ExtensionAPI, content: string): void {
+	pi.sendMessage({ customType: "pi-gremlins-primary", content, display: true });
+}
+
+function getCycleOptions(
+	agents: readonly PrimaryAgentDefinition[],
+): Array<PrimaryAgentDefinition | null> {
+	return [null, ...agents];
+}
+
+export function getNextCycledPrimaryAgent(
+	agents: readonly PrimaryAgentDefinition[],
+	selectedName: string | null,
+): PrimaryAgentDefinition | null {
+	const options = getCycleOptions(agents);
+	const currentIndex = options.findIndex(
+		(agent) => (agent?.name ?? null) === selectedName,
+	);
+	return options[(currentIndex + 1) % options.length] ?? null;
+}
+
+export async function persistPrimaryAgentSelection(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	state: PrimaryAgentState,
+	agent: PrimaryAgentDefinition | null,
+): Promise<PrimaryAgentState> {
+	const nextName = agent?.name ?? null;
+	if (!hasSelectionChanged(state, nextName)) {
+		updatePrimaryAgentStatus(ctx, state);
+		return state;
+	}
+	pi.appendEntry(PRIMARY_AGENT_ENTRY_TYPE, toSessionEntryData(agent));
+	const nextState = selectAgentInState(state, agent);
+	updatePrimaryAgentStatus(ctx, nextState);
+	notifyPrimaryAgent(ctx, `Primary agent: ${nextName ?? "None"}`);
+	return nextState;
+}
+
+export async function selectPrimaryAgentByName(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	state: PrimaryAgentState,
+	discoveryCache: PrimaryAgentDiscoveryCache,
+	requestedName: string,
+): Promise<PrimaryAgentState> {
+	if (requestedName.toLowerCase() === "none") {
+		return persistPrimaryAgentSelection(pi, ctx, state, null);
+	}
+
+	const { agents } = await discoveryCache.get(ctx.cwd);
+	const resolution = resolvePrimaryAgentByName(agents, requestedName);
+	if (resolution.status === "found") {
+		return persistPrimaryAgentSelection(pi, ctx, state, resolution.agent);
+	}
+	if (resolution.status === "ambiguous") {
+		const names = resolution.matches.map((agent) => agent.name).join(", ");
+		notifyPrimaryAgent(
+			ctx,
+			`Primary agent name is ambiguous: ${requestedName}. Use exact case: ${names}`,
+			"warning",
+		);
+		updatePrimaryAgentStatus(ctx, state);
+		return state;
+	}
+	notifyPrimaryAgent(ctx, `Primary agent not found: ${requestedName}`, "warning");
+	updatePrimaryAgentStatus(ctx, state);
+	return state;
+}
+
+export async function runMohawkCommand(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	state: PrimaryAgentState,
+	discoveryCache: PrimaryAgentDiscoveryCache,
+	args: string,
+): Promise<PrimaryAgentState> {
+	const requestedName = args.trim();
+	if (requestedName) {
+		return selectPrimaryAgentByName(pi, ctx, state, discoveryCache, requestedName);
+	}
+
+	const { agents } = await discoveryCache.get(ctx.cwd);
+	if (!ctx.hasUI) {
+		sendTranscriptMessage(
+			pi,
+			`Primary agents: None${agents.length > 0 ? `, ${agents.map((agent) => agent.name).join(", ")}` : ""}`,
+		);
+		updatePrimaryAgentStatus(ctx, state);
+		return state;
+	}
+
+	const selected = await ctx.ui.select("Select primary agent", [
+		"None",
+		...agents.map((agent) => agent.name),
+	]);
+	if (!selected) {
+		updatePrimaryAgentStatus(ctx, state);
+		return state;
+	}
+	return selectPrimaryAgentByName(pi, ctx, state, discoveryCache, selected);
+}
+
+export async function cyclePrimaryAgent(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	state: PrimaryAgentState,
+	discoveryCache: PrimaryAgentDiscoveryCache,
+): Promise<PrimaryAgentState> {
+	const { agents } = await discoveryCache.get(ctx.cwd);
+	const nextAgent = getNextCycledPrimaryAgent(agents, state.selectedName);
+	return persistPrimaryAgentSelection(pi, ctx, state, nextAgent);
+}

--- a/extensions/pi-gremlins/primary-agent-definition.ts
+++ b/extensions/pi-gremlins/primary-agent-definition.ts
@@ -1,0 +1,76 @@
+import type { AgentFrontmatter, AgentSource } from "./agent-definition.js";
+import {
+	filenameStem,
+	parseAgentMarkdown,
+	readAgentMarkdown,
+	readFirstHeading,
+	readScalar,
+} from "./agent-definition.js";
+
+export interface PrimaryAgentFrontmatter extends AgentFrontmatter {
+	name?: string;
+	description?: string;
+	agent_type?: string;
+	body?: string;
+}
+
+export interface PersistedPrimaryAgentSelection {
+	selectedName: string | null;
+	source?: AgentSource;
+	filePath?: string;
+}
+
+export interface PrimaryAgentDefinition {
+	name: string;
+	description?: string;
+	source: AgentSource;
+	filePath: string;
+	rawMarkdown: string;
+	frontmatter: PrimaryAgentFrontmatter;
+	selection: PersistedPrimaryAgentSelection;
+}
+
+export function parsePrimaryAgentDefinition(
+	markdown: string,
+	filePath: string,
+	source: AgentSource,
+): PrimaryAgentDefinition | null {
+	const { frontmatter, body, hasFrontmatter } = parseAgentMarkdown(markdown);
+	if (!hasFrontmatter) return null;
+	const agentType = readScalar(frontmatter, "agent_type");
+	if (agentType !== "primary") return null;
+
+	const name =
+		readScalar(frontmatter, "name") ?? readFirstHeading(body) ?? filenameStem(filePath);
+	if (!name) return null;
+
+	const description = readScalar(frontmatter, "description");
+	const selection: PersistedPrimaryAgentSelection = {
+		selectedName: name,
+		source,
+		filePath,
+	};
+
+	return {
+		name,
+		description,
+		source,
+		filePath,
+		rawMarkdown: markdown,
+		frontmatter: {
+			...frontmatter,
+			description,
+			agent_type: agentType,
+			body,
+		},
+		selection,
+	};
+}
+
+export async function loadPrimaryAgentDefinition(
+	filePath: string,
+	source: AgentSource,
+): Promise<PrimaryAgentDefinition | null> {
+	const rawMarkdown = await readAgentMarkdown(filePath);
+	return parsePrimaryAgentDefinition(rawMarkdown, filePath, source);
+}

--- a/extensions/pi-gremlins/primary-agent-prompt.ts
+++ b/extensions/pi-gremlins/primary-agent-prompt.ts
@@ -1,0 +1,85 @@
+import type {
+	BeforeAgentStartEvent,
+	BeforeAgentStartEventResult,
+	ExtensionAPI,
+	ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
+import type { PrimaryAgentDiscoveryCache } from "./gremlin-discovery.js";
+import type { PrimaryAgentDefinition } from "./primary-agent-definition.js";
+import {
+	PRIMARY_AGENT_ENTRY_TYPE,
+	selectAgentInState,
+	toSessionEntryData,
+	type PrimaryAgentState,
+} from "./primary-agent-state.js";
+
+export const PROMPT_BLOCK_START = "<!-- pi-gremlins primary agent:start -->";
+export const PROMPT_BLOCK_END = "<!-- pi-gremlins primary agent:end -->";
+const LEGACY_PROMPT_BLOCK_START = "<!-- pi-mohawk primary agent:start -->";
+const LEGACY_PROMPT_BLOCK_END = "<!-- pi-mohawk primary agent:end -->";
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripBlock(systemPrompt: string, start: string, end: string): string {
+	return systemPrompt.replace(
+		new RegExp(`\\n{0,2}${escapeRegExp(start)}[\\s\\S]*?${escapeRegExp(end)}`, "g"),
+		"",
+	);
+}
+
+export function stripPrimaryAgentPromptBlocks(systemPrompt: string): string {
+	return stripBlock(
+		stripBlock(systemPrompt, PROMPT_BLOCK_START, PROMPT_BLOCK_END),
+		LEGACY_PROMPT_BLOCK_START,
+		LEGACY_PROMPT_BLOCK_END,
+	);
+}
+
+export function appendPrimaryAgentPromptBlock(
+	systemPrompt: string,
+	agent: PrimaryAgentDefinition,
+): string {
+	const withoutExistingBlock = stripPrimaryAgentPromptBlocks(systemPrompt);
+	return `${withoutExistingBlock}\n\n${PROMPT_BLOCK_START}\n# pi-gremlins primary agent: ${agent.name}\n\n${agent.rawMarkdown}\n${PROMPT_BLOCK_END}`;
+}
+
+export interface PromptInjectionResult {
+	state: PrimaryAgentState;
+	result: BeforeAgentStartEventResult | undefined;
+}
+
+export async function applyPrimaryAgentPromptInjection(args: {
+	pi: ExtensionAPI;
+	event: BeforeAgentStartEvent;
+	ctx: ExtensionContext;
+	state: PrimaryAgentState;
+	discoveryCache: PrimaryAgentDiscoveryCache;
+	updateStatus: (ctx: ExtensionContext, state: PrimaryAgentState) => void;
+	notify: (
+		ctx: ExtensionContext,
+		message: string,
+		type?: "info" | "warning" | "error",
+	) => void;
+}): Promise<PromptInjectionResult> {
+	if (!args.state.selectedName) return { state: args.state, result: undefined };
+	const { agents } = await args.discoveryCache.get(args.ctx.cwd);
+	const agent = agents.find((candidate) => candidate.name === args.state.selectedName);
+	if (!agent) {
+		const missingName = args.state.selectedName;
+		args.pi.appendEntry(PRIMARY_AGENT_ENTRY_TYPE, toSessionEntryData(null));
+		const nextState = selectAgentInState(args.state, null);
+		args.updateStatus(args.ctx, nextState);
+		args.notify(
+			args.ctx,
+			`Selected primary agent unavailable, reset to None: ${missingName}`,
+			"warning",
+		);
+		return { state: nextState, result: undefined };
+	}
+	return {
+		state: args.state,
+		result: { systemPrompt: appendPrimaryAgentPromptBlock(args.event.systemPrompt, agent) },
+	};
+}

--- a/extensions/pi-gremlins/primary-agent-state.ts
+++ b/extensions/pi-gremlins/primary-agent-state.ts
@@ -1,0 +1,105 @@
+import type { PrimaryAgentDefinition } from "./primary-agent-definition.js";
+
+export const PRIMARY_AGENT_ENTRY_TYPE = "pi-gremlins-primary-agent";
+export const LEGACY_PRIMARY_AGENT_ENTRY_TYPE = "pi-mohawk-primary-agent";
+
+export interface PrimaryAgentSessionEntryData {
+	selectedName: string | null;
+	source?: "user" | "project";
+	filePath?: string;
+}
+
+export interface PrimaryAgentState {
+	selectedName: string | null;
+	missingSelectedName: string | null;
+}
+
+export const NONE_SELECTION: PrimaryAgentSessionEntryData = { selectedName: null };
+
+export function createInitialPrimaryAgentState(): PrimaryAgentState {
+	return { selectedName: null, missingSelectedName: null };
+}
+
+export function isPrimaryAgentSessionEntryData(
+	value: unknown,
+): value is PrimaryAgentSessionEntryData {
+	if (!value || typeof value !== "object") return false;
+	if (!("selectedName" in value)) return false;
+	const selectedName = value.selectedName;
+	if (selectedName !== null && typeof selectedName !== "string") return false;
+	if (
+		"source" in value &&
+		value.source !== undefined &&
+		value.source !== "user" &&
+		value.source !== "project"
+	) {
+		return false;
+	}
+	if (
+		"filePath" in value &&
+		value.filePath !== undefined &&
+		typeof value.filePath !== "string"
+	) {
+		return false;
+	}
+	return true;
+}
+
+interface BranchCustomEntry {
+	type: string;
+	customType?: string;
+	data?: unknown;
+}
+
+export function reconstructPrimaryAgentStateFromBranch(
+	branchEntries: readonly BranchCustomEntry[],
+	agents: readonly PrimaryAgentDefinition[],
+): PrimaryAgentState {
+	let latestData: PrimaryAgentSessionEntryData | null = null;
+	for (const entry of [...branchEntries].reverse()) {
+		if (
+			entry.type === "custom" &&
+			(entry.customType === PRIMARY_AGENT_ENTRY_TYPE ||
+				entry.customType === LEGACY_PRIMARY_AGENT_ENTRY_TYPE) &&
+			isPrimaryAgentSessionEntryData(entry.data)
+		) {
+			latestData = entry.data;
+			break;
+		}
+	}
+
+	if (!latestData) return createInitialPrimaryAgentState();
+	if (latestData.selectedName === null) return createInitialPrimaryAgentState();
+
+	const selectedExists = agents.some(
+		(agent) => agent.name === latestData.selectedName,
+	);
+	return selectedExists
+		? { selectedName: latestData.selectedName, missingSelectedName: null }
+		: { selectedName: null, missingSelectedName: latestData.selectedName };
+}
+
+export function toSessionEntryData(
+	agent: PrimaryAgentDefinition | null,
+): PrimaryAgentSessionEntryData {
+	if (!agent) return NONE_SELECTION;
+	return {
+		selectedName: agent.name,
+		source: agent.source,
+		filePath: agent.filePath,
+	};
+}
+
+export function selectAgentInState(
+	state: PrimaryAgentState,
+	agent: PrimaryAgentDefinition | null,
+): PrimaryAgentState {
+	return { ...state, selectedName: agent?.name ?? null, missingSelectedName: null };
+}
+
+export function hasSelectionChanged(
+	state: PrimaryAgentState,
+	nextName: string | null,
+): boolean {
+	return state.selectedName !== nextName || state.missingSelectedName !== null;
+}

--- a/extensions/pi-gremlins/primary-agent.test.js
+++ b/extensions/pi-gremlins/primary-agent.test.js
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { createWorkspace, writeAgentFile } from "./test-helpers.js";
+
+let workspaceRoot = null;
+
+afterEach(() => {
+	if (workspaceRoot) {
+		fs.rmSync(workspaceRoot, { recursive: true, force: true });
+		workspaceRoot = null;
+	}
+});
+
+function writePrimaryFile(dir, fileName, body) {
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, fileName), body, "utf-8");
+}
+
+function createMockPi() {
+	const handlers = new Map();
+	return {
+		tools: [],
+		commands: new Map(),
+		shortcuts: new Map(),
+		entries: [],
+		messages: [],
+		on(event, handler) {
+			handlers.set(event, handler);
+		},
+		handler(event) {
+			return handlers.get(event);
+		},
+		registerTool(tool) {
+			this.tools.push(tool);
+		},
+		registerCommand(name, options) {
+			this.commands.set(name, options);
+		},
+		registerShortcut(shortcut, options) {
+			this.shortcuts.set(shortcut, options);
+		},
+		appendEntry(customType, data) {
+			this.entries.push({ customType, data });
+		},
+		sendMessage(message) {
+			this.messages.push(message);
+		},
+	};
+}
+
+function createMockContext(workspace, branchEntries = [], hasUI = false) {
+	return {
+		cwd: workspace.repoRoot,
+		hasUI,
+		ui: {
+			statuses: [],
+			notifications: [],
+			selected: undefined,
+			setStatus(key, text) {
+				this.statuses.push({ key, text });
+			},
+			notify(message, type = "info") {
+				this.notifications.push({ message, type });
+			},
+			async select() {
+				return this.selected;
+			},
+		},
+		sessionManager: {
+			getBranch() {
+				return branchEntries;
+			},
+		},
+		getSystemPrompt() {
+			return "system";
+		},
+		model: undefined,
+		modelRegistry: undefined,
+	};
+}
+
+describe("primary-agent definition and discovery", () => {
+	test("loads only primary agents and applies display-name fallback order", async () => {
+		const { parsePrimaryAgentDefinition } = await import("./primary-agent-definition.ts");
+		const byName = parsePrimaryAgentDefinition(
+			"---\nname: Commander\nagent_type: primary\n---\n# Heading",
+			"/tmp/file.md",
+			"user",
+		);
+		const byHeading = parsePrimaryAgentDefinition(
+			"---\nagent_type: primary\n---\n# Heading Name",
+			"/tmp/file.md",
+			"user",
+		);
+		const byFile = parsePrimaryAgentDefinition(
+			"---\nagent_type: primary\n---\nNo heading",
+			"/tmp/file-name.md",
+			"user",
+		);
+		const subAgent = parsePrimaryAgentDefinition(
+			"---\nname: sub\nagent_type: sub-agent\n---\n# Sub",
+			"/tmp/sub.md",
+			"user",
+		);
+
+		expect(byName?.name).toBe("Commander");
+		expect(byHeading?.name).toBe("Heading Name");
+		expect(byFile?.name).toBe("file-name");
+		expect(subAgent).toBeNull();
+	});
+
+	test("keeps primary agents separate from gremlins and lets project override user", async () => {
+		const { createGremlinDiscoveryCache, createPrimaryAgentDiscoveryCache } = await import("./gremlin-discovery.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.userAgentsDir, "shared.md", "---\nname: shared\nagent_type: primary\n---\nuser primary");
+		writeAgentFile(workspace.userAgentsDir, "gremlin.md", "gremlin");
+		writePrimaryFile(workspace.projectAgentsDir, "shared.md", "---\nname: shared\nagent_type: primary\n---\nproject primary");
+		writePrimaryFile(workspace.projectAgentsDir, "other.md", "---\nagent_type: primary\n---\n# Other Primary");
+
+		const primaryDiscovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const gremlinDiscovery = createGremlinDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const primary = await primaryDiscovery.get(workspace.repoRoot);
+		const gremlins = await gremlinDiscovery.get(workspace.repoRoot);
+
+		expect(primary.agents.map((agent) => ({ name: agent.name, source: agent.source }))).toEqual([
+			{ name: "Other Primary", source: "project" },
+			{ name: "shared", source: "project" },
+		]);
+		expect(primary.agents.find((agent) => agent.name === "shared").rawMarkdown).toContain("project primary");
+		expect(gremlins.gremlins.map((gremlin) => gremlin.name)).toEqual(["gremlin"]);
+	});
+
+	test("resolves exact, unambiguous folded, ambiguous folded, and missing names", async () => {
+		const { resolvePrimaryAgentByName } = await import("./gremlin-discovery.ts");
+		const agents = ["Alpha", "ALPHA", "Beta"].map((name) => ({ name }));
+
+		expect(resolvePrimaryAgentByName(agents, "Beta")).toMatchObject({ status: "found", agent: { name: "Beta" } });
+		expect(resolvePrimaryAgentByName(agents, "beta")).toMatchObject({ status: "found", agent: { name: "Beta" } });
+		expect(resolvePrimaryAgentByName(agents, "alpha")).toMatchObject({ status: "ambiguous" });
+		expect(resolvePrimaryAgentByName(agents, "missing")).toEqual({ status: "not-found" });
+	});
+});
+
+describe("primary-agent state, controls, and prompt injection", () => {
+	test("reconstructs legacy state and writes new pi-gremlins entry without raw markdown", async () => {
+		const { createPrimaryAgentDiscoveryCache } = await import("./gremlin-discovery.ts");
+		const { createPiGremlinsExtension } = await import("./index.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.userAgentsDir, "wall.md", "---\nname: Wall\nagent_type: primary\n---\nsecret raw markdown");
+		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const pi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(pi);
+		const ctx = createMockContext(workspace, [
+			{ type: "custom", customType: "pi-mohawk-primary-agent", data: { selectedName: "Wall", source: "user", filePath: "old" } },
+		]);
+
+		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
+		await pi.commands.get("mohawk").handler("none", ctx);
+
+		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
+		expect(pi.entries).toEqual([{ customType: "pi-gremlins-primary-agent", data: { selectedName: null } }]);
+		expect(JSON.stringify(pi.entries)).not.toContain("secret raw markdown");
+	});
+
+	test("command, no-ui listing, shortcut, and prompt injection use selected primary", async () => {
+		const { createPrimaryAgentDiscoveryCache } = await import("./gremlin-discovery.ts");
+		const { createPiGremlinsExtension } = await import("./index.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.userAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
+		writePrimaryFile(workspace.userAgentsDir, "beta.md", "---\nname: Beta\nagent_type: primary\n---\nbeta prompt");
+		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const pi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(pi);
+		const ctx = createMockContext(workspace);
+
+		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
+		await pi.commands.get("mohawk").handler("", ctx);
+		expect(pi.messages.at(-1).content).toBe("Primary agents: None, Alpha, Beta");
+
+		await pi.commands.get("mohawk").handler("beta", ctx);
+		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: Beta" });
+		const injected = await pi.handler("before_agent_start")({ type: "before_agent_start", systemPrompt: "system", prompt: "go", systemPromptOptions: {} }, ctx);
+		expect(injected.systemPrompt).toContain("<!-- pi-gremlins primary agent:start -->");
+		expect(injected.systemPrompt).toContain("# pi-gremlins primary agent: Beta");
+		expect(injected.systemPrompt).toContain("beta prompt");
+
+		await pi.shortcuts.get("ctrl+shift+m").handler(ctx);
+		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
+	});
+
+	test("prompt injection strips existing pi-gremlins and legacy pi-mohawk blocks", async () => {
+		const { appendPrimaryAgentPromptBlock } = await import("./primary-agent-prompt.ts");
+		const agent = { name: "Wall", rawMarkdown: "---\nname: Wall\nagent_type: primary\n---\nwall prompt" };
+		const prompt = [
+			"system",
+			"<!-- pi-mohawk primary agent:start -->old<!-- pi-mohawk primary agent:end -->",
+			"<!-- pi-gremlins primary agent:start -->old<!-- pi-gremlins primary agent:end -->",
+		].join("\n");
+		const result = appendPrimaryAgentPromptBlock(prompt, agent);
+
+		expect(result).not.toContain("pi-mohawk primary agent:start");
+		expect(result.match(/pi-gremlins primary agent:start/g)).toHaveLength(1);
+		expect(result).toContain("wall prompt");
+	});
+});

--- a/extensions/pi-gremlins/v1-contract-harness.js
+++ b/extensions/pi-gremlins/v1-contract-harness.js
@@ -101,16 +101,31 @@ export function setCreateAgentSessionImpl(impl) {
 export function createExtensionHarness() {
 	let registeredTool;
 	const commands = new Map();
+	const shortcuts = new Map();
+	const handlers = new Map();
+	const entries = [];
+	const messages = [];
 	registerPiGremlins({
-		on: () => {},
+		on: (event, handler) => {
+			handlers.set(event, handler);
+		},
 		registerCommand: (name, command) => {
 			commands.set(name, command);
+		},
+		registerShortcut: (shortcut, shortcutOptions) => {
+			shortcuts.set(shortcut, shortcutOptions);
 		},
 		registerTool: (tool) => {
 			registeredTool = tool;
 		},
+		appendEntry: (customType, data) => {
+			entries.push({ customType, data });
+		},
+		sendMessage: (message) => {
+			messages.push(message);
+		},
 	});
-	return { tool: registeredTool, commands };
+	return { tool: registeredTool, commands, shortcuts, handlers, entries, messages };
 }
 
 export function createRegisteredTool() {


### PR DESCRIPTION
Closes #39

## Issue context
Issue #39 requests deprecating `pi-mohawk` by moving primary-agent selection, session state, status/shortcut controls, and prompt injection into `pi-gremlins` while preserving the existing v1 gremlin tool contract.

## Summary
- Added role-aware agent parsing/discovery for `agent_type: sub-agent` gremlins and `agent_type: primary` primary agents with strict role separation and project-over-user precedence.
- Added primary-agent session state, `/mohawk` compatibility command, `Ctrl+Shift+M` cycling, `Primary: <name|None>` status updates, and `before_agent_start` prompt injection.
- Reads legacy `pi-mohawk-primary-agent` session entries for migration, writes new `pi-gremlins-primary-agent` entries only, and strips legacy prompt blocks before appending selected primary-agent markdown.
- Updated README, CHANGELOG, PRD-0003, ADR-0003, and implementation plan; added focused Bun coverage for primary-agent behavior.

## Verification
- `npm run typecheck` ✅
- `npm test` ✅ 52 tests passed
- `npm run check` ✅ typecheck + 52 tests passed
- `rg "pi-mohawk|mohawk|primary-agent" extensions docs README.md CHANGELOG.md` ✅ intentional compatibility/deprecation references only

## Risks / follow-ups
- Users running old `pi-mohawk` and new `pi-gremlins` simultaneously can get duplicate command/shortcut/status/prompt-hook behavior; README now warns to disable or uninstall `pi-mohawk` after confirming migration.
- Separate `pi-mohawk` package deprecation docs are outside this repo/worktree and remain follow-up after this PR lands.
