### PR TITLE
Fix primary-agent selection persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Runtime cache hot paths now use compact render cache keys, per-entry render segment reuse, and memoized discovery directory listings to reduce repeated string and filesystem churn during active gremlin runs.
 
 ### Fixed
+- **Primary-agent selection persistence** (PRD-0003, ADR-0003, issue #42): `/mohawk` selections, shortcut cycling, and cleared primary-agent state now persist in project-local `.pi/settings.json`, restore in fresh Pi sessions, and reset with a warning if the saved primary agent disappears.
 - **Gremlin child prompt isolation** (PRD-0002, ADR-0002, ADR-0003, issue #41): child sessions now use selected sub-agent markdown as their system prompt and no longer receive parent prompt snapshots, primary-agent prompt blocks, active primary-agent markdown, or orchestration rules.
 - Hardened gremlin runtime reliability around child-session cleanup, abort handling, discovery file failures, request validation, CRLF gremlin frontmatter parsing, unresolved model selection, and parent-abort progress updates.
 

--- a/README.md
+++ b/README.md
@@ -167,11 +167,13 @@ Controls:
 
 Session behavior:
 
-- selection is current-session branch state, not global config.
-- new entries are persisted as `pi-gremlins-primary-agent` with selected name, source, and file path only.
+- selection is restored across Pi sessions from project-local `.pi/settings.json` under `pi-gremlins.primaryAgent`; this avoids surprising cross-project primary-agent injection.
+- current-session branch entries still take precedence when present.
+- `/mohawk <name>`, picker selection, `Ctrl+Shift+M`, and `/mohawk none` persist selected name, source, and file path only.
+- new session entries are also appended as `pi-gremlins-primary-agent` for branch history compatibility.
 - legacy `pi-mohawk-primary-agent` entries are read for migration; new writes use `pi-gremlins-primary-agent`.
-- raw primary-agent markdown is never stored in session entries.
-- missing selected primary agent resets to `None` and warns instead of injecting stale markdown.
+- raw primary-agent markdown is never stored in session entries or settings.
+- missing selected primary agent resets to `None` in project settings and warns instead of injecting stale markdown.
 
 Prompt behavior:
 

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -38,8 +38,13 @@ import {
 } from "./primary-agent-controls.js";
 import { applyPrimaryAgentPromptInjection } from "./primary-agent-prompt.js";
 import {
+	clearPersistedPrimaryAgentSelection,
+	readPersistedPrimaryAgentSelection,
+} from "./primary-agent-persistence.js";
+import {
 	createInitialPrimaryAgentState,
-	reconstructPrimaryAgentStateFromBranch,
+	getLatestPrimaryAgentSessionEntryData,
+	reconstructPrimaryAgentStateFromData,
 	type PrimaryAgentState,
 } from "./primary-agent-state.js";
 
@@ -151,12 +156,19 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 			discovery.clear();
 			primaryAgentDiscovery.clear();
 			const { agents } = await primaryAgentDiscovery.get(ctx.cwd);
-			primaryAgentState = reconstructPrimaryAgentStateFromBranch(
+			const branchSelection = getLatestPrimaryAgentSessionEntryData(
 				ctx.sessionManager.getBranch(),
+			);
+			const persistedSelection = branchSelection
+				? null
+				: readPersistedPrimaryAgentSelection(ctx.cwd);
+			primaryAgentState = reconstructPrimaryAgentStateFromData(
+				branchSelection ?? persistedSelection,
 				agents,
 			);
 			updatePrimaryAgentStatus(ctx, primaryAgentState);
 			if (primaryAgentState.missingSelectedName) {
+				clearPersistedPrimaryAgentSelection(ctx.cwd);
 				notifyPrimaryAgent(
 					ctx,
 					`Primary agent unavailable, reset to None: ${primaryAgentState.missingSelectedName}`,

--- a/extensions/pi-gremlins/primary-agent-controls.ts
+++ b/extensions/pi-gremlins/primary-agent-controls.ts
@@ -8,6 +8,7 @@ import {
 	type PrimaryAgentDiscoveryCache,
 } from "./gremlin-discovery.js";
 import type { PrimaryAgentDefinition } from "./primary-agent-definition.js";
+import { writePersistedPrimaryAgentSelection } from "./primary-agent-persistence.js";
 import {
 	hasSelectionChanged,
 	PRIMARY_AGENT_ENTRY_TYPE,
@@ -70,7 +71,9 @@ export async function persistPrimaryAgentSelection(
 		updatePrimaryAgentStatus(ctx, state);
 		return state;
 	}
-	pi.appendEntry(PRIMARY_AGENT_ENTRY_TYPE, toSessionEntryData(agent));
+	const entryData = toSessionEntryData(agent);
+	pi.appendEntry(PRIMARY_AGENT_ENTRY_TYPE, entryData);
+	writePersistedPrimaryAgentSelection(ctx.cwd, entryData);
 	const nextState = selectAgentInState(state, agent);
 	updatePrimaryAgentStatus(ctx, nextState);
 	notifyPrimaryAgent(ctx, `Primary agent: ${nextName ?? "None"}`);

--- a/extensions/pi-gremlins/primary-agent-persistence.ts
+++ b/extensions/pi-gremlins/primary-agent-persistence.ts
@@ -1,0 +1,78 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+	isPrimaryAgentSessionEntryData,
+	NONE_SELECTION,
+	type PrimaryAgentSessionEntryData,
+} from "./primary-agent-state.js";
+
+export const PRIMARY_AGENT_SETTINGS_NAMESPACE = "pi-gremlins";
+export const PRIMARY_AGENT_SETTINGS_KEY = "primaryAgent";
+
+interface PrimaryAgentSettingsRoot {
+	[PRIMARY_AGENT_SETTINGS_NAMESPACE]?: {
+		[PRIMARY_AGENT_SETTINGS_KEY]?: unknown;
+	};
+}
+
+function findNearestPiDir(cwd: string): string | null {
+	let currentDir = path.resolve(cwd);
+	while (true) {
+		const candidate = path.join(currentDir, ".pi");
+		try {
+			if (fs.statSync(candidate).isDirectory()) return candidate;
+		} catch {
+			// Continue walking toward the filesystem root.
+		}
+		const parentDir = path.dirname(currentDir);
+		if (parentDir === currentDir) return null;
+		currentDir = parentDir;
+	}
+}
+
+export function getPrimaryAgentSettingsPath(cwd: string): string {
+	const nearestPiDir = findNearestPiDir(cwd);
+	return path.join(nearestPiDir ?? path.join(path.resolve(cwd), ".pi"), "settings.json");
+}
+
+function readSettingsFile(settingsPath: string): PrimaryAgentSettingsRoot {
+	try {
+		return JSON.parse(fs.readFileSync(settingsPath, "utf-8")) as PrimaryAgentSettingsRoot;
+	} catch (error) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			error.code === "ENOENT"
+		) {
+			return {};
+		}
+		throw error;
+	}
+}
+
+export function readPersistedPrimaryAgentSelection(
+	cwd: string,
+): PrimaryAgentSessionEntryData | null {
+	const settings = readSettingsFile(getPrimaryAgentSettingsPath(cwd));
+	const value = settings[PRIMARY_AGENT_SETTINGS_NAMESPACE]?.[PRIMARY_AGENT_SETTINGS_KEY];
+	return isPrimaryAgentSessionEntryData(value) ? value : null;
+}
+
+export function writePersistedPrimaryAgentSelection(
+	cwd: string,
+	selection: PrimaryAgentSessionEntryData,
+): void {
+	const settingsPath = getPrimaryAgentSettingsPath(cwd);
+	const settings = readSettingsFile(settingsPath);
+	settings[PRIMARY_AGENT_SETTINGS_NAMESPACE] = {
+		...(settings[PRIMARY_AGENT_SETTINGS_NAMESPACE] ?? {}),
+		[PRIMARY_AGENT_SETTINGS_KEY]: selection,
+	};
+	fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+	fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8");
+}
+
+export function clearPersistedPrimaryAgentSelection(cwd: string): void {
+	writePersistedPrimaryAgentSelection(cwd, NONE_SELECTION);
+}

--- a/extensions/pi-gremlins/primary-agent-prompt.ts
+++ b/extensions/pi-gremlins/primary-agent-prompt.ts
@@ -6,6 +6,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import type { PrimaryAgentDiscoveryCache } from "./gremlin-discovery.js";
 import type { PrimaryAgentDefinition } from "./primary-agent-definition.js";
+import { clearPersistedPrimaryAgentSelection } from "./primary-agent-persistence.js";
 import {
 	PRIMARY_AGENT_ENTRY_TYPE,
 	selectAgentInState,
@@ -69,6 +70,7 @@ export async function applyPrimaryAgentPromptInjection(args: {
 	if (!agent) {
 		const missingName = args.state.selectedName;
 		args.pi.appendEntry(PRIMARY_AGENT_ENTRY_TYPE, toSessionEntryData(null));
+		clearPersistedPrimaryAgentSelection(args.ctx.cwd);
 		const nextState = selectAgentInState(args.state, null);
 		args.updateStatus(args.ctx, nextState);
 		args.notify(

--- a/extensions/pi-gremlins/primary-agent-state.ts
+++ b/extensions/pi-gremlins/primary-agent-state.ts
@@ -51,11 +51,9 @@ interface BranchCustomEntry {
 	data?: unknown;
 }
 
-export function reconstructPrimaryAgentStateFromBranch(
+export function getLatestPrimaryAgentSessionEntryData(
 	branchEntries: readonly BranchCustomEntry[],
-	agents: readonly PrimaryAgentDefinition[],
-): PrimaryAgentState {
-	let latestData: PrimaryAgentSessionEntryData | null = null;
+): PrimaryAgentSessionEntryData | null {
 	for (const entry of [...branchEntries].reverse()) {
 		if (
 			entry.type === "custom" &&
@@ -63,20 +61,33 @@ export function reconstructPrimaryAgentStateFromBranch(
 				entry.customType === LEGACY_PRIMARY_AGENT_ENTRY_TYPE) &&
 			isPrimaryAgentSessionEntryData(entry.data)
 		) {
-			latestData = entry.data;
-			break;
+			return entry.data;
 		}
 	}
+	return null;
+}
 
-	if (!latestData) return createInitialPrimaryAgentState();
-	if (latestData.selectedName === null) return createInitialPrimaryAgentState();
+export function reconstructPrimaryAgentStateFromData(
+	data: PrimaryAgentSessionEntryData | null,
+	agents: readonly PrimaryAgentDefinition[],
+): PrimaryAgentState {
+	if (!data) return createInitialPrimaryAgentState();
+	if (data.selectedName === null) return createInitialPrimaryAgentState();
 
-	const selectedExists = agents.some(
-		(agent) => agent.name === latestData.selectedName,
-	);
+	const selectedExists = agents.some((agent) => agent.name === data.selectedName);
 	return selectedExists
-		? { selectedName: latestData.selectedName, missingSelectedName: null }
-		: { selectedName: null, missingSelectedName: latestData.selectedName };
+		? { selectedName: data.selectedName, missingSelectedName: null }
+		: { selectedName: null, missingSelectedName: data.selectedName };
+}
+
+export function reconstructPrimaryAgentStateFromBranch(
+	branchEntries: readonly BranchCustomEntry[],
+	agents: readonly PrimaryAgentDefinition[],
+): PrimaryAgentState {
+	return reconstructPrimaryAgentStateFromData(
+		getLatestPrimaryAgentSessionEntryData(branchEntries),
+		agents,
+	);
 }
 
 export function toSessionEntryData(

--- a/extensions/pi-gremlins/primary-agent.test.js
+++ b/extensions/pi-gremlins/primary-agent.test.js
@@ -193,6 +193,70 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
 	});
 
+	test("selection persists to project settings and restores in a new session without raw markdown", async () => {
+		const { createPrimaryAgentDiscoveryCache } = await import("./gremlin-discovery.ts");
+		const { createPiGremlinsExtension } = await import("./index.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.projectAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
+		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+
+		const firstPi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(firstPi);
+		const firstCtx = createMockContext(workspace);
+		await firstPi.handler("session_start")({ type: "session_start", reason: "startup" }, firstCtx);
+		await firstPi.commands.get("mohawk").handler("Alpha", firstCtx);
+
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const settingsContent = fs.readFileSync(settingsPath, "utf-8");
+		expect(settingsContent).toContain('"selectedName": "Alpha"');
+		expect(settingsContent).toContain('"source": "project"');
+		expect(settingsContent).not.toContain("alpha prompt");
+
+		const secondPi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(secondPi);
+		const secondCtx = createMockContext(workspace);
+		await secondPi.handler("session_start")({ type: "session_start", reason: "startup" }, secondCtx);
+		expect(secondCtx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: Alpha" });
+		const injected = await secondPi.handler("before_agent_start")({ type: "before_agent_start", systemPrompt: "system", prompt: "go", systemPromptOptions: {} }, secondCtx);
+		expect(injected.systemPrompt).toContain("alpha prompt");
+	});
+
+	test("cleared and missing persisted primary-agent selections reset to None", async () => {
+		const { createPrimaryAgentDiscoveryCache } = await import("./gremlin-discovery.ts");
+		const { createPiGremlinsExtension } = await import("./index.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.projectAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
+		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+
+		const firstPi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(firstPi);
+		const firstCtx = createMockContext(workspace);
+		await firstPi.handler("session_start")({ type: "session_start", reason: "startup" }, firstCtx);
+		await firstPi.commands.get("mohawk").handler("Alpha", firstCtx);
+		await firstPi.commands.get("mohawk").handler("none", firstCtx);
+		expect(fs.readFileSync(settingsPath, "utf-8")).toContain('"selectedName": null');
+
+		const clearedPi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(clearedPi);
+		const clearedCtx = createMockContext(workspace);
+		await clearedPi.handler("session_start")({ type: "session_start", reason: "startup" }, clearedCtx);
+		expect(clearedCtx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
+
+		fs.writeFileSync(settingsPath, JSON.stringify({ "pi-gremlins": { primaryAgent: { selectedName: "Missing", source: "project", filePath: path.join(workspace.projectAgentsDir, "missing.md") } } }, null, 2), "utf-8");
+		const missingPi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(missingPi);
+		const missingCtx = createMockContext(workspace);
+		await missingPi.handler("session_start")({ type: "session_start", reason: "startup" }, missingCtx);
+		expect(missingCtx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
+		expect(missingCtx.ui.notifications.at(-1)).toEqual({ message: "Primary agent unavailable, reset to None: Missing", type: "warning" });
+		expect(fs.readFileSync(settingsPath, "utf-8")).toContain('"selectedName": null');
+		const injected = await missingPi.handler("before_agent_start")({ type: "before_agent_start", systemPrompt: "system", prompt: "go", systemPromptOptions: {} }, missingCtx);
+		expect(injected).toBeUndefined();
+	});
+
 	test("prompt injection strips existing pi-gremlins and legacy pi-mohawk blocks", async () => {
 		const { appendPrimaryAgentPromptBlock } = await import("./primary-agent-prompt.ts");
 		const agent = { name: "Wall", rawMarkdown: "---\nname: Wall\nagent_type: primary\n---\nwall prompt" };


### PR DESCRIPTION
## Summary
- Persist selected primary-agent metadata in project-local `.pi/settings.json` and restore it on fresh sessions
- Persist cleared state and reset missing saved selections to None with a warning
- Document project-local persistence and add regression coverage for restore/clear/missing flows

## Verification
- `npm run typecheck`
- `npm test -- extensions/pi-gremlins/primary-agent.test.js` (npm script runs full Bun suite)
- `npm run check`

Closes #42