### PR TITLE
fix: isolate gremlin child prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Runtime cache hot paths now use compact render cache keys, per-entry render segment reuse, and memoized discovery directory listings to reduce repeated string and filesystem churn during active gremlin runs.
 
 ### Fixed
+- **Gremlin child prompt isolation** (PRD-0002, ADR-0002, ADR-0003, issue #41): child sessions now use selected sub-agent markdown as their system prompt and no longer receive parent prompt snapshots, primary-agent prompt blocks, active primary-agent markdown, or orchestration rules.
 - Hardened gremlin runtime reliability around child-session cleanup, abort handling, discovery file failures, request validation, CRLF gremlin frontmatter parsing, unresolved model selection, and parent-abort progress updates.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ Runtime behavior:
 - `intent` is required and states why the parent is delegating or what outcome the gremlin should serve
 - `context` is required and carries concrete task details, constraints, paths, findings, and requested output
 - child sessions run in-process through Pi SDK
-- child sessions inherit parent system prompt snapshot only
+- child session system prompt is the selected gremlin raw markdown only
+- child user prompt carries caller `intent` and `context` only
+- child sessions do not inherit parent system prompt snapshots, primary-agent prompt blocks, active primary-agent markdown, orchestration rules, or conversation history
 - no nested Pi CLI subprocesses
 - no temp prompt files
 - child sessions do not load extensions, skills, prompts, themes, or AGENTS files
@@ -175,6 +177,7 @@ Prompt behavior:
 
 - selected primary-agent raw markdown is appended during `before_agent_start` inside `<!-- pi-gremlins primary agent:start -->` / `<!-- pi-gremlins primary agent:end -->`.
 - existing `pi-gremlins` and legacy `pi-mohawk` primary-agent blocks are stripped before appending to avoid duplicate injection.
+- primary-agent prompt blocks stay parent-only and are never propagated into gremlin child sessions.
 - `agent_type: sub-agent` gremlins are never injected as primary agents.
 
 Migration from `pi-mohawk`:

--- a/docs/adr/0002-in-process-sdk-based-gremlin-runtime.md
+++ b/docs/adr/0002-in-process-sdk-based-gremlin-runtime.md
@@ -42,7 +42,7 @@ Pi's own documentation in `docs/sdk.md` explicitly recommends using `AgentSessio
 
 - Reliability: eliminate stuck nested Pi subprocesses as default failure class.
 - Performance: remove CLI startup, JSON serialization/parsing, temp file I/O, and extra process lifetime management.
-- Isolation correctness: child gremlins must receive only computed system prompt, gremlin markdown, passed intent, and passed context.
+- Isolation correctness: child gremlins must receive selected gremlin markdown as their system prompt plus passed intent/context as their user prompt; parent system prompt snapshots, primary-agent prompt blocks, and orchestration rules must not cross into child sessions.
 - Scope reduction: architecture should match slimmed v1 surface, not legacy viewer/chain feature set.
 - Maintainability: smaller, testable module graph with no new god file.
 - Abort behavior: cancellation must be structured, deterministic, and easy to prove in tests.
@@ -105,10 +105,11 @@ Rationale: User asked for full rewrite because subprocess termination has been p
   - Architecture better matches Pi's documented SDK usage model.
 - **Negative:**
   - OS-process isolation is intentionally traded away.
-  - Child-session isolation must be enforced through custom resource loading and test coverage, not by separate process default.
+  - Child-session isolation must be enforced through custom resource loading, gremlin-only system prompt construction, and test coverage, not by separate process default.
   - Existing viewer-specific architecture and chain runtime become dead code and must be deleted after cutover.
 - **Follow-on constraints:**
   - Child gremlins must not bind parent extensions or load ambient AGENTS/skills/prompts/themes.
+  - Child gremlins must not receive parent system prompt snapshots, primary-agent prompt blocks, active primary-agent markdown, or parent orchestration rules.
   - Inline rendering becomes only supported inspection surface for v1.
   - If subprocess isolation is revisited later, it requires a new ADR instead of quietly reintroducing process management.
 
@@ -160,3 +161,4 @@ This ADR intentionally supersedes ADR-0001. ADR-0001 optimized popup viewer and 
 
 - 2026-04-22: Accepted; supersedes ADR-0001 in favor of SDK-based in-process child sessions and inline-only v1 UI
 - 2026-04-24: Noted required per-gremlin `intent` field as part of public v1 request contract and child prompt framing
+- 2026-04-25: Clarified issue #41 prompt-isolation boundary after primary-agent merge: gremlin child sessions use selected sub-agent markdown as system prompt and do not propagate parent prompt snapshots or primary-agent blocks

--- a/docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md
+++ b/docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md
@@ -109,6 +109,7 @@ The implementation must follow these architectural constraints:
   - Future changes to primary-agent persisted state or prompt-injection delimiters require ADR review because they affect session compatibility and runtime prompt composition.
   - Any future removal of `/mohawk` compatibility controls must be treated as a user-facing product decision, not hidden cleanup.
   - Shared discovery must continue to enforce role separation and must not use primary-agent markdown as gremlin prompt material or gremlin markdown as primary-agent prompt material.
+  - Primary-agent prompt injection is parent-session-only; gremlin child sessions must not receive injected primary-agent blocks or active primary-agent markdown.
 
 ## Implementation Impact
 
@@ -130,6 +131,7 @@ The implementation must follow these architectural constraints:
   - Focused Bun tests for session state reconstruction from `pi-gremlins-primary-agent` and legacy `pi-mohawk-primary-agent` entries, with writes only to `pi-gremlins-primary-agent`.
   - Focused Bun tests for `/mohawk` command behavior, `ctrl+shift+m` cycling, no-UI fallback messaging, and `Primary: <name|None>` status updates.
   - Focused Bun tests for `before_agent_start` injection, duplicate block stripping, legacy block stripping, missing selected-agent reset, and no prompt mutation when selection is `None`.
+  - Focused Bun tests proving gremlin child-session prompts exclude primary-agent markers and active primary-agent markdown even when parent-session injection is enabled.
   - Full repository verification after implementation: `npm run typecheck`, `npm test`, and `npm run check`.
 - **Manual:**
   - Install updated `pi-gremlins`, select a primary agent, send a prompt, and confirm selected primary markdown affects the parent agent.
@@ -145,3 +147,4 @@ ADR-0002 still governs gremlin execution architecture. If implementation pressur
 ## Status History
 
 - 2026-04-25: Accepted; records issue #39 package-boundary decision to merge primary-agent selection and prompt injection into `pi-gremlins` while deprecating separate `pi-mohawk` package after equivalent behavior ships
+- 2026-04-25: Clarified issue #41 isolation constraint that primary-agent prompt injection stays parent-only and is excluded from gremlin child sessions

--- a/docs/prd/0002-pi-gremlins-v1-sdk-rewrite.md
+++ b/docs/prd/0002-pi-gremlins-v1-sdk-rewrite.md
@@ -18,7 +18,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - One invocation shape only.
 - One to ten gremlins only.
 - More than one gremlin means true parallel execution.
-- Each gremlin gets only current computed system prompt, its own markdown definition, caller-supplied intent, and caller-supplied context.
+- Each gremlin gets its own markdown definition as child system prompt, plus caller-supplied intent and caller-supplied context as the child user prompt.
 - No full parent conversation history.
 - No chain mode.
 - No popup viewer, no `/gremlins:view`, no targeted steering command.
@@ -30,7 +30,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - Remove subprocess-management class of bugs from default runtime architecture.
 - Reduce latency per gremlin by eliminating extra Pi CLI startup, JSONL parsing, and temp prompt files.
 - Ship one narrow, easy-to-understand v1 surface instead of many partially overlapping modes.
-- Preserve prompt isolation strictly: no inherited conversation transcript, no inherited AGENTS files, no inherited extensions/skills/prompts in child sessions.
+- Preserve prompt isolation strictly: no inherited conversation transcript, parent prompt snapshot, primary-agent prompt block, AGENTS file, extension, skill, or prompt in child sessions.
 - Keep inline progress useful during execution without restoring popup/view complexity.
 
 ## User Stories
@@ -61,10 +61,10 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - If `gremlins.length > 1`, start all gremlins in parallel with no hidden lower concurrency cap.
 - Parse gremlin frontmatter for runtime config such as model / thinking / tools when present.
 - Build child sessions with:
-  - current computed parent system prompt snapshot
-  - raw gremlin markdown contents
-  - caller-supplied intent string
-  - caller-supplied context string
+  - selected gremlin raw markdown contents as the child system prompt
+  - caller-supplied intent string in the child user prompt
+  - caller-supplied context string in the child user prompt
+  - no parent system prompt snapshot, primary-agent prompt block, active primary-agent markdown, orchestration rules, or parent conversation history
   - in-memory session manager
   - custom resource loader that disables inherited extensions, prompts, skills, themes, AGENTS files, and conversation history
 - Inline progress model with per-gremlin status, current activity, latest text/tool summary, usage, and terminal outcome.
@@ -94,7 +94,8 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - [ ] Duplicate gremlin names resolve deterministically with project-local definition winning over user-level definition among typed sub-agent files.
 - [ ] Child gremlin sessions do not receive parent conversation history.
 - [ ] Child gremlin sessions do not load AGENTS files, extensions, prompts, skills, or themes from parent runtime.
-- [ ] Child gremlin sessions receive current computed system prompt snapshot, raw gremlin markdown contents, supplied intent, and supplied context only.
+- [ ] Child gremlin sessions receive selected gremlin raw markdown as system prompt plus supplied intent and context as user prompt only.
+- [ ] Child gremlin sessions do not receive parent system prompt snapshots, primary-agent prompt blocks, active primary-agent markdown, orchestration rules, or parent conversation history.
 - [ ] More than one gremlin request starts parallel execution immediately; runtime does not serialize by default and does not impose lower internal concurrency than requested gremlin count.
 - [ ] Abort from parent tool execution cancels every running gremlin session and leaves no active child sessions registered after completion.
 - [ ] Tool row shows inline live progress for every gremlin while execution is active.
@@ -159,3 +160,4 @@ Primary references used for this PRD:
 
 - 2026-04-22: Draft created
 - 2026-04-24: V1 request contract updated to require per-gremlin `intent` separate from `context`
+- 2026-04-25: Prompt isolation refined for issue #41 so gremlin child sessions receive selected sub-agent markdown only as system prompt; parent snapshots and primary-agent prompt blocks stay out of child sessions

--- a/extensions/pi-gremlins/gremlin-prompt.ts
+++ b/extensions/pi-gremlins/gremlin-prompt.ts
@@ -1,23 +1,13 @@
 export interface BuildGremlinPromptOptions {
-	parentSystemPrompt: string;
-	rawMarkdown: string;
 	intent: string;
 	context: string;
 }
 
 export function buildGremlinPrompt({
-	parentSystemPrompt,
-	rawMarkdown,
 	intent,
 	context,
 }: BuildGremlinPromptOptions): string {
 	return [
-		"Parent system prompt snapshot:",
-		parentSystemPrompt,
-		"",
-		"Gremlin definition markdown:",
-		rawMarkdown,
-		"",
 		"Caller intent:",
 		intent,
 		"",

--- a/extensions/pi-gremlins/gremlin-runner.test.js
+++ b/extensions/pi-gremlins/gremlin-runner.test.js
@@ -38,8 +38,8 @@ describe("gremlin runner v1 contract", () => {
 		const fake = createFakeSession({
 			getContextUsage: () => ({ tokens: 6, contextWindow: 200000, percent: 0.003 }),
 			onPrompt: async ({ text, emit }) => {
-				expect(text).toContain("Parent system prompt snapshot:");
-				expect(text).toContain("raw gremlin body");
+				expect(text).not.toContain("Parent system prompt snapshot:");
+				expect(text).not.toContain("raw gremlin body");
 				expect(text).toContain("Caller intent:");
 				expect(text).toContain("Inspect implementation independently");
 				expect(text).toContain("Caller context:");
@@ -98,7 +98,6 @@ describe("gremlin runner v1 contract", () => {
 				rawMarkdown: "---\nname: researcher\nmodel: openai/gpt-5-mini\n---\nraw gremlin body",
 				frontmatter: { model: "openai/gpt-5-mini" },
 			},
-			parentSystemPrompt: "system snapshot",
 			onUpdate: (update) => updates.push(update),
 			createSession: async () => fake,
 		});
@@ -173,7 +172,6 @@ describe("gremlin runner v1 contract", () => {
 				rawMarkdown: "---\nname: researcher\n---\nraw gremlin body",
 				frontmatter: {},
 			},
-			parentSystemPrompt: "system snapshot",
 			onUpdate: (update) => updates.push(update),
 			createSession: async () => fake,
 		});
@@ -219,7 +217,6 @@ describe("gremlin runner v1 contract", () => {
 				rawMarkdown: "---\nname: researcher\n---\nraw gremlin body",
 				frontmatter: {},
 			},
-			parentSystemPrompt: "system snapshot",
 			createSession: async () => fake,
 		});
 
@@ -244,7 +241,6 @@ describe("gremlin runner v1 contract", () => {
 				rawMarkdown: "---\nname: researcher\n---\nraw gremlin body",
 				frontmatter: {},
 			},
-			parentSystemPrompt: "system snapshot",
 			createSession: async () => ({
 				session: {
 					subscribe() {
@@ -276,7 +272,6 @@ describe("gremlin runner v1 contract", () => {
 				rawMarkdown: "---\nname: researcher\nmodel: openai/missing\n---\nraw gremlin body",
 				frontmatter: { model: "openai/missing" },
 			},
-			parentSystemPrompt: "system snapshot",
 			modelRegistry: {
 				getAll: () => [],
 				find: () => undefined,
@@ -312,7 +307,6 @@ describe("gremlin runner v1 contract", () => {
 				rawMarkdown: "---\nname: researcher\n---\nraw gremlin body",
 				frontmatter: {},
 			},
-			parentSystemPrompt: "system snapshot",
 			signal: controller.signal,
 			createSession: async () => fake,
 		});
@@ -338,7 +332,6 @@ describe("gremlin runner v1 contract", () => {
 				rawMarkdown: "---\nname: reviewer\n---\nreview body",
 				frontmatter: {},
 			},
-			parentSystemPrompt: "system snapshot",
 			createSession: async () => failing,
 		});
 		expect(failed.status).toBe("failed");
@@ -376,7 +369,6 @@ describe("gremlin runner v1 contract", () => {
 				rawMarkdown: "---\nname: researcher\n---\nraw gremlin body",
 				frontmatter: {},
 			},
-			parentSystemPrompt: "system snapshot",
 			signal: controller.signal,
 			createSession: async () => fake,
 		});

--- a/extensions/pi-gremlins/gremlin-runner.ts
+++ b/extensions/pi-gremlins/gremlin-runner.ts
@@ -27,7 +27,6 @@ export interface RunSingleGremlinOptions {
 	gremlinId: string;
 	request: GremlinRequest;
 	definition: GremlinDefinition;
-	parentSystemPrompt: string;
 	parentModel?: string | Model<any>;
 	parentThinking?: ThinkingLevel;
 	modelRegistry?: ModelRegistry;
@@ -125,7 +124,6 @@ export async function runSingleGremlin({
 	gremlinId,
 	request,
 	definition,
-	parentSystemPrompt,
 	parentModel,
 	parentThinking,
 	modelRegistry,
@@ -182,7 +180,6 @@ export async function runSingleGremlin({
 	});
 
 	const sessionPlan = buildGremlinSessionConfig({
-		parentSystemPrompt,
 		parentModel,
 		parentThinking,
 		gremlin: definition,
@@ -248,7 +245,6 @@ export async function runSingleGremlin({
 
 	try {
 		const created = await createSession({
-			parentSystemPrompt,
 			parentModel,
 			parentThinking,
 			gremlin: definition,

--- a/extensions/pi-gremlins/gremlin-session-factory.test.js
+++ b/extensions/pi-gremlins/gremlin-session-factory.test.js
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
+const PRIMARY_BLOCK_START = "<!-- pi-gremlins primary agent:start -->";
+const PRIMARY_BLOCK_END = "<!-- pi-gremlins primary agent:end -->";
+
 describe("gremlin session factory v1 contract", () => {
-	test("builds child session config from parent system prompt raw gremlin markdown caller intent and caller context only", async () => {
+	test("builds child session config from raw gremlin markdown caller intent and caller context only", async () => {
 		const { buildGremlinPrompt } = await import("./gremlin-prompt.ts");
 		const { buildGremlinSessionConfig } = await import(
 			"./gremlin-session-factory.ts"
 		);
 
-		const parentSystemPrompt = "parent computed system prompt snapshot";
 		const rawMarkdown = [
 			"---",
 			"name: researcher",
@@ -20,13 +22,10 @@ describe("gremlin session factory v1 contract", () => {
 		const intent = "Map architecture before parent edits auth code";
 		const context = "Find auth flow entry points";
 		const prompt = buildGremlinPrompt({
-			parentSystemPrompt,
-			rawMarkdown,
 			intent,
 			context,
 		});
 		const config = buildGremlinSessionConfig({
-			parentSystemPrompt,
 			parentModel: "gpt-5",
 			parentThinking: "medium",
 			gremlin: {
@@ -43,14 +42,13 @@ describe("gremlin session factory v1 contract", () => {
 			context,
 		});
 
-		expect(prompt).toContain(parentSystemPrompt);
-		expect(prompt).toContain(rawMarkdown);
+		expect(prompt).not.toContain(rawMarkdown);
 		expect(prompt).toContain("Caller intent:");
 		expect(prompt).toContain(intent);
 		expect(prompt).toContain("Caller context:");
 		expect(prompt).toContain(context);
 		expect(config).toMatchObject({
-			systemPrompt: parentSystemPrompt,
+			systemPrompt: rawMarkdown,
 			prompt,
 			model: "gpt-5-mini",
 			thinking: "high",
@@ -63,6 +61,53 @@ describe("gremlin session factory v1 contract", () => {
 				themes: [],
 			},
 		});
+		expect(config.resourceLoader.getSystemPrompt()).toBe(rawMarkdown);
+	});
+
+	test("excludes parent primary-agent prompt blocks from child session system prompt and user prompt", async () => {
+		const { buildGremlinSessionConfig } = await import(
+			"./gremlin-session-factory.ts"
+		);
+
+		const parentPromptSnapshot = [
+			"Parent rules before injected block.",
+			PRIMARY_BLOCK_START,
+			"# pi-gremlins primary agent: Orchestrator",
+			"Primary-only orchestration rules must stay in parent session.",
+			PRIMARY_BLOCK_END,
+			"Parent rules after injected block.",
+		].join("\n");
+		const rawMarkdown = [
+			"---",
+			"name: TARS",
+			"agent_type: sub-agent",
+			"---",
+			"Sub-agent markdown allowed in child session.",
+		].join("\n");
+		const config = buildGremlinSessionConfig({
+			parentModel: "openai/gpt-5",
+			gremlin: {
+				name: "TARS",
+				source: "project",
+				rawMarkdown,
+				frontmatter: {},
+			},
+			intent: "Research safely",
+			context: "Inspect isolation behavior without parent orchestration rules.",
+		});
+
+		expect(config.systemPrompt).toBe(rawMarkdown);
+		expect(config.systemPrompt).toContain("Sub-agent markdown allowed");
+		for (const leakedParentFragment of [
+			...parentPromptSnapshot.split("\n"),
+			PRIMARY_BLOCK_START,
+			PRIMARY_BLOCK_END,
+			"Primary-only orchestration rules",
+		]) {
+			expect(config.systemPrompt).not.toContain(leakedParentFragment);
+			expect(config.prompt).not.toContain(leakedParentFragment);
+		}
+		expect(config.resourceLoader.getSystemPrompt()).toBe(rawMarkdown);
 	});
 
 	test("creates empty isolated resource loader with no extensions prompts skills themes or AGENTS files", async () => {
@@ -70,7 +115,7 @@ describe("gremlin session factory v1 contract", () => {
 			"./gremlin-session-factory.ts"
 		);
 
-		const loader = createIsolatedGremlinResourceLoader("snapshot system prompt");
+		const loader = createIsolatedGremlinResourceLoader("sub-agent system prompt");
 		expect(loader.getExtensions()).toMatchObject({
 			extensions: [],
 			errors: [],
@@ -79,7 +124,7 @@ describe("gremlin session factory v1 contract", () => {
 		expect(loader.getPrompts()).toEqual({ prompts: [], diagnostics: [] });
 		expect(loader.getThemes()).toEqual({ themes: [], diagnostics: [] });
 		expect(loader.getAgentsFiles()).toEqual({ agentsFiles: [] });
-		expect(loader.getSystemPrompt()).toBe("snapshot system prompt");
+		expect(loader.getSystemPrompt()).toBe("sub-agent system prompt");
 		expect(loader.getAppendSystemPrompt()).toEqual([]);
 	});
 
@@ -127,7 +172,6 @@ describe("gremlin session factory v1 contract", () => {
 		});
 		expect(
 			buildGremlinSessionConfig({
-				parentSystemPrompt: "snapshot",
 				parentModel: "openai/gpt-5",
 				gremlin: {
 					name: "reviewer",
@@ -151,7 +195,6 @@ describe("gremlin session factory v1 contract", () => {
 		);
 
 		const config = buildGremlinSessionConfig({
-			parentSystemPrompt: "snapshot",
 			parentModel: "openai/gpt-5",
 			parentThinking: "low",
 			gremlin: {

--- a/extensions/pi-gremlins/gremlin-session-factory.ts
+++ b/extensions/pi-gremlins/gremlin-session-factory.ts
@@ -22,7 +22,6 @@ const VALID_THINKING_LEVELS = new Set<ThinkingLevel>([
 ]);
 
 export interface BuildGremlinSessionConfigOptions {
-	parentSystemPrompt: string;
 	parentModel?: string | Model<any>;
 	parentThinking?: ThinkingLevel;
 	gremlin: Pick<GremlinDefinition, "name" | "source" | "rawMarkdown" | "frontmatter">;
@@ -147,7 +146,6 @@ export function resolveGremlinThinking(
 }
 
 export function buildGremlinSessionConfig({
-	parentSystemPrompt,
 	parentModel,
 	parentThinking,
 	gremlin,
@@ -167,12 +165,10 @@ export function buildGremlinSessionConfig({
 		gremlin.frontmatter.thinking,
 		parentThinking,
 	);
-	const systemPrompt = parentSystemPrompt;
+	const systemPrompt = gremlin.rawMarkdown;
 	return {
 		systemPrompt,
 		prompt: buildGremlinPrompt({
-			parentSystemPrompt,
-			rawMarkdown: gremlin.rawMarkdown,
 			intent,
 			context,
 		}),

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -299,7 +299,6 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 							gremlinId,
 							request,
 							definition: gremlin,
-							parentSystemPrompt: ctx.getSystemPrompt(),
 							parentModel: ctx.model,
 							modelRegistry: ctx.modelRegistry,
 							signal: childSignal,


### PR DESCRIPTION
## Summary
- Change gremlin child session system prompt to selected sub-agent raw markdown only
- Remove parent system prompt snapshots from gremlin user prompt construction and runner/index handoff
- Add regression coverage for primary-agent prompt marker/content exclusion
- Update README, CHANGELOG, PRD-0002, ADR-0002, and ADR-0003 to document parent-only primary-agent prompt behavior

## Verification
- npm test
- npm run typecheck
- npm run check

Closes #41