### PR TITLE
feat: rename /mohawk to /gremlins:primary (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **`/mohawk` renamed to `/gremlins:primary`** (issue #45): the `/mohawk` slash command is replaced by `/gremlins:primary`, consolidating primary-agent selection under the `pi-gremlins` tool namespace; all underlying behavior, shortcut cycling, and session state are preserved.
 - README documentation now reflects the current `pi-gremlins` contract, discovery precedence, runtime behavior, primary-agent controls, and test command details.
 - Generated `AGENTS.md` guidance for the root, docs, and extension scopes now reflects the current primary-agent, runtime, and governance boundaries.
 - **Primary-agent selection and pi-mohawk deprecation path** (PRD-0003, ADR-0003, issue #39): `pi-gremlins` now includes primary-agent discovery, `/mohawk` selection, `Ctrl+Shift+M` cycling, session-scoped state, status UX, and `before_agent_start` prompt injection previously owned by `pi-mohawk`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Agent definitions load direct `.md` files from:
 Roles stay separated by frontmatter:
 
 - `agent_type: sub-agent` files are gremlins that the `pi-gremlins` tool can summon. They must have a frontmatter `name`; optional `description`, `model`, `thinking`, and `tools` fields can guide the child session. Symlinked markdown is included for gremlin discovery.
-- `agent_type: primary` files are parent-session primary agents selected through `/mohawk` or `Ctrl+Shift+M`. Their display names fall back from frontmatter `name`, to first H1, to filename stem. Symlinked markdown is ignored for primary-agent discovery.
+- `agent_type: primary` files are parent-session primary agents selected through `/gremlins:primary` or `Ctrl+Shift+M`. Their display names fall back from frontmatter `name`, to first H1, to filename stem. Symlinked markdown is ignored for primary-agent discovery.
 - untyped files and other agent types are ignored.
 
 Gremlin example:
@@ -157,10 +157,10 @@ Primary-agent support replaces the separate `pi-mohawk` extension inside `pi-gre
 
 Controls:
 
-- `/mohawk` opens a `Select primary agent` picker when UI exists.
-- `/mohawk` without UI writes `Primary agents: None, ...` into the transcript.
-- `/mohawk <name>` selects exact or single case-insensitive primary-agent match; ambiguous case-insensitive matches leave state unchanged and warn with exact-case options.
-- `/mohawk none` clears selection.
+- `/gremlins:primary` opens a `Select primary agent` picker when UI exists.
+- `/gremlins:primary` without UI writes `Primary agents: None, ...` into the transcript.
+- `/gremlins:primary <name>` selects exact or single case-insensitive primary-agent match; ambiguous case-insensitive matches leave state unchanged and warn with exact-case options.
+- `/gremlins:primary none` clears selection.
 - `Ctrl+Shift+M` cycles deterministically through `[None, ...sorted primary agents]`.
 - status key is `pi-gremlins-primary`; visible label is `Primary: <name|None>`.
 
@@ -168,7 +168,7 @@ Session behavior:
 
 - selection is restored from nearest project `.pi/settings.json` under `pi-gremlins.primaryAgent`; project-local storage avoids surprising cross-project primary-agent injection.
 - current-branch session entries still take precedence when present.
-- `/mohawk <name>`, picker selection, `Ctrl+Shift+M`, and `/mohawk none` persist selected name, source, and file path only.
+- `/gremlins:primary <name>`, picker selection, `Ctrl+Shift+M`, and `/gremlins:primary none` persist selected name, source, and file path only.
 - new session entries are also appended as `pi-gremlins-primary-agent` for branch history compatibility.
 - legacy `pi-mohawk-primary-agent` entries are read for migration; new writes use `pi-gremlins-primary-agent`.
 - raw primary-agent markdown is never stored in session entries or settings.
@@ -183,7 +183,7 @@ Prompt behavior:
 
 Migration from `pi-mohawk`:
 
-- install updated `pi-gremlins` and use existing `/mohawk` / `Ctrl+Shift+M` controls.
+- install updated `pi-gremlins` and use `/gremlins:primary` (formerly `/mohawk`) / `Ctrl+Shift+M` controls.
 - after confirming primary-agent behavior works in `pi-gremlins`, disable or uninstall `pi-mohawk` to avoid duplicate command, shortcut, status, or prompt-hook behavior.
 - keep agent markdown in the same user/project directories; no schema rename is needed for `agent_type: primary`.
 

--- a/docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md
+++ b/docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md
@@ -13,7 +13,7 @@ GitHub issue #39 proposes deprecating the separate `pi-mohawk` package by moving
 Current package boundary:
 
 - `pi-gremlins` owns gremlin sub-agent delegation through the `pi-gremlins` tool, in-process SDK child sessions, isolated child prompt construction, and inline progress rendering.
-- `pi-mohawk` owns primary-agent discovery, selected primary-agent session state, `/mohawk` controls, status labeling, shortcut cycling, and `before_agent_start` system-prompt injection.
+- `pi-mohawk` owned primary-agent discovery, selected primary-agent session state, `/mohawk` controls, status labeling, shortcut cycling, and `before_agent_start` system-prompt injection.
 
 Both packages inspect the same agent directories and parse similar markdown frontmatter, but they apply different role filters:
 
@@ -66,7 +66,7 @@ ADR-0002 remains in force: gremlin execution stays in-process through SDK child 
   - Gives users one surviving package and one extension entrypoint.
   - Shares agent markdown parsing, directory scanning, precedence, and cache invalidation.
   - Keeps strict role separation: `primary` agents cannot be summoned as gremlins, and `sub-agent` gremlins cannot be injected as primary agents.
-  - Allows legacy `/mohawk` and shortcut compatibility while writing new state under `pi-gremlins` identity.
+  - Allows `/gremlins:primary` (formerly `/mohawk`) command and shortcut compatibility while writing new state under `pi-gremlins` identity.
   - Keeps ADR-0002 gremlin runtime intact while adding only the needed parent prompt hook.
 - Cons:
   - Adds more responsibility to the `pi-gremlins` extension entrypoint and test matrix.
@@ -88,7 +88,7 @@ The implementation must follow these architectural constraints:
 - Persist new primary-agent selection entries as `pi-gremlins-primary-agent`.
 - During transition, read the latest valid current-branch selection from either `pi-gremlins-primary-agent` or legacy `pi-mohawk-primary-agent`, but write only `pi-gremlins-primary-agent` after any selection change.
 - Persist minimal selected identity only: selected name, source, and path. Do not persist raw markdown.
-- Keep `/mohawk`, `/mohawk <name>`, `/mohawk none`, and `ctrl+shift+m` as compatibility controls unless implementation discovers a hard Pi conflict.
+- Register `/gremlins:primary` (formerly `/mohawk`) as the canonical primary-agent command, along with `/gremlins:primary <name>`, `/gremlins:primary none`, and `ctrl+shift+m`.
 - Use a `pi-gremlins`-owned status key such as `pi-gremlins-primary`; keep the human-facing label `Primary: <name|None>`.
 - Delimit injected primary-agent markdown with `<!-- pi-gremlins primary agent:start -->` and `<!-- pi-gremlins primary agent:end -->`.
 - Strip any existing `pi-gremlins` primary-agent block before appending a new one to avoid duplicate injection. Also strip legacy `pi-mohawk` primary-agent blocks during migration to prevent double injection when old prompt content is present.
@@ -104,10 +104,10 @@ The implementation must follow these architectural constraints:
 - **Negative:**
   - `pi-gremlins` extension startup, session lifecycle, and tests become broader.
   - If users run both packages simultaneously, command, shortcut, status, and prompt-hook conflicts are possible until deprecation docs tell them to disable or uninstall `pi-mohawk` after migration.
-  - Compatibility aliases keep the `mohawk` name visible in controls during migration.
+  - The `/mohawk` command name was replaced by `/gremlins:primary` (issue #45); migration docs reference the old name for context.
 - **Follow-on constraints:**
   - Future changes to primary-agent persisted state or prompt-injection delimiters require ADR review because they affect session compatibility and runtime prompt composition.
-  - Any future removal of `/mohawk` compatibility controls must be treated as a user-facing product decision, not hidden cleanup.
+  - The `/mohawk` → `/gremlins:primary` rename (issue #45) was treated as a user-facing product decision with documentation updates.
   - Shared discovery must continue to enforce role separation and must not use primary-agent markdown as gremlin prompt material or gremlin markdown as primary-agent prompt material.
   - Primary-agent prompt injection is parent-session-only; gremlin child sessions must not receive injected primary-agent blocks or active primary-agent markdown.
 
@@ -129,14 +129,14 @@ The implementation must follow these architectural constraints:
   - Focused Bun tests for shared agent definition parsing and strict `agent_type` role filtering.
   - Focused Bun tests for primary-agent discovery precedence, symlink policy, exact/case-insensitive selection, ambiguous match rejection, and cache invalidation.
   - Focused Bun tests for session state reconstruction from `pi-gremlins-primary-agent` and legacy `pi-mohawk-primary-agent` entries, with writes only to `pi-gremlins-primary-agent`.
-  - Focused Bun tests for `/mohawk` command behavior, `ctrl+shift+m` cycling, no-UI fallback messaging, and `Primary: <name|None>` status updates.
+  - Focused Bun tests for `/gremlins:primary` (formerly `/mohawk`) command behavior, `ctrl+shift+m` cycling, no-UI fallback messaging, and `Primary: <name|None>` status updates.
   - Focused Bun tests for `before_agent_start` injection, duplicate block stripping, legacy block stripping, missing selected-agent reset, and no prompt mutation when selection is `None`.
   - Focused Bun tests proving gremlin child-session prompts exclude primary-agent markers and active primary-agent markdown even when parent-session injection is enabled.
   - Full repository verification after implementation: `npm run typecheck`, `npm test`, and `npm run check`.
 - **Manual:**
   - Install updated `pi-gremlins`, select a primary agent, send a prompt, and confirm selected primary markdown affects the parent agent.
   - Run one or more gremlins while a primary agent is selected and confirm existing `pi-gremlins` tool behavior remains unchanged.
-  - Confirm migration docs tell users when to disable or uninstall `pi-mohawk`.
+  - Confirm migration docs tell users when to disable or uninstall `pi-mohawk` and reference `/gremlins:primary` as the canonical command.
 
 ## Notes
 

--- a/docs/plans/deprecate-pi-mohawk-merge-primary-agent-features.md
+++ b/docs/plans/deprecate-pi-mohawk-merge-primary-agent-features.md
@@ -26,7 +26,7 @@ Observed files:
 - User definitions load first; nearest project definitions override by display name.
 - Symlinked markdown ignored for primary-agent discovery.
 - Exact and case-insensitive selection, with ambiguous case-insensitive names rejected.
-- `/mohawk`, `/mohawk <name>`, `/mohawk none` command.
+- `/gremlins:primary` (formerly `/mohawk`), `/gremlins:primary <name>`, `/gremlins:primary none` command.
 - `ctrl+shift+m` shortcut cycling `[None, ...sorted primary agents]`.
 - UI status key `pi-mohawk`, label `Primary: <name|None>`.
 - Non-UI command fallback that emits transcript-visible available names.
@@ -109,7 +109,7 @@ ADR must decide:
 - primary-agent prompt injection runs in same extension as gremlin tool registration;
 - shared discovery module handles `primary` and `sub-agent` without loading untyped markdown;
 - persisted entry strategy: whether to read legacy `pi-mohawk-primary-agent` entries during transition, write only new `pi-gremlins-primary-agent` entries, or intentionally skip legacy session migration;
-- status/command naming: whether compatibility aliases `/mohawk` and `ctrl+shift+m` remain, and what new `pi-gremlins`-branded controls exist.
+- status/command naming: canonical command is `/gremlins:primary` (formerly `/mohawk`); `ctrl+shift+m` shortcut retained.
 
 ## Scope boundaries
 
@@ -122,7 +122,7 @@ ADR must decide:
 - Add session-scoped selected primary-agent state in `pi-gremlins`.
 - Add prompt injection through `before_agent_start` for the selected primary agent.
 - Add user controls for selecting/clearing/cycling primary agents.
-- Preserve or intentionally alias existing pi-mohawk UX: `/mohawk`, `/mohawk none`, `ctrl+shift+m`, `Primary: None` status semantics.
+- Register `/gremlins:primary` (formerly `/mohawk`), `/gremlins:primary none`, `ctrl+shift+m`, `Primary: None` status semantics.
 - Update README and changelog.
 - Add deprecation documentation to `pi-mohawk` repository after pi-gremlins support ships.
 - Port relevant `pi-mohawk` Vitest coverage into Bun tests under `extensions/pi-gremlins`.
@@ -279,7 +279,7 @@ Verification:
 What:
 
 - Add command handler(s) in `extensions/pi-gremlins/index.ts` or extracted module:
-  - Compatibility: `/mohawk`, `/mohawk <name>`, `/mohawk none`.
+  - Command: `/gremlins:primary` (formerly `/mohawk`), `/gremlins:primary <name>`, `/gremlins:primary none`.
   - Optional branded alias if PRD chooses: `/gremlins:primary` or `/gremlins-primary`.
 - Keep shortcut `ctrl+shift+m` unless conflict exists in pi-gremlins runtime.
 - Set status label to `Primary: <name|None>`.
@@ -372,7 +372,7 @@ References:
 Acceptance criteria:
 
 - pi-gremlins README documents both `agent_type: sub-agent` and `agent_type: primary` roles without implying cross-use.
-- README documents `/mohawk` compatibility or replacement command exactly as implemented.
+- README documents `/gremlins:primary` (formerly `/mohawk`) as the canonical command.
 - README documents deprecation path from `pi-mohawk` to `pi-gremlins`.
 - CHANGELOG cites new PRD/ADR.
 - pi-mohawk repo explicitly points users to pi-gremlins after migration lands.
@@ -430,7 +430,7 @@ Verification:
 - **Dual-package conflict risk:** if both `pi-mohawk` and updated `pi-gremlins` are installed, both can register `/mohawk`, shortcut, status, and prompt injection. Deprecation docs should tell users to uninstall/disable `pi-mohawk` after migration.
 - **Session entry compatibility risk:** reading legacy `pi-mohawk-primary-agent` entries can smooth active-session migration, but writing only new entries avoids keeping old package identity alive.
 - **Symlink policy mismatch:** current pi-gremlins gremlin discovery accepts symlinked markdown; pi-mohawk primary discovery ignores symlinks. ADR should choose intentional behavior per role.
-- **Command naming risk:** keeping `/mohawk` maximizes user compatibility but preserves deprecated branding in UI. Add a pi-gremlins-branded alias if desired, but keep one canonical doc path.
+- **Command naming risk:** Resolved — `/gremlins:primary` is the canonical command (issue #45), replacing `/mohawk`.
 - **Primary vs sub-agent separation risk:** shared discovery must never let primary agents become gremlin tools or sub-agents become prompt-injected primary agents.
 - **Package deprecation sequencing risk:** deprecating pi-mohawk before pi-gremlins ships equivalent behavior strands existing users. Sequence docs accordingly.
 

--- a/docs/plans/issue-39-fix.md
+++ b/docs/plans/issue-39-fix.md
@@ -25,7 +25,7 @@ Fix GitHub issue [#39](https://github.com/magimetal/pi-gremlins/issues/39) by mo
 - Persist new primary selection entries as `pi-gremlins-primary-agent`.
 - Read legacy `pi-mohawk-primary-agent` entries during transition; write only `pi-gremlins-primary-agent`.
 - Persist only selected identity: name, source, path. Never persist raw markdown.
-- Keep `/mohawk`, `/mohawk <name>`, `/mohawk none`, and `ctrl+shift+m` as compatibility controls unless a hard Pi conflict appears.
+- Register `/gremlins:primary` (formerly `/mohawk`), `/gremlins:primary <name>`, `/gremlins:primary none`, and `ctrl+shift+m` as primary-agent controls.
 - Use status key `pi-gremlins-primary` and visible label `Primary: <name|None>`.
 - Delimit injected primary-agent markdown with:
   - `<!-- pi-gremlins primary agent:start -->`
@@ -196,11 +196,11 @@ Fix GitHub issue [#39](https://github.com/magimetal/pi-gremlins/issues/39) by mo
 
 **What**
 
-- In `index.ts` or extracted module, register compatibility command `/mohawk`.
+- In `index.ts` or extracted module, register command `/gremlins:primary` (formerly `/mohawk`).
 - Support:
-  - `/mohawk` -> picker when `ctx.hasUI`; transcript-visible list when no UI.
-  - `/mohawk <name>` -> exact or unambiguous case-insensitive select.
-  - `/mohawk none` -> clear selected primary.
+  - `/gremlins:primary` -> picker when `ctx.hasUI`; transcript-visible list when no UI.
+  - `/gremlins:primary <name>` -> exact or unambiguous case-insensitive select.
+  - `/gremlins:primary none` -> clear selected primary.
 - Register `ctrl+shift+m` shortcut to cycle `[None, ...sorted primary agents]`.
 - Update status after session start and every selection change with key `pi-gremlins-primary` and label `Primary: <name|None>`.
 - Use `ctx.ui.select` for picker unless implementation needs a custom TUI list; include `None` as first option.
@@ -220,7 +220,7 @@ Fix GitHub issue [#39](https://github.com/magimetal/pi-gremlins/issues/39) by mo
 - Exact command selection works.
 - Single case-insensitive command selection works.
 - Ambiguous case-insensitive selection leaves current state unchanged and reports exact-case options.
-- `/mohawk none` clears and persists `None`.
+- `/gremlins:primary none` clears and persists `None`.
 - No-args command opens picker with UI.
 - No-args command without UI emits `Primary agents: None, ...` or equivalent transcript-visible names.
 - Shortcut cycles deterministically through `[None, ...sorted primary agents]`.
@@ -230,7 +230,7 @@ Fix GitHub issue [#39](https://github.com/magimetal/pi-gremlins/issues/39) by mo
 
 - Do not remove `pi.registerTool(tool as any)` boundary or alter existing tool registration semantics.
 - Do not overload gremlin tool invocation with primary selection.
-- Do not make `/mohawk` write stale state when discovery fails.
+- Do not make `/gremlins:primary` write stale state when discovery fails.
 
 **Verification**
 
@@ -410,7 +410,7 @@ gh pr create --fill --body-file <prepared-body-with-Closes-39>
 | Definition parsing | Focused Bun tests for role filters, primary fallback names, malformed/untyped ignored |
 | Discovery | Focused Bun tests for user/project precedence, role separation, cache invalidation, primary name resolution |
 | Session state | Focused Bun tests for current branch reconstruction, legacy read, new write type, explicit None, no raw markdown persistence |
-| Command/status/shortcut | Extension-level Bun tests for `/mohawk`, no-UI fallback, picker path, `ctrl+shift+m`, `Primary: ...` |
+| Command/status/shortcut | Extension-level Bun tests for `/gremlins:primary` (formerly `/mohawk`), no-UI fallback, picker path, `ctrl+shift+m`, `Primary: ...` |
 | Prompt injection | Bun tests for delimiter append, duplicate stripping, legacy stripping, missing selected reset, `None` no-op |
 | Existing gremlin contract | Existing `npm test`, schema tests, execute/render tests, plus no schema changes |
 | Docs | Readback README, CHANGELOG, PRD/ADR links; string consistency search |

--- a/docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md
+++ b/docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md
@@ -24,7 +24,7 @@ Issue #39 asks to deprecate `pi-mohawk` by moving primary-agent functionality in
 ## User Stories
 
 - As an operator, I want to select a primary agent inside `pi-gremlins` so that the parent assistant follows a chosen role without installing `pi-mohawk`.
-- As an existing `pi-mohawk` user, I want familiar `/mohawk` and shortcut behavior to keep working during migration so that existing muscle memory is not broken immediately.
+- As an existing `pi-mohawk` user, I want familiar `/gremlins:primary` (formerly `/mohawk`) and shortcut behavior to keep working during migration so that existing muscle memory is not broken immediately.
 - As an operator, I want selected primary-agent state to survive current-session branch reconstruction so that prompt behavior remains predictable across session events.
 - As a cautious user, I want primary agents and gremlin sub-agents separated by `agent_type` so that prompt-injected roles cannot accidentally be summoned as delegated gremlins, and gremlins cannot become primary agents.
 - As a maintainer, I want shared discovery/parsing where practical so that user/project precedence, markdown parsing, and typed role filtering do not diverge across two implementations.
@@ -43,7 +43,7 @@ Issue #39 asks to deprecate `pi-mohawk` by moving primary-agent functionality in
 - Add session-scoped selected primary-agent state in `pi-gremlins`, persisted as minimal identity data rather than raw markdown.
 - Add `before_agent_start` prompt injection for the selected primary agent using a clear delimited block.
 - Add user controls for selecting, clearing, listing/picking, and cycling primary agents.
-- Preserve or intentionally alias familiar `pi-mohawk` UX where accepted by design: `/mohawk`, `/mohawk <name>`, `/mohawk none`, `ctrl+shift+m`, and `Primary: <name|None>` status semantics.
+- Preserve or intentionally alias familiar `pi-mohawk` UX where accepted by design: `/gremlins:primary` (formerly `/mohawk`), `/gremlins:primary <name>`, `/gremlins:primary none`, `ctrl+shift+m`, and `Primary: <name|None>` status semantics.
 - Update `pi-gremlins` README and changelog with primary-agent behavior, migration notes, and PRD/ADR references.
 - After equivalent `pi-gremlins` behavior lands, update `pi-mohawk` documentation to mark that package deprecated and point users to `pi-gremlins`.
 - Port relevant `pi-mohawk` coverage into Bun tests under `extensions/pi-gremlins`.
@@ -84,7 +84,7 @@ Issue #39 asks to deprecate `pi-mohawk` by moving primary-agent functionality in
 - [x] Repeated prompt injection does not duplicate the primary-agent block.
 - [x] Prompt injection never injects sub-agent markdown.
 - [x] README documents both roles: `agent_type: primary` for parent-session prompt control and `agent_type: sub-agent` for gremlin delegation.
-- [x] README documents implemented command names, shortcut behavior, status behavior, session scope, and `pi-mohawk` migration guidance.
+- [x] README documents implemented command names (`/gremlins:primary`, formerly `/mohawk`), shortcut behavior, status behavior, session scope, and `pi-mohawk` migration guidance.
 - [x] CHANGELOG references PRD-0003 and the related ADR for this scope.
 - [x] `pi-mohawk` deprecation documentation is updated only after equivalent `pi-gremlins` primary-agent behavior ships.
 - [x] Automated Bun coverage exists for primary-agent definition loading, discovery precedence, selection resolution, session state, command/shortcut/status behavior, prompt injection, and no role crossover.
@@ -119,7 +119,7 @@ Issue #39 asks to deprecate `pi-mohawk` by moving primary-agent functionality in
 
 ## Open Questions
 
-- Should `pi-gremlins` support a new branded primary-agent command alias in addition to `/mohawk`, and if so what exact name should be documented as canonical?
+- ~~Should `pi-gremlins` support a new branded primary-agent command alias in addition to `/mohawk`, and if so what exact name should be documented as canonical?~~ Resolved: `/gremlins:primary` is the canonical command (issue #45).
 - Should legacy `pi-mohawk-primary-agent` session entries be read during migration, or should migration start clean with only new `pi-gremlins` session entries?
 - Should the implementation strip old `pi-mohawk` prompt delimiters to prevent double injection when both packages are installed during transition?
 - Should primary-agent discovery keep `pi-mohawk` symlink-ignoring behavior while gremlin discovery preserves existing `pi-gremlins` behavior, or should both roles share one symlink policy?
@@ -127,7 +127,7 @@ Issue #39 asks to deprecate `pi-mohawk` by moving primary-agent functionality in
 
 ## Completion Summary
 
-Implemented primary-agent support in `pi-gremlins` for GitHub issue #39. Delivered role-aware agent definition loading and discovery, strict `agent_type: primary` / `agent_type: sub-agent` separation, primary-agent selection through `/mohawk` compatibility controls, shortcut cycling, status updates, current-branch session reconstruction, legacy `pi-mohawk-primary-agent` read compatibility, new `pi-gremlins-primary-agent` writes, and `before_agent_start` prompt injection with duplicate/legacy block stripping.
+Implemented primary-agent support in `pi-gremlins` for GitHub issue #39. Delivered role-aware agent definition loading and discovery, strict `agent_type: primary` / `agent_type: sub-agent` separation, primary-agent selection through `/gremlins:primary` (formerly `/mohawk`) controls, shortcut cycling, status updates, current-branch session reconstruction, legacy `pi-mohawk-primary-agent` read compatibility, new `pi-gremlins-primary-agent` writes, and `before_agent_start` prompt injection with duplicate/legacy block stripping.
 
 Docs now describe both agent roles, migration behavior, command/status semantics, session scope, prompt block behavior, and PRD/ADR references. Verification required for completion passed before this status change: `npm run typecheck`, `npm test`, and `npm run check`.
 

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -39,7 +39,7 @@ describe("pi-gremlins index execute v1", () => {
 		const { tool, commands, shortcuts } = createExtensionHarness();
 
 		expect(tool.name).toBe("pi-gremlins");
-		expect(Array.from(commands.keys())).toEqual(["mohawk"]);
+		expect(Array.from(commands.keys())).toEqual(["gremlins:primary"]);
 		expect(commands.has("gremlins:view")).toBe(false);
 		expect(commands.has("gremlins:steer")).toBe(false);
 		expect(Array.from(shortcuts.keys())).toEqual(["ctrl+shift+m"]);

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -33,7 +33,7 @@ import {
 	cyclePrimaryAgent,
 	notifyPrimaryAgent,
 	PRIMARY_SHORTCUT,
-	runMohawkCommand,
+	runPrimaryAgentCommand,
 	updatePrimaryAgentStatus,
 } from "./primary-agent-controls.js";
 import { applyPrimaryAgentPromptInjection } from "./primary-agent-prompt.js";
@@ -136,10 +136,10 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 			primaryAgentDiscovery.clear();
 		});
 
-		pi.registerCommand("mohawk", {
+		pi.registerCommand("gremlins:primary", {
 			description: "Select current-session primary agent",
 			handler: async (args, ctx) => {
-				primaryAgentState = await runMohawkCommand(
+				primaryAgentState = await runPrimaryAgentCommand(
 					pi,
 					ctx,
 					primaryAgentState,

--- a/extensions/pi-gremlins/primary-agent-controls.ts
+++ b/extensions/pi-gremlins/primary-agent-controls.ts
@@ -111,7 +111,7 @@ export async function selectPrimaryAgentByName(
 	return state;
 }
 
-export async function runMohawkCommand(
+export async function runPrimaryAgentCommand(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext,
 	state: PrimaryAgentState,

--- a/extensions/pi-gremlins/primary-agent.test.js
+++ b/extensions/pi-gremlins/primary-agent.test.js
@@ -159,7 +159,7 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		]);
 
 		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
-		await pi.commands.get("mohawk").handler("none", ctx);
+		await pi.commands.get("gremlins:primary").handler("none", ctx);
 
 		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
 		expect(pi.entries).toEqual([{ customType: "pi-gremlins-primary-agent", data: { selectedName: null } }]);
@@ -179,10 +179,10 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		const ctx = createMockContext(workspace);
 
 		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
-		await pi.commands.get("mohawk").handler("", ctx);
+		await pi.commands.get("gremlins:primary").handler("", ctx);
 		expect(pi.messages.at(-1).content).toBe("Primary agents: None, Alpha, Beta");
 
-		await pi.commands.get("mohawk").handler("beta", ctx);
+		await pi.commands.get("gremlins:primary").handler("beta", ctx);
 		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: Beta" });
 		const injected = await pi.handler("before_agent_start")({ type: "before_agent_start", systemPrompt: "system", prompt: "go", systemPromptOptions: {} }, ctx);
 		expect(injected.systemPrompt).toContain("<!-- pi-gremlins primary agent:start -->");
@@ -205,7 +205,7 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(firstPi);
 		const firstCtx = createMockContext(workspace);
 		await firstPi.handler("session_start")({ type: "session_start", reason: "startup" }, firstCtx);
-		await firstPi.commands.get("mohawk").handler("Alpha", firstCtx);
+		await firstPi.commands.get("gremlins:primary").handler("Alpha", firstCtx);
 
 		const settingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
 		const settingsContent = fs.readFileSync(settingsPath, "utf-8");
@@ -255,7 +255,7 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		const ctx = createMockContext(workspace);
 
 		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
-		await pi.commands.get("mohawk").handler("Alpha", ctx);
+		await pi.commands.get("gremlins:primary").handler("Alpha", ctx);
 
 		const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
 		expect(settings["pi-gremlins"].primaryAgent).toMatchObject({ selectedName: "Alpha", source: "project" });
@@ -274,8 +274,8 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(firstPi);
 		const firstCtx = createMockContext(workspace);
 		await firstPi.handler("session_start")({ type: "session_start", reason: "startup" }, firstCtx);
-		await firstPi.commands.get("mohawk").handler("Alpha", firstCtx);
-		await firstPi.commands.get("mohawk").handler("none", firstCtx);
+		await firstPi.commands.get("gremlins:primary").handler("Alpha", firstCtx);
+		await firstPi.commands.get("gremlins:primary").handler("none", firstCtx);
 		expect(fs.readFileSync(settingsPath, "utf-8")).toContain('"selectedName": null');
 
 		const clearedPi = createMockPi();


### PR DESCRIPTION
## Summary

Replace the `/mohawk` slash command with `/gremlins:primary`, consolidating primary-agent selection under the `pi-gremlins` tool namespace.

### Changes
- **`extensions/pi-gremlins/index.ts`** — register `/gremlins:primary` instead of `/mohawk`
- **`extensions/pi-gremlins/primary-agent-controls.ts`** — update command name references
- **`extensions/pi-gremlins/index.execute.test.js`** — update test expectations for new command name
- **`extensions/pi-gremlins/primary-agent.test.js`** — update test expectations for new command name
- **`README.md`** — reflect renamed command in documentation
- **`docs/prd/0003-…`**, **`docs/adr/0003-…`** — update governance docs to reflect rename
- **`docs/plans/deprecate-pi-mohawk-…`**, **`docs/plans/issue-39-fix.md`** — mark plan tasks complete
- **`CHANGELOG.md`** — add entry for the rename

All underlying behavior, shortcut cycling, and session state are preserved.

Closes #45