### PR TITLE
feat: absorb pi-gizmo side-chat as /gremlins:chat and /gremlins:tangent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repaired reliability audit findings for renderer cache uniqueness, same-size agent discovery changes, corrupt primary-agent settings recovery, effective request-cwd discovery, and ambiguous gremlin model reporting.
 
 ### Added
+- **Side-chat absorbed from pi-gizmo** (PRD-0004, ADR-0004, issue #47): pi-gremlins now ships `/gremlins:chat` (parent-transcript snapshot) and `/gremlins:tangent` (clean child session), rebuilt on the existing in-process SDK runtime with zero tools and inline rendering. See README "Side-chat" section for the pi-gizmo migration table.
 - Generated agent guidance now covers root, docs, and extension scopes so contributors get current PRD/ADR, primary-agent, and runtime boundaries before editing.
 - Shared role-aware agent parsing/discovery modules now load `agent_type: sub-agent` gremlins and `agent_type: primary` primary agents from user/project agent directories while preserving strict role separation and project-over-user precedence.
 - Primary-agent state and prompt helpers persist new selections as `pi-gremlins-primary-agent`, read legacy `pi-mohawk-primary-agent` entries for migration, and strip legacy prompt blocks before appending the selected primary markdown.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,67 @@ Runtime behavior:
 - collapsed tool row shows source, status, intent/task preview, latest activity, usage, and errors
 - expanded tool row shows intent, task, cwd, model, thinking, latest text/tool data, usage, and errors
 
+## Side-chat: `/gremlins:chat` and `/gremlins:tangent`
+
+Side-chat support is absorbed from the standalone `pi-gizmo` package (PRD-0004,
+ADR-0004, issue #47). It exposes two slash commands inside `pi-gremlins`,
+built on the same in-process Pi SDK runtime as gremlin delegation, with zero
+tools and inline rendering.
+
+### Commands
+
+- `/gremlins:chat <prompt>` — opens a fresh side-thread seeded with a
+  snapshot of the parent transcript captured at invocation time. Output is
+  rendered inline.
+- `/gremlins:tangent <prompt>` — opens a clean child session with no parent
+  transcript and no project context. Output is rendered inline.
+- Empty or whitespace-only argument prints a usage hint and does not start
+  a session.
+
+### v1 guarantees
+
+- Fresh side-thread per invocation; no thread persistence across invocations.
+- Inline rendering only — no overlay or popup viewer (ADR-0004 D1).
+- Zero tools — pure conversation surface; cannot read or modify the workspace
+  (ADR-0004 D4).
+- Built on `gremlin-session-factory` primitives; same isolation as gremlin
+  delegation (ADR-0003, ADR-0004 D3, D5): no parent extensions, skills,
+  prompts, themes, AGENTS files, or primary-agent markdown leak into the
+  side-thread.
+- Copy/paste is the supported handoff mechanism in v1; there is no
+  `inject` command.
+
+### Visual delimiter
+
+Side-chat turns are rendered with a fixed header and footer so they are
+unambiguous next to gremlin tool rows and parent assistant turns:
+
+- Chat header: `💬 side-chat (chat)`
+- Tangent header: `🧭 side-chat (tangent)`
+- Common footer: `└─ side-chat ended ─`
+
+### Migration from `pi-gizmo`
+
+| Retired pi-gizmo command | pi-gremlins replacement | Notes |
+| --- | --- | --- |
+| `gizmo` (chat send) | `/gremlins:chat <prompt>` | Parent-context attached, fresh per invocation. |
+| `gizmo:tangent` | `/gremlins:tangent <prompt>` | Clean child session. |
+| `gizmo:new` | (none — structurally unnecessary) | Fresh-per-invocation makes explicit "new" redundant. |
+| `gizmo:recap` | (deferred) | No v1 replacement; revisit via future PRD. |
+| `gizmo:clear` | (none — structurally unnecessary) | Fresh-per-invocation makes "clear" redundant. |
+| `gizmo:inject` | (deferred) | Use copy/paste in v1; revisit via future PRD. |
+| `gizmo:summarize` | (deferred) | No v1 replacement. |
+| `gizmo:model` | (deferred) | No per-side-chat model override in v1. |
+| `gizmo:thinking` | (deferred) | No per-side-chat thinking override in v1. |
+
+See [PRD-0004](docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md)
+and [ADR-0004](docs/adr/0004-side-chat-absorption-from-pi-gizmo.md).
+
+Note: do not run `pi-gizmo` and `pi-gremlins` side-chat commands
+concurrently if both are installed in the same Pi profile; migrate to
+`pi-gremlins` and disable / uninstall `pi-gizmo` to avoid duplicate command
+registration.
+
 ## Primary agents
 
 Primary-agent support replaces the separate `pi-mohawk` extension inside `pi-gremlins`.

--- a/docs/adr/0004-side-chat-absorption-from-pi-gizmo.md
+++ b/docs/adr/0004-side-chat-absorption-from-pi-gizmo.md
@@ -1,6 +1,6 @@
 # ADR-0004: Side-Chat Absorption from pi-gizmo into pi-gremlins
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-29
 - **Decision Maker:** magimetal
 - **Related:**
@@ -246,3 +246,4 @@ future ADR, triggered only by concrete demand evidence:
 
 - 2026-04-29: Proposed
 - 2026-04-29: Updated PRD cross-link.
+- 2026-04-29: Accepted; implementation matches D1-D8 (PR #48, commit ab2c856).

--- a/docs/adr/0004-side-chat-absorption-from-pi-gizmo.md
+++ b/docs/adr/0004-side-chat-absorption-from-pi-gizmo.md
@@ -1,0 +1,248 @@
+# ADR-0004: Side-Chat Absorption from pi-gizmo into pi-gremlins
+
+- **Status:** Proposed
+- **Date:** 2026-04-29
+- **Decision Maker:** magimetal
+- **Related:**
+  - GitHub issue #47 — "Absorb pi-gizmo side-chat into pi-gremlins"
+  - PRD-0004 — `docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md`
+  - ADR-0001 — Semantic Presentation Architecture (superseded by ADR-0002, cited for inline-rendering lineage)
+  - ADR-0002 — In-Process SDK-Based Gremlin Runtime
+  - ADR-0003 — Unified Agent Discovery and Primary-Agent Prompt Injection
+  - `AGENTS.md` anti-patterns list (popup viewer, nested runtimes, transcript leaks)
+- **Supersedes:** n/a
+
+## Context
+
+pi-gizmo today ships a "side-chat" feature: a slash-command-driven secondary
+conversation thread surfaced in an overlay/popup viewer, backed by a custom
+session-entry persistence layer and a nested runtime distinct from the host
+agent. Issue #47 asks us to absorb that capability into pi-gremlins so the
+host project owns one rendering surface, one runtime, and one agent-discovery
+contract end-to-end.
+
+Three prior ADRs constrain the absorption:
+
+- **ADR-0001 / ADR-0002** established that pi-gremlins renders agent output
+  through a single semantic-presentation pipeline driven by the in-process SDK
+  runtime. Reviving an overlay/popup viewer would re-introduce a rendering
+  surface that ADR-0002 explicitly collapsed and that `AGENTS.md` lists as the
+  "popup viewer" anti-pattern.
+- **ADR-0003** locked the isolation boundary used by `buildGremlinSessionConfig`
+  in `extensions/pi-gremlins/gremlin-session-factory.ts`: child sessions must
+  not inherit the parent's extensions, prompts, themes, skills, `AGENTS.md`
+  files, primary-agent markdown, or transcript content unless explicitly
+  seeded.
+
+PRD-0004 (sibling, in-progress) captures the product surface (`/gremlins:chat`,
+`/gremlins:tangent`) and user expectations. This ADR records the architectural
+commitments that make that surface implementable inside pi-gremlins without
+regressing prior decisions, and defines the deprecation boundary toward
+pi-gizmo.
+
+## Decision Drivers
+
+- Preserve the single-renderer invariant from ADR-0001/0002 (no popup viewer).
+- Preserve the isolation contract from ADR-0003 (no parent-context bleed).
+- Avoid re-introducing nested runtimes or bespoke persistence stores.
+- Keep the v1 surface minimal so future demand, not speculation, drives feature
+  expansion.
+- Provide a clean cross-package deprecation story for pi-gizmo consumers.
+
+## Options Considered
+
+### Option A: Port pi-gizmo wholesale into pi-gremlins
+
+- Pros: Fastest path to feature parity; preserves existing pi-gizmo UX.
+- Cons: Drags the overlay viewer, custom persistence, and nested runtime back
+  into pi-gremlins — directly violates ADR-0002 and the `AGENTS.md` popup-viewer
+  and nested-runtime anti-patterns. Rejected.
+
+### Option B: Revive an overlay/modal rendering surface for side-chat only
+
+- Pros: Visually separates side-chat from primary transcript.
+- Cons: Two rendering surfaces to maintain; contradicts ADR-0001/0002's
+  semantic-presentation consolidation; matches the documented "popup viewer"
+  anti-pattern. Rejected.
+
+### Option C: Persist side-chat threads across invocations
+
+- Pros: Lets users resume tangents.
+- Cons: Requires a new persistence model (the exact shape ADR-0002 dismantled
+  in pi-gizmo); no demand evidence in issue #47; expands the v1 surface area.
+  Rejected for v1; revisitable via future ADR.
+
+### Option D: Allow tool registration on side-chat sessions in v1
+
+- Pros: Side-chat could perform real work, not just conversation.
+- Cons: Multiplies the security/isolation surface (which tools, with what
+  permissions, against which working directory) with no concrete v1 use case.
+  Rejected for v1; revisitable via future ADR.
+
+### Option E (chosen): Inline-rendered, ephemeral, isolation-respecting side-chat inside pi-gremlins
+
+- Pros: Reuses existing renderer, runtime, and isolation primitives; no new
+  persistence; no new rendering surface; minimal v1 footprint; clean
+  deprecation story for pi-gizmo.
+- Cons: No thread resumption; no tool use; loses pi-gizmo's overlay UX.
+
+## Decision
+
+Chosen: **Option E — Inline-rendered, ephemeral, isolation-respecting
+side-chat inside pi-gremlins.**
+
+The decision is composed of the following commitments (D1–D8):
+
+### D1 — Rendering surface: inline only
+
+Side-chat output renders **inline** through pi-gremlins' existing renderer
+hooks (the same semantic-presentation pipeline established by ADR-0001 and
+consolidated under ADR-0002). No overlay, no modal, no popup viewer. This
+explicitly closes the door on reviving pi-gizmo's overlay surface and aligns
+with the `AGENTS.md` "popup viewer" anti-pattern entry.
+
+### D2 — Thread model: ephemeral, per-invocation
+
+Each `/gremlins:chat` and `/gremlins:tangent` invocation creates a **new
+in-memory side-chat session**. There is **no persistence** of side-chat
+threads across invocations. pi-gizmo's custom session-entry persistence is not
+ported. This aligns with ADR-0002's collapse of nested runtimes and avoids
+re-introducing a bespoke storage contract.
+
+### D3 — Context seeding and isolation
+
+- `/gremlins:chat` seeds the child session with a **snapshot of the parent
+  transcript at invocation time**, passed through the same isolation boundary
+  used by `buildGremlinSessionConfig`.
+- `/gremlins:tangent` seeds the child session with **no parent context**.
+
+Both modes inherit ADR-0003's isolation guarantees in full: no parent
+extensions, prompts, themes, skills, `AGENTS.md` files, primary-agent
+markdown, or transcript content leaks beyond the explicit chat-mode seed.
+
+### D4 — Tool access: zero tools in v1
+
+v1 side-chat sessions register **zero tools**. Side-chat is pure conversation.
+A future ADR may revisit if explicit demand emerges; until then, the surface
+stays narrow.
+
+### D5 — Code locus: inside `extensions/pi-gremlins/`
+
+New modules (e.g., `side-chat-command.ts`, `side-chat-session-factory.ts`)
+live under `extensions/pi-gremlins/` and **reuse the existing
+`gremlin-session-factory` primitives**. No new package. No nested runtime.
+This keeps the absorbed feature on the same runtime and isolation rails as the
+rest of pi-gremlins.
+
+### D6 — Slash command registration
+
+Two commands are registered through the existing pi-extension `registerCommand`
+API (the same path used for tool registration today):
+
+- `/gremlins:chat <question>` — required argument; seeds with parent
+  transcript.
+- `/gremlins:tangent <question>` — required argument; no parent context.
+
+Empty arguments print usage rather than starting a session.
+
+### D7 — Deprecation boundary for pi-gizmo
+
+pi-gizmo will receive a final release marking the package **deprecated** and
+pointing users to pi-gremlins. pi-gremlins ships a migration mapping in its
+README and CHANGELOG. This ADR scopes the deprecation as **cross-package
+coordination**, not a pi-gremlins runtime change — pi-gremlins itself does not
+import, depend on, or shim pi-gizmo.
+
+### D8 — Forward compatibility: explicitly deferred items
+
+The following are **explicitly deferred** out of v1. Each is a candidate for a
+future ADR, triggered only by concrete demand evidence:
+
+- **Q1** Persistence / thread resumption across invocations.
+- **Q2** Overlay / modal rendering surface for side-chat.
+- **Q3** Inject / handoff semantics between primary and side-chat sessions.
+- **Q4** Tool access inside side-chat sessions.
+- **Q5** Per-side-chat model and thinking-mode overrides.
+
+## Consequences
+
+- **Positive — Rendering surface (D1):** One renderer, one surface; no
+  regression of ADR-0001/0002; no new viewer code paths to maintain.
+- **Positive — Thread model (D2):** No new persistence shape; failure modes
+  reduced to in-memory lifetime; trivially testable.
+- **Positive — Isolation (D3):** Reuses ADR-0003's isolation boundary, so the
+  isolation invariant is centralised in `buildGremlinSessionConfig`; no
+  parallel boundary to drift.
+- **Positive — Tools (D4):** Smallest possible v1 attack surface; no
+  permissioning model required upfront.
+- **Positive — Code locus (D5):** Side-chat is discoverable next to existing
+  factory primitives; future maintainers see one runtime, not two.
+- **Positive — Commands (D6):** Reuses the established extension command API;
+  no new registration mechanism.
+- **Positive — Deprecation (D7):** Single source of truth for users; pi-gizmo
+  exits cleanly without pi-gremlins inheriting its internals.
+- **Negative — Thread model (D2):** Users lose pi-gizmo's resumable threads;
+  every invocation starts fresh.
+- **Negative — Tools (D4):** Side-chat cannot perform actions; conversation
+  only.
+- **Negative — Rendering (D1):** Inline rendering interleaves side-chat output
+  with primary transcript; users who relied on visual separation in the
+  overlay must adapt.
+- **Negative — Migration cost (D7):** pi-gizmo users must update workflows;
+  migration mapping must stay accurate across the deprecation window.
+- **Follow-on constraints:**
+  - Any future revisit of Q1–Q5 must clear ADR-0001/0002 (no popup viewer)
+    and ADR-0003 (isolation) before landing.
+  - Side-chat factory must remain a *consumer* of `gremlin-session-factory`
+    primitives, not a fork.
+  - pi-gremlins must not take a runtime dependency on pi-gizmo at any point
+    in the deprecation window.
+
+## Implementation Impact
+
+- **extensions/pi-gremlins:** New `side-chat-command.ts` and
+  `side-chat-session-factory.ts` (or equivalents) reusing
+  `gremlin-session-factory.ts`. `index.ts` registers `/gremlins:chat` and
+  `/gremlins:tangent` via the existing `registerCommand` API.
+- **Renderer:** No structural changes; side-chat output flows through existing
+  semantic-presentation hooks.
+- **Persistence / config:** None. No new on-disk state.
+- **pi-gizmo (separate repo):** Final deprecation release; package marked
+  deprecated; README points to pi-gremlins.
+- **pi-gremlins README / CHANGELOG:** Migration mapping from pi-gizmo
+  side-chat to `/gremlins:chat` and `/gremlins:tangent`; CHANGELOG entry cites
+  **ADR-0004** and **PRD-0004**.
+
+## Verification
+
+- **Automated:**
+  - Tests MUST assert the ADR-0003 isolation contract for side-chat sessions:
+    no parent extensions, prompts, themes, skills, `AGENTS.md` files,
+    primary-agent markdown, or transcript content leaks beyond the explicit
+    `/gremlins:chat` seed.
+  - Tests MUST assert that `/gremlins:tangent` seeds with no parent context.
+  - Tests MUST assert that v1 side-chat sessions register zero tools.
+  - Tests MUST assert that empty-argument invocations print usage instead of
+    starting a session.
+- **Compliance hooks:**
+  - CHANGELOG entry for the absorbing release MUST cite **ADR-0004** and
+    **PRD-0004**.
+  - README migration section MUST reference this ADR.
+- **Manual:**
+  - Run `/gremlins:chat <q>` after a non-trivial primary turn; confirm the
+    seeded transcript snapshot is present and rendered inline.
+  - Run `/gremlins:tangent <q>` from the same session; confirm no parent
+    context is visible to the child agent.
+
+## Notes
+
+- The `Proposed` status reflects that PRD-0004 is being authored in parallel
+  and that the absorbing implementation has not yet landed. Promote to
+  `Accepted` once both the PRD is finalised and the implementation is merged.
+- Revisit triggers for Q1–Q5 (D8): concrete user demand, a security-driven
+  need for tool access, or a UX failure attributable to inline rendering.
+
+## Status History
+
+- 2026-04-29: Proposed
+- 2026-04-29: Updated PRD cross-link.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,3 +68,4 @@ Reference ADR IDs in changelog entries for significant changes:
 | 0001 | Semantic Presentation Architecture for Pi Gremlins Viewer and Embedded Surfaces | Superseded by ADR-0002 | 2026-04-21 |
 | 0002 | In-Process SDK-Based Gremlin Runtime                             | Accepted | 2026-04-22 |
 | 0003 | Unified Agent Discovery and Primary-Agent Prompt Injection in pi-gremlins | Accepted | 2026-04-25 |
+| 0004 | Side-Chat Absorption from pi-gizmo into pi-gremlins              | Proposed | 2026-04-29 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,4 +68,4 @@ Reference ADR IDs in changelog entries for significant changes:
 | 0001 | Semantic Presentation Architecture for Pi Gremlins Viewer and Embedded Surfaces | Superseded by ADR-0002 | 2026-04-21 |
 | 0002 | In-Process SDK-Based Gremlin Runtime                             | Accepted | 2026-04-22 |
 | 0003 | Unified Agent Discovery and Primary-Agent Prompt Injection in pi-gremlins | Accepted | 2026-04-25 |
-| 0004 | Side-Chat Absorption from pi-gizmo into pi-gremlins              | Proposed | 2026-04-29 |
+| 0004 | Side-Chat Absorption from pi-gizmo into pi-gremlins              | Accepted | 2026-04-29 |

--- a/docs/plans/issue-47-side-chat-absorption.md
+++ b/docs/plans/issue-47-side-chat-absorption.md
@@ -1,0 +1,387 @@
+# Plan: Issue #47 — Pi Gremlins Side-Chat Absorption (`/gremlins:chat`, `/gremlins:tangent`)
+
+## Goal
+
+Land `/gremlins:chat` and `/gremlins:tangent` inside `extensions/pi-gremlins/`,
+backed by the existing in-process SDK gremlin session factory primitives, with
+zero tools, fresh-per-invocation sessions, inline rendering, parent-transcript
+seeding for `/gremlins:chat` only, and full ADR-0003 isolation. Ship README and
+CHANGELOG updates required by PRD-0004 / ADR-0004 acceptance criteria. Capture
+`pi-gizmo` deprecation as a post-merge cross-package coordination checklist
+(out of this PR's scope, but tracked here so the absorption is not considered
+done until those items execute).
+
+## References
+
+- GitHub issue: <https://github.com/magimetal/pi-gremlins/issues/47>
+- PRD: `docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md`
+- ADR: `docs/adr/0004-side-chat-absorption-from-pi-gizmo.md`
+- Prior decisions reused: ADR-0002 (in-process SDK runtime), ADR-0003 (isolation contract)
+- Touched code (anchors):
+  - `extensions/pi-gremlins/index.ts` (extension entry, registers commands via `pi.registerCommand`)
+  - `extensions/pi-gremlins/gremlin-session-factory.ts`
+    (`buildGremlinSessionConfig`, `createIsolatedGremlinResourceLoader`,
+    `createEmptyGremlinResources`, `createGremlinSession`,
+    `resolveGremlinModel`, `resolveGremlinThinking`)
+  - `extensions/pi-gremlins/gremlin-prompt.ts` (`buildGremlinPrompt`)
+  - `extensions/pi-gremlins/gremlin-runner.ts` (event projection patterns; reused only for inspiration, not imported)
+- Pi platform anchors (read-only):
+  - `node_modules/@mariozechner/pi-coding-agent/dist/core/extensions/types.d.ts`
+    — confirmed `ExtensionAPI.registerCommand(name, { description?, handler:
+    (args, ctx: ExtensionCommandContext) => Promise<void> })`,
+    `pi.sendMessage({ customType, content, display, details })`,
+    `pi.registerMessageRenderer(customType, renderer)`, and `ctx.ui.notify`.
+  - `node_modules/@mariozechner/pi-coding-agent/dist/core/session-manager.d.ts`
+    — confirmed `ReadonlySessionManager.getBranch()` returns
+    `SessionEntry[]`, with `SessionMessageEntry { type: "message", message:
+    AgentMessage }`. This is the parent-transcript snapshot source.
+
+**Confirmed command-registration API by inspection (Observed):**
+`pi.registerCommand("gremlins:primary", { description, handler })` is already
+used in `extensions/pi-gremlins/index.ts` (line 139). Side-chat will register
+through the same symbol; no new mechanism required (ADR-0004 D6).
+
+## Out-of-Scope (mirrors PRD-0004)
+
+- Thread persistence across invocations (Q1; PRD non-goal).
+- Overlay/popup UI for side-chat (Q2; PRD non-goal; ADR-0004 D1).
+- Inject/handoff between side-thread and parent (Q3; PRD non-goal).
+- Tool access inside side-thread (Q4; PRD non-goal; ADR-0004 D4).
+- Porting `pi-gizmo` source (Q5; PRD non-goal; ADR-0004 D5).
+- Per-side-thread model/thinking overrides, recap, summarize, inject, clear, new (replacements for `gizmo:model`, `gizmo:thinking`, `gizmo:recap`, `gizmo:summarize`, `gizmo:inject`, `gizmo:clear`, `gizmo:new`).
+- Reviving nested Pi CLI subprocess runtime, temp prompt files, chain mode, or popup viewer.
+- Removing `pi-gizmo` package code in this repo (it lives in a separate repo); only docs in *this* repo gain the migration table. Actual `pi-gizmo` repo edits are POST-MERGE.
+- Changes to gremlin delegation tool schema (PRD-0002) or primary-agent selection (PRD-0003).
+
+## Step-by-Step Tasks
+
+### Task 1 — Pre-implementation evidence pass (NO CODE)
+
+- **What:** Before adding modules, the implementer must confirm the parent-transcript shape exposed to a command handler.
+- **References:**
+  - `extensions/pi-gremlins/index.ts:110` (`ctx.sessionManager.getBranch()` already used).
+  - `node_modules/@mariozechner/pi-coding-agent/dist/core/session-manager.d.ts` — `SessionEntry`, `SessionMessageEntry`, `ReadonlySessionManager.getBranch`.
+  - `node_modules/@mariozechner/pi-agent-core` — `AgentMessage` type (role + content parts).
+- **Action:** run `fff-multi-grep`-style searches (or plain `grep -rn`) for `getBranch`, `SessionMessageEntry`, `AgentMessage`, `messages`, `transcript`, `history`, and `getEntries` across `node_modules/@mariozechner/pi-coding-agent/dist` and `node_modules/@mariozechner/pi-agent-core/dist`. Confirm:
+  1. `ctx.sessionManager.getBranch()` returns the linear branch from root to current leaf as `SessionEntry[]`.
+  2. `SessionMessageEntry.message` is the `AgentMessage` whose `role` and `content` (string or `(TextContent | ImageContent)[]`) are stable across the v0.69 surface.
+- **Strategy chosen (Inferred but supported):** capture parent transcript at command-handler invocation time via `ctx.sessionManager.getBranch()`, filter to `entry.type === "message"`, and project to a plain `Array<{ role, text }>` snapshot. Strategy (a) — read from extension hook context — is rejected because command handlers do not receive a `before_agent_start`-style message array; strategy (b) — snapshot at command-handler invocation — matches ADR-0004 D3 ("snapshot of the parent transcript at invocation time").
+- **Fail-fast contract:** if `ctx.sessionManager` is missing, `getBranch()` throws, or the entries cannot be coerced to a non-empty `Array<{ role, text }>`, `/gremlins:chat` MUST print a usage hint via `ctx.ui.notify(..., "warning")` and exit cleanly without starting a session. Document this gap as a follow-up (`docs/plans/`-style FIXME at the top of `side-chat-command.ts`) instead of guessing.
+- **Acceptance:** notes added inline to the new modules' header comments citing the exact symbol names confirmed; no implementation written yet.
+- **Guardrail:** do not modify any file in this task.
+- **Verification:** the implementer logs the confirmed symbols in the PR description before merging Task 2.
+
+### Task 2 — Add `extensions/pi-gremlins/side-chat-session-factory.ts`
+
+- **What:** New module that produces an isolated, **zero-tool** SDK session for one side-chat invocation, layered on `gremlin-session-factory.ts` primitives. Does NOT import or modify the gremlin factory's public surface — it composes it.
+- **Exports (named):**
+  - `interface ParentTranscriptSnapshot { entries: Array<{ role: "user" | "assistant"; text: string }>; capturedAt: string; }`
+  - `interface BuildSideChatSessionConfigOptions { mode: "chat" | "tangent"; userPrompt: string; parentSnapshot?: ParentTranscriptSnapshot; parentModel?: string | Model<any>; parentThinking?: ThinkingLevel; cwd?: string; modelRegistry?: ModelRegistry; }`
+  - `interface SideChatSessionConfig { systemPrompt: string; prompt: string; model?: string; resolvedModel?: Model<any>; thinking?: ThinkingLevel; tools: []; cwd?: string; resources: ReturnType<typeof createEmptyGremlinResources>; resourceLoader: ResourceLoader; usesSubprocess: false; writesTempPromptFile: false; }`
+  - `function buildSideChatSessionConfig(options): SideChatSessionConfig`
+  - `function createSideChatSession(options): Promise<CreateAgentSessionResult>` — thin wrapper that calls `createGremlinSession` (re-exported through composition) with `tools: []` forced.
+  - `const SIDE_CHAT_SYSTEM_PROMPT_CHAT` / `_TANGENT` (constants — small, explicit; do not load from disk; enforces ADR-0003 "no parent extensions, prompts, themes, skills, AGENTS.md, primary-agent markdown leaks").
+- **Internal contracts (must be unit-asserted in Task 5):**
+  - `tools` is the empty array `[]` (NOT `undefined`) — pi-coding-agent treats `undefined` as "default" but `[]` as "explicitly none". Verify this against
+    `node_modules/@mariozechner/pi-coding-agent/dist/core/agent-session.d.ts` before relying on it; if `[]` does not disable tools, fall back to passing an explicit tool-allowlist filter and document.
+  - `resources` uses `createEmptyGremlinResources()` from the gremlin factory — same isolation primitive ADR-0003 locked.
+  - `resourceLoader` uses `createIsolatedGremlinResourceLoader(systemPrompt)` from the gremlin factory.
+  - `mode === "tangent"` MUST ignore `parentSnapshot` even if supplied (defensive). Test asserts this.
+  - `mode === "chat"` MUST embed `parentSnapshot` only inside the `prompt` field, never inside `systemPrompt`, and never as a tool, resource, or extension. The prompt embedding format is fixed (see below) so tests can grep it.
+  - `model` and `thinking` resolution reuse `resolveGremlinModel` / `resolveGremlinThinking` with `frontmatter` synthesized as `{}` (no per-side-chat overrides per Q5/D8).
+- **Prompt format (fixed):**
+  - `systemPrompt`: `SIDE_CHAT_SYSTEM_PROMPT_CHAT` or `SIDE_CHAT_SYSTEM_PROMPT_TANGENT`. Contents are ~4-8 lines: identity ("You are a side-chat conversational assistant for the Gremlins🧌 host session."), no-tools statement, no-workspace-mutation guarantee, terse-by-default guidance. No reference to gremlin delegation, primary-agent, AGENTS.md, or external skills.
+  - `prompt` (chat mode):
+    ```
+    <parent-transcript-snapshot capturedAt="...">
+    [user] ...
+    [assistant] ...
+    ...
+    </parent-transcript-snapshot>
+
+    <side-chat-question>
+    ...userPrompt...
+    </side-chat-question>
+    ```
+  - `prompt` (tangent mode):
+    ```
+    <side-chat-question>
+    ...userPrompt...
+    </side-chat-question>
+    ```
+- **Dependencies:** Task 1.
+- **Guardrails:**
+  - MUST NOT import `gremlin-prompt.ts`'s `buildGremlinPrompt` (different framing — keep side-chat prompt format separate from gremlin delegation framing).
+  - MUST NOT mutate or re-export `gremlin-session-factory.ts` shapes; treat that file as read-only.
+  - MUST NOT add per-side-chat model/thinking override knobs (D8 deferral).
+  - MUST NOT register tools, even an empty allowlist that triggers default tool registration.
+- **Validation hook:** Task 5 unit tests + `npm run typecheck`.
+
+### Task 3 — Add `extensions/pi-gremlins/side-chat-command.ts`
+
+- **What:** Module that registers `/gremlins:chat` and `/gremlins:tangent`, parses arguments, captures parent-transcript snapshot for chat mode, dispatches to the side-chat factory, drives the SDK session, and renders output inline through pi-gremlins' existing renderer surface (`pi.sendMessage` + `pi.registerMessageRenderer`).
+- **Exports (named):**
+  - `const SIDE_CHAT_CHAT_COMMAND = "gremlins:chat"`
+  - `const SIDE_CHAT_TANGENT_COMMAND = "gremlins:tangent"`
+  - `const SIDE_CHAT_MESSAGE_TYPE = "pi-gremlins:side-chat"`
+  - `interface SideChatCommandDeps { createSideChatSession?: typeof createSideChatSession; capturedAtFactory?: () => string; }` (constructor-injected for tests)
+  - `function registerSideChatCommands(pi: ExtensionAPI, deps?: SideChatCommandDeps): void` — called from `index.ts`.
+  - `function captureParentTranscriptSnapshot(ctx: ExtensionCommandContext): ParentTranscriptSnapshot | undefined` (exported for test).
+  - `function parseSideChatArgs(args: string): { ok: true; userPrompt: string } | { ok: false; usage: string }` (exported for test).
+- **Behavior:**
+  1. Parse `args`:
+     - Trim whitespace. If empty, call `ctx.ui.notify(USAGE_TEXT, "info")` (or fallback `console.log` if `hasUI === false`) and return without starting a session. Do NOT throw.
+     - Usage text:
+       - `/gremlins:chat <prompt>` → `Usage: /gremlins:chat <prompt>` plus 1-line description.
+       - `/gremlins:tangent <prompt>` → `Usage: /gremlins:tangent <prompt>` plus 1-line description.
+  2. For chat mode only, call `captureParentTranscriptSnapshot(ctx)`:
+     - `ctx.sessionManager.getBranch()` → filter `entry.type === "message"` → project to `{ role, text }` (stringify content arrays via `extractTextFromContent`-style helper local to this module).
+     - If snapshot is empty (no parent turns yet), proceed with empty entries array; chat mode still works on a brand-new session, just without history.
+  3. Build session via `buildSideChatSessionConfig({ mode, userPrompt, parentSnapshot, parentModel: ctx.model, ... })`.
+  4. Create session via `createSideChatSession(...)`.
+  5. Drive `session.prompt(plan.prompt)`. Subscribe to events using the same projection patterns as `gremlin-runner.ts` *but inlined locally* — DO NOT import `gremlin-runner.ts` (it owns gremlin tool-call activity, which side-chat does not need; importing would couple two surfaces).
+  6. As the assistant streams text, call `pi.sendMessage({ customType: SIDE_CHAT_MESSAGE_TYPE, content: <text>, display: true, details: { mode, capturedAt } })`. This places the side-chat turn inline through the standard renderer (ADR-0004 D1).
+  7. On completion / abort / error, dispose the session and emit a final inline marker via `pi.sendMessage`.
+  8. Honor `ctx.signal` for abort.
+- **Inline rendering & visual delimiter (PRD UX, ADR-0004 D1):**
+  - Register a custom message renderer in `index.ts` for `SIDE_CHAT_MESSAGE_TYPE` that prefixes each side-chat turn with a clear, fixed label:
+    - Chat mode: `💬 side-chat (chat)` on the first line, then the assistant text.
+    - Tangent mode: `🧭 side-chat (tangent)` on the first line, then the assistant text.
+    - Both end with a footer line: `└─ side-chat ended ─` after the final chunk.
+  - Exact prefix/label strings are exported as `SIDE_CHAT_CHAT_LABEL` and `SIDE_CHAT_TANGENT_LABEL` constants so tests can assert them. Use Unicode `└─` for the closer (matches existing pi-tui idioms; if pi-tui exposes a helper, prefer that — implementer to confirm at Task 1 evidence pass).
+- **Dependencies:** Task 2.
+- **Guardrails:**
+  - MUST NOT introduce overlay/popup viewer (ADR-0004 D1, AGENTS.md anti-pattern).
+  - MUST NOT persist side-chat output to a custom session entry type (ADR-0004 D2, D8). Use `pi.sendMessage` (ephemeral inline rendering only); do NOT call `pi.appendEntry`.
+  - MUST NOT capture parent transcript for `/gremlins:tangent`.
+  - MUST NOT pass parent transcript through `systemPrompt` or as a tool — input only (ADR-0004 D3).
+  - MUST NOT register tools on the SDK session (ADR-0004 D4).
+  - MUST NOT call into `primary-agent-prompt.ts` / `primary-agent-controls.ts` / `applyPrimaryAgentPromptInjection` (no primary-agent leakage; PRD-0003 isolation invariant).
+  - MUST NOT shell out, spawn nested Pi CLI, or write a temp prompt file (ADR-0002 anti-patterns).
+  - Empty arg path MUST exit before any session is created.
+- **Validation hook:** Task 5 unit tests + `npm test`.
+
+### Task 4 — Wire registration in `extensions/pi-gremlins/index.ts`
+
+- **What:** Inside `createPiGremlinsExtension(options)` -> `registerPiGremlins(pi)`, after the existing `pi.registerCommand("gremlins:primary", ...)` and `pi.registerShortcut(PRIMARY_SHORTCUT, ...)` blocks (lines ~139–161), call:
+  - `registerSideChatCommands(pi);`
+  - `pi.registerMessageRenderer(SIDE_CHAT_MESSAGE_TYPE, sideChatMessageRenderer);` (renderer factory exported from `side-chat-command.ts` or a small `side-chat-rendering.ts` if size grows).
+- **References:**
+  - `extensions/pi-gremlins/index.ts` lines 95–164 (existing registration block) — the only edit window. Do not refactor surrounding code.
+- **Acceptance:**
+  - `index.ts` adds two new top-of-file imports: `registerSideChatCommands`, `SIDE_CHAT_MESSAGE_TYPE`, `sideChatMessageRenderer`.
+  - No other file in `extensions/pi-gremlins/` is modified by Task 4.
+  - `pi.registerTool` block at the bottom is untouched.
+- **Guardrails:**
+  - Do not move the existing `pi.registerCommand("gremlins:primary", ...)` block.
+  - Do not change `BRAND_NAME`, `TOOL_NAME`, `TOOL_DESCRIPTION`, `PiGremlinsParams`, or anything related to the `pi-gremlins` tool.
+  - Do not introduce a new branch of session-state plumbing (`primaryAgentState` flow stays intact).
+- **Validation hook:** existing `extensions/pi-gremlins/index.execute.test.js` and `index.render.test.js` MUST continue to pass without modification (Task 5 enumerates them).
+
+### Task 5 — Tests (Bun JS, beside modules)
+
+All new tests live under `extensions/pi-gremlins/` and follow the existing
+`bun:test` pattern in `gremlin-session-factory.test.js`.
+
+#### 5a. New: `extensions/pi-gremlins/side-chat-session-factory.test.js`
+
+Suite: `side-chat session factory v1 contract`. Each test imports the TS
+source via dynamic `await import("./side-chat-session-factory.ts")`.
+
+- **T1 — zero tools (chat mode):** assert `config.tools` is an empty array `[]`, not `undefined` and not non-empty.
+- **T2 — zero tools (tangent mode):** same as T1 with `mode: "tangent"`.
+- **T3 — isolation (resources empty):** `config.resources.extensions/skills/prompts/themes/agents` are all `[]`. Asserts ADR-0003 isolation primitive is reused.
+- **T4 — isolation (resourceLoader getters):** call each getter (`getExtensions`, `getSkills`, `getPrompts`, `getThemes`, `getAgentsFiles`, `getAppendSystemPrompt`) and assert empty arrays or empty results. Asserts no parent ext/skills/themes/AGENTS leak.
+- **T5 — system prompt isolation:** `config.systemPrompt` is one of the two fixed `SIDE_CHAT_SYSTEM_PROMPT_*` constants and contains NONE of: parent agent name, primary-agent markdown markers (`<!-- pi-gremlins primary agent:start -->`), `AGENTS.md`-derived strings, gremlin frontmatter literals, or arbitrary parent text. Implemented by passing a fake `parentSnapshot` containing a sentinel like `"PARENT_SENTINEL_BANNED"` and asserting `systemPrompt.includes("PARENT_SENTINEL_BANNED") === false`.
+- **T6 — tangent mode passes no transcript:** with `mode: "tangent"` and a non-empty `parentSnapshot`, `config.prompt.includes("parent-transcript-snapshot") === false` and `config.prompt.includes(<sentinel>) === false`.
+- **T7 — chat mode embeds the supplied snapshot only as input:** with `mode: "chat"` and entries `[{ role: "user", text: "X1" }, { role: "assistant", text: "X2" }]`, `config.prompt.includes("X1")` and `config.prompt.includes("X2")` are true; `config.systemPrompt.includes("X1") === false`; `config.tools` still `[]`; `config.resources.extensions === []`.
+- **T8 — empty snapshot in chat mode is allowed:** with `parentSnapshot.entries === []`, `config.prompt` contains the `<side-chat-question>` block but the transcript block is omitted (or empty); no crash.
+- **T9 — model/thinking inheritance:** parent model `"openai/gpt-5"` is propagated as `config.model`; parent thinking `"medium"` is propagated as `config.thinking`. Asserts D8 (no per-side-chat overrides) by passing fake gremlin-frontmatter-shaped overrides (which the side-chat factory does NOT expose) and confirming they cannot be supplied.
+
+#### 5b. New: `extensions/pi-gremlins/side-chat-command.test.js`
+
+Suite: `side-chat command v1 contract`.
+
+- **T1 — empty arg prints usage (chat):** stub `pi.registerCommand` to capture handlers, invoke chat handler with `args = ""`, assert `ctx.ui.notify` was called with text matching `/Usage: \/gremlins:chat/`, and assert `createSideChatSession` was NOT invoked.
+- **T2 — empty arg prints usage (tangent):** mirror of T1 for tangent.
+- **T3 — whitespace-only arg treated as empty:** `args = "   \t  "` → usage path.
+- **T4 — chat handler captures parent transcript:** stub `ctx.sessionManager.getBranch` to return two `SessionMessageEntry`-shaped objects; assert the snapshot passed to a stubbed `createSideChatSession` has matching `entries` and a non-empty `capturedAt`.
+- **T5 — tangent handler does NOT capture parent transcript:** assert `parentSnapshot` is `undefined` (or absent) on the call to `createSideChatSession`.
+- **T6 — consecutive invocations are independent (no in-memory state leak):** invoke chat handler twice with different prompts; each call constructs a fresh session config (assert `createSideChatSession` called twice with distinct `userPrompt` arguments), and the second call's `parentSnapshot` reflects the second `getBranch()` reading rather than the first (mutate the stub between calls).
+- **T7 — tangent and chat invocations do not share state:** invoke chat then tangent; assert tangent's call args do NOT include any sentinel from chat's `parentSnapshot`.
+- **T8 — abort propagation:** stub `ctx.signal` with an `AbortController().signal` and assert it is forwarded to the session driver. (Optional if signal forwarding is straightforward; keep test if reasonable, drop if it requires excessive scaffolding.)
+- **T9 — inline rendering uses `pi.sendMessage` with `SIDE_CHAT_MESSAGE_TYPE`:** stub `pi.sendMessage` to capture calls; drive a fake session that emits one assistant text chunk; assert `pi.sendMessage` was called with `customType === "pi-gremlins:side-chat"`, `display === true`, and content containing the chunk text.
+- **T10 — visual delimiter constants exported:** `SIDE_CHAT_CHAT_LABEL` and `SIDE_CHAT_TANGENT_LABEL` are non-empty strings and differ.
+
+#### 5c. Existing tests — must remain green and untouched
+
+These files run today via `bun test extensions/pi-gremlins/*.test.js`
+(`package.json` `scripts.test`) and MUST NOT be edited:
+
+- `extensions/pi-gremlins/gremlin-discovery.test.js`
+- `extensions/pi-gremlins/gremlin-rendering.test.js`
+- `extensions/pi-gremlins/gremlin-runner.test.js`
+- `extensions/pi-gremlins/gremlin-scheduler.test.js`
+- `extensions/pi-gremlins/gremlin-schema.test.js`
+- `extensions/pi-gremlins/gremlin-session-factory.test.js`
+- `extensions/pi-gremlins/index.execute.test.js`
+- `extensions/pi-gremlins/index.render.test.js`
+- `extensions/pi-gremlins/primary-agent.test.js`
+
+If any of these starts failing after the side-chat additions, the change is
+out of contract — fix the side-chat module, not the existing test.
+
+### Task 6 — README.md update
+
+- **What:** Add a `## Side-chat: /gremlins:chat and /gremlins:tangent` section.
+- **Where:** insert after the `## Use` section, before any later sections (read README first to confirm exact insertion point — implementer must `read README.md` end-to-end before editing).
+- **Required content:**
+  - One-paragraph overview: side-chat absorbed from pi-gizmo; two commands; built on the same in-process SDK runtime.
+  - Subsection `### Commands`:
+    - `/gremlins:chat <prompt>` — seeds with a snapshot of the parent transcript at invocation time; inline output.
+    - `/gremlins:tangent <prompt>` — clean child session, no parent context; inline output.
+    - Empty argument prints usage; does not start a session.
+  - Subsection `### v1 guarantees`:
+    - Fresh side-thread per invocation (Q1).
+    - Inline rendering only — no overlay/popup (Q2; ADR-0004 D1).
+    - Zero tools — pure conversation surface; cannot read or modify the workspace (Q4; ADR-0004 D4).
+    - Built on `gremlin-session-factory` primitives; same isolation as gremlin delegation (ADR-0003, ADR-0004 D3, D5).
+    - Copy/paste is the supported handoff mechanism in v1 (Q3).
+  - Subsection `### Visual delimiter`: documents the exact `💬 side-chat (chat)` / `🧭 side-chat (tangent)` headers and `└─ side-chat ended ─` footer.
+  - Subsection `### Migration from pi-gizmo` with the **1:N migration table**:
+
+    | Retired pi-gizmo command | pi-gremlins replacement | Notes |
+    | --- | --- | --- |
+    | `gizmo` (chat send) | `/gremlins:chat <prompt>` | Parent-context attached, fresh per invocation. |
+    | `gizmo:tangent` | `/gremlins:tangent <prompt>` | Clean child session. |
+    | `gizmo:new` | (none — structurally unnecessary) | Fresh-per-invocation makes explicit "new" redundant. |
+    | `gizmo:recap` | (deferred) | No v1 replacement; revisit via future PRD. |
+    | `gizmo:clear` | (none — structurally unnecessary) | Fresh-per-invocation makes "clear" redundant. |
+    | `gizmo:inject` | (deferred) | Use copy/paste in v1; revisit via future PRD. |
+    | `gizmo:summarize` | (deferred) | No v1 replacement. |
+    | `gizmo:model` | (deferred) | No per-side-chat model override in v1. |
+    | `gizmo:thinking` | (deferred) | No per-side-chat thinking override in v1. |
+
+  - One sentence reference: "See [PRD-0004](docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md) and [ADR-0004](docs/adr/0004-side-chat-absorption-from-pi-gizmo.md)."
+  - Note: do NOT run `pi-gizmo` and `pi-gremlins` side-chat commands concurrently if installed simultaneously (mirrors the PRD risk note).
+- **Guardrails:** preserve existing README sections verbatim outside the inserted block.
+- **Validation hook:** `head -200 README.md` after edit; manual visual review.
+
+### Task 7 — CHANGELOG.md update
+
+- **What:** Under the existing `## [Unreleased]` block, add a new bullet to the most appropriate subsection (`### Added` if present, else create one above `### Changed`):
+  - `**Side-chat absorbed from pi-gizmo** (PRD-0004, ADR-0004, issue #47): pi-gremlins now ships /gremlins:chat (parent-transcript snapshot) and /gremlins:tangent (clean child session), rebuilt on the existing in-process SDK runtime with zero tools and inline rendering. See README "Side-chat" section for the pi-gizmo migration table.`
+- **Guardrails:** do not reorder or rewrite existing `## [Unreleased]` bullets.
+- **Validation hook:** `head -40 CHANGELOG.md` after edit.
+
+### Task 8 — Self-review pass before marking the PR ready
+
+- Re-read `side-chat-session-factory.ts` and `side-chat-command.ts` end-to-end and check each PRD-0004 acceptance criterion and each ADR-0004 D1–D8 commitment against the diff. Cross out only those visible in the code.
+- Re-run `npm run check` (typecheck + bun test).
+- Confirm the README and CHANGELOG edits cite PRD-0004 and ADR-0004 and that the migration table covers all nine retired pi-gizmo commands listed in PRD-0004 acceptance ("`gizmo:new`, `gizmo:recap`, `gizmo:inject`, `gizmo:summarize`, `gizmo:model`, `gizmo:thinking`, `gizmo:clear`, plus chat send/list verbs").
+
+## Test Matrix (acceptance criterion → test)
+
+| Acceptance criterion (source) | Test file → test name |
+| --- | --- |
+| `/gremlins:chat` registered (PRD §AC) | `side-chat-command.test.js` → T9 (registration captured) + Task 4 review |
+| `/gremlins:tangent` registered (PRD §AC) | `side-chat-command.test.js` → T9 (registration captured) + Task 4 review |
+| No new commands beyond chat/tangent (PRD §AC) | Task 4 review (only two `pi.registerCommand` additions) |
+| Implementation under `extensions/pi-gremlins/` reusing factory (PRD §AC; ADR-0004 D5) | `side-chat-session-factory.test.js` → T3, T4 |
+| No `pi-gizmo` source ported (PRD §AC; ADR-0004 D5) | Task 4 review (no new dep added in `package.json`) |
+| Fresh per-invocation chat (Q1) | `side-chat-command.test.js` → T6 |
+| Fresh per-invocation tangent (Q1) | `side-chat-command.test.js` → T6, T7 |
+| No custom session entry type for persistence (Q1; D2) | Task 3 guardrail (no `pi.appendEntry` call); review |
+| Inline rendering only (Q2; D1) | `side-chat-command.test.js` → T9 (uses `pi.sendMessage` not overlay) |
+| No inject/handoff command (Q3) | Task 4 review (only chat + tangent registered) |
+| Zero tools in side-thread (Q4; D4) | `side-chat-session-factory.test.js` → T1, T2 |
+| Chat attaches parent context only as input (Q4; D3) | `side-chat-session-factory.test.js` → T5, T7 |
+| Tangent has no parent context (D3) | `side-chat-session-factory.test.js` → T6 |
+| Built on existing factory; no nested CLI/popup/temp file (Q5; ADR-0002) | `side-chat-session-factory.test.js` → T3, T4; Task 3 guardrail |
+| Empty arg prints usage instead of starting session (PRD UX; ADR-0004 D6) | `side-chat-command.test.js` → T1, T2, T3 |
+| Visual delimiter present and unambiguous (PRD UX; ADR-0004 D1) | `side-chat-command.test.js` → T10 |
+| README documents commands, fresh-per-invocation, inline-only, no-tools (PRD AC) | Task 6 review |
+| README contains 1:N pi-gizmo migration table (PRD AC) | Task 6 review |
+| CHANGELOG cites PRD-0004 and issue #47 (PRD AC; ADR-0004 verification) | Task 7 review |
+| ADR-0003 isolation invariant preserved (no parent ext/skills/themes/AGENTS/primary-agent leak) | `side-chat-session-factory.test.js` → T3, T4, T5 |
+
+## Risks and Mitigations
+
+- **R1 — `tools: []` does not actually disable tools in pi-coding-agent 0.69.** If pi treats `[]` as "default" rather than "explicit empty", side-chat would expose tools in violation of D4. **Mitigation:** Task 1 evidence pass confirms behavior against `agent-session.d.ts`; if `[]` doesn't work, pivot to passing an explicit allowlist filter that yields zero tool registrations and assert in T1/T2.
+- **R2 — Parent-transcript shape changes across pi versions.** `SessionEntry` schema differs between session versions (`CURRENT_SESSION_VERSION = 3`). **Mitigation:** project to `{ role, text }` defensively; tolerate `entry.message?.role` and `entry.message?.content` being missing; cover via T4 stub variations.
+- **R3 — Primary-agent prompt injection accidentally triggering on side-chat.** `before_agent_start` hook in `index.ts` injects primary-agent markdown. The side-chat session is a *separate* SDK session created via `createGremlinSession`, so the host extension's `before_agent_start` does not fire on it (Inferred from gremlin runner behavior, where gremlins also don't inherit the primary-agent prompt — this is exactly the ADR-0003 invariant). **Mitigation:** T5 sentinel test asserts no primary-agent markers leak into `systemPrompt` or `prompt`. If the test fails, a second guard inside the side-chat factory hard-strips the primary-agent block patterns from any inherited string before use.
+- **R4 — Inline renderer collision with existing pi-gremlins tool render.** `pi-gremlins` already registers a tool renderer (`renderCall` / `renderResult`) for `pi-gremlins`. The side-chat path uses `pi.registerMessageRenderer(SIDE_CHAT_MESSAGE_TYPE, ...)`, a separate API. **Mitigation:** Task 4 confirms two distinct surfaces; existing `index.execute.test.js` / `index.render.test.js` continue green.
+- **R5 — Regressing existing PRD-0002 / PRD-0003 surfaces.** **Mitigation:** Task 5c forbids edits to existing tests; Task 4 forbids edits to surrounding registration code; full `npm run check` before merge.
+- **R6 — Argument parser eating prompts that contain quotes / newlines.** `args` arrives as the raw string after the command name. **Mitigation:** treat the entire trimmed `args` as a single free-form `userPrompt`; do not split or interpret quotes. Cover with a test that passes `args` containing both single and double quotes (extension to T1 / T4).
+- **R7 — Cross-package conflict if a user has both `pi-gizmo` and `pi-gremlins` installed and both register `/gremlins:*` or `/gizmo:*`.** **Mitigation:** README migration section explicitly tells users to migrate before relying on the new commands. Out-of-band coordination handled in post-merge items below.
+- **R8 — Forgetting to register the message renderer for `SIDE_CHAT_MESSAGE_TYPE`.** Inline messages would render with a default placeholder. **Mitigation:** Task 4 explicitly lists the renderer registration; T9 covers `sendMessage` call but a second smoke check during Task 8 self-review confirms `registerMessageRenderer` is wired.
+
+## Post-Merge Items (cross-package coordination, NOT in this PR)
+
+Owner: **magimetal**. Executed in the **`pi-gizmo` repo** *after* the side-chat
+absorption PR merges in `pi-gremlins`. These satisfy PRD-0004 deprecation
+deliverables and ADR-0004 D7. They are intentionally out of scope for issue
+#47's PR; tracking them here is mandatory so the absorption is not considered
+done until they ship.
+
+1. **`pi-gizmo` README** — replace "What this does" with a deprecation banner pointing at `pi-gremlins`, `/gremlins:chat`, and `/gremlins:tangent`. Link the `pi-gremlins` README migration section. Reference PRD-0004 and ADR-0004 by anchor (use absolute GitHub URLs since cross-repo).
+2. **`pi-gizmo` CHANGELOG** — `## [Unreleased]` deprecation entry: "Deprecated. Use `pi-gremlins` `/gremlins:chat` and `/gremlins:tangent`. See PRD-0004 / ADR-0004 in the `pi-gremlins` repo."
+3. **`pi-gizmo` final release** — bump version, ship the deprecation README/CHANGELOG, tag the release.
+4. **npm deprecation marker (out-of-band)** — run `npm deprecate <pi-gizmo-package-name>@"*" "Deprecated; use pi-gremlins. See https://github.com/magimetal/pi-gremlins"` once the final release is published. This step is npm-CLI-only and never touches either repo's source.
+5. **Verification of post-merge coordination:** after step 4, `npm view <pi-gizmo-package-name>` should show the deprecation message, and the `pi-gizmo` README's first paragraph must reference `pi-gremlins`. Track completion in the issue #47 thread before closing.
+
+These five items are NOT blockers for the issue-47 PR merge in `pi-gremlins`,
+but issue #47 stays open until they are checked off.
+
+## Verification Commands (sequence at end of implementation)
+
+Run from the repo root after Tasks 2–7 are complete:
+
+```bash
+npm run typecheck
+npm test
+npm run check
+```
+
+Expected:
+
+- `npm run typecheck` (`tsc --noEmit`) — passes; no new `as any`, `@ts-ignore`, or `@ts-expect-error` introduced (the existing one in `index.ts:217` for the TypeBox 1.x deep-instantiation issue stays).
+- `npm test` (`bun test extensions/pi-gremlins/*.test.js`) — all existing suites still green; `side-chat-session-factory.test.js` and `side-chat-command.test.js` green.
+- `npm run check` — equivalent to running typecheck then test in series; must pass.
+
+If any verification step fails, fix the side-chat modules — do not modify
+existing pi-gremlins runtime modules or existing tests to make the side-chat
+work.
+
+## Assumptions
+
+- `pi.registerCommand(name, { description, handler })` is the registration
+  symbol for slash commands in this Pi version (Observed in `index.ts:139`
+  and `types.d.ts:800`).
+- `ctx.sessionManager.getBranch()` returns parent-session entries usable as
+  the chat-mode snapshot (Observed in `index.ts:110` + `types.d.ts:244`).
+- `pi.sendMessage({ customType, content, display: true })` plus
+  `pi.registerMessageRenderer(customType, ...)` is sufficient for inline
+  rendering of side-chat assistant turns without needing a tool-row surface
+  (Inferred from `types.d.ts:814–820`).
+- `tools: []` on the SDK session config disables tools registration (Inferred;
+  Task 1 evidence pass confirms before Task 2 ships).
+- The `pi-gizmo` repo lives under the same `magimetal` GitHub org and is
+  edited out-of-band; this repo never imports it.
+
+## Open Questions / Unknowns
+
+- **U1 — Exact tools-disable contract of `createAgentSession`.** Need
+  Task 1 evidence pass to confirm whether `tools: []` vs `tools: undefined` vs
+  omitting the field disables tools. Resolved before Task 2 begins.
+- **U2 — Stable transcript projection.** Whether `SessionMessageEntry.message`
+  always exposes `role` and `content` in the v0.69.0 surface, or whether
+  some entries can be tool/result messages we should drop. Plan resolves this
+  defensively (filter to `role in ("user", "assistant")` only) but
+  implementer should confirm during Task 1.
+- **U3 — Renderer hook ergonomics.** Whether `pi.registerMessageRenderer`
+  expects a Component-returning function similar to `renderCall`/`renderResult`
+  or a simpler text-returning shape. Resolved during Task 1 by reading
+  `MessageRenderer<T>` in `types.d.ts`.
+- **U4 — `pi-gizmo` package name on npm.** Needed for Step 4 of post-merge
+  items. Confirm via `npm view` before running `npm deprecate`.

--- a/docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md
+++ b/docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md
@@ -1,0 +1,143 @@
+# PRD-0004: Pi Gremlins Side-Chat Absorption and pi-gizmo Deprecation
+
+- **Status:** Active
+- **Date:** 2026-04-29
+- **Author:** Magi Metal
+- **Related:** `extensions/pi-gremlins`, `extensions/pi-gizmo`, `README.md`, `CHANGELOG.md`, GitHub issue [#47](https://github.com/magimetal/pi-gremlins/issues/47), [ADR-0002](../adr/0002-in-process-sdk-based-gremlin-runtime.md), [ADR-0003](../adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md)
+- **Supersedes:** None
+
+## Problem Statement
+
+`pi-gizmo` ships a side-chat experience for parent-session conversational excursions, but it does so through a sprawling nine-command surface (`gizmo:new`, `gizmo:recap`, `gizmo:inject`, `gizmo:summarize`, `gizmo:model`, `gizmo:thinking`, `gizmo:clear`, plus chat send/list verbs) and a parallel runtime built around nested Pi CLI subprocesses, temp prompt files, chain mode, and a popup viewer — exactly the runtime shape that ADR-0002 collapsed when `pi-gremlins` adopted the in-process SDK gremlin runtime. The result is two packages with overlapping discovery, divergent UX, and the maintenance burden of a runtime path the project has formally moved away from.
+
+Issue #47 proposes folding side-chat into `pi-gremlins` as exactly two commands — `/gremlins:chat` (parent context attached) and `/gremlins:tangent` (clean child session) — built fresh inside `extensions/pi-gremlins/` on the existing gremlin session factory, then deprecating `pi-gizmo`. This PRD captures the user-facing scope, locks design answers to Q1–Q5, and defines acceptance criteria for both the new commands and the `pi-gizmo` deprecation deliverables. Now is the right time because `pi-gremlins` already owns gremlin delegation (PRD-0002) and primary-agent selection (PRD-0003); absorbing side-chat consolidates the agent-orchestration surface into a single package and lets us retire the legacy runtime without stranding active workflows.
+
+## Product Goals
+
+- Replace the nine-command `pi-gizmo` side-chat surface with two intentional commands inside `pi-gremlins`.
+- Reuse the `pi-gremlins` in-process SDK session factory rather than reviving the legacy nested-CLI runtime.
+- Keep the v1 side-chat experience scoped to pure conversation — no tools, no workspace mutation risk.
+- Give `pi-gizmo` users a clear 1:N migration table from old commands to new behavior.
+- Deprecate `pi-gizmo` only after equivalent `pi-gremlins` side-chat behavior ships.
+
+## User Stories
+
+- As an operator mid-task, I want to run `/gremlins:chat <prompt>` so that I can ask a clarifying question with my parent session's context attached without spawning a delegated gremlin.
+- As an operator exploring an unrelated idea, I want to run `/gremlins:tangent <prompt>` so that I can have a clean side conversation that does not inherit my parent transcript.
+- As a `pi-gizmo` user, I want a documented mapping from old gizmo commands to the new two-command surface so that I know what behavior I keep, what I lose, and what is deferred.
+- As a cautious operator, I want side-chat to have no tool access in v1 so that an exploratory conversation cannot mutate my workspace.
+- As a maintainer, I want side-chat built on the existing gremlin session factory so that we do not maintain a second runtime path or revive patterns ADR-0002 retired.
+- As a package user, I want `pi-gizmo` deprecation guidance only after the replacement lands so that I do not lose side-chat capability mid-migration.
+
+## Scope
+
+### In Scope
+
+- Add `/gremlins:chat <prompt>` command to `pi-gremlins`: starts (or continues, see Q1) a side conversation with the parent session's context attached as input.
+- Add `/gremlins:tangent <prompt>` command to `pi-gremlins`: starts a clean child session with no parent transcript attached.
+- Build both commands fresh inside `extensions/pi-gremlins/` using the existing `gremlin-session-factory` patterns and the in-process SDK runtime established by ADR-0002.
+- Render side-chat output inline in the parent transcript (Q2 decision below).
+- Provide a fresh side-thread per `/gremlins:chat` and `/gremlins:tangent` invocation in v1 (Q1 decision below).
+- Operate the side-thread as a pure conversation surface with zero tool access in v1 (Q4 decision below).
+- Document side-chat behavior, command UX, isolation guarantees, and the `pi-gizmo` migration mapping in `pi-gremlins` README.
+- After equivalent behavior ships, update `pi-gizmo` documentation to mark the package deprecated and point users to `/gremlins:chat` and `/gremlins:tangent`.
+- Migration mapping table (1:N) from each retired `pi-gizmo` command to its new behavior or out-of-scope status.
+- Bun test coverage for the two commands, parent-context attachment behavior, clean-session behavior, fresh-thread-per-invocation behavior, and absence of tool access.
+
+### Out of Scope / Non-Goals
+
+- **Thread persistence across invocations** — every invocation starts a fresh side-thread in v1 (Q1).
+- **Overlay/popup UI for side-chat** — inline rendering only in v1; an overlay surface may be revisited via a future ADR if usage demands it (Q2).
+- **Inject/handoff between side-thread and parent** — users can copy/paste manually; revisit after v1 (Q3).
+- **Tool access inside the side-thread** — pure conversation only in v1 (Q4); no workspace, file, or shell tools.
+- **Porting `pi-gizmo` source code** — rebuild inside `pi-gremlins` using existing factory patterns (Q5); do not revive nested Pi CLI subprocesses, temp prompt files, chain mode, or the popup viewer.
+- **Per-side-thread model overrides** (replacement for `gizmo:model`).
+- **Per-side-thread thinking-budget overrides** (replacement for `gizmo:thinking`).
+- **Recap/summarize commands** (replacements for `gizmo:recap` and `gizmo:summarize`).
+- **Manual context-injection commands** (replacement for `gizmo:inject`).
+- **Side-thread clear command** (replacement for `gizmo:clear`) — fresh-per-invocation makes this redundant.
+- **Reviving any retired `pi-gizmo` runtime patterns** (nested Pi CLI subprocess runtime, temp prompt files, chain mode, popup viewer).
+- **Deprecating or removing `pi-gizmo`** before equivalent `/gremlins:chat` and `/gremlins:tangent` behavior ships in `pi-gremlins`.
+- **Changes to gremlin delegation tool schema or primary-agent selection behavior** established by PRD-0002 and PRD-0003.
+
+## Design Decisions (Q1–Q5)
+
+These answers are normative for v1 and drive the acceptance criteria below.
+
+- **Q1 — Thread persistence: FRESH per invocation.** Each `/gremlins:chat` and `/gremlins:tangent` invocation starts a new side-thread. Rationale: matches `pi-gremlins`'s simplicity bias, avoids reviving the kind of custom session entries that ADR-0002 collapsed, and removes a class of state-reconstruction bugs from the v1 surface. Persistence may be reconsidered in a follow-up PRD if real usage demands continuity.
+- **Q2 — Overlay vs inline: INLINE in v1.** Side-chat output renders inline in the parent transcript, consistent with the current `pi-gremlins` surface. An overlay/popup UI is explicitly deferred and would require a future ADR before adoption.
+- **Q3 — Inject/handoff: OUT OF SCOPE for v1.** Users transfer information between side-thread and parent by copy/paste. Revisit after v1 ships.
+- **Q4 — Tool access in side-thread: NONE in v1.** Side-chat is a pure conversation surface. No workspace tools, no file tools, no shell. This eliminates the risk of a side-thread mutating the workspace and aligns with the issue's stated reduction goal.
+- **Q5 — Rebuild vs port: REBUILD inside `pi-gremlins`.** Implement on top of `gremlin-session-factory` patterns and the in-process SDK runtime per ADR-0002. Do not port `pi-gizmo` source. Per AGENTS.md, do not revive the nested Pi CLI subprocess runtime, temp prompt files, chain mode, or the popup viewer.
+
+## Acceptance Criteria
+
+### Issue #47 baseline
+
+- [ ] `/gremlins:chat <prompt>` is registered by `pi-gremlins` and runs a side conversation with the parent session's context attached as input.
+- [ ] `/gremlins:tangent <prompt>` is registered by `pi-gremlins` and runs a clean child session with no parent transcript attached.
+- [ ] No new commands beyond `/gremlins:chat` and `/gremlins:tangent` are added for side-chat in v1.
+- [ ] Implementation lives entirely under `extensions/pi-gremlins/` and reuses the existing gremlin session factory.
+- [ ] No `pi-gizmo` source is ported or imported by `pi-gremlins`.
+- [ ] `pi-gizmo` is marked deprecated in its own README/changelog after the replacement ships, with users pointed to `/gremlins:chat` and `/gremlins:tangent`.
+
+### Q1–Q5 decisions
+
+- [ ] Each `/gremlins:chat` invocation creates a new side-thread; no state from a prior `/gremlins:chat` invocation leaks into the next (Q1).
+- [ ] Each `/gremlins:tangent` invocation creates a new clean child session; no state from a prior tangent leaks into the next (Q1).
+- [ ] No custom session entry type is introduced to persist side-thread history across invocations in v1 (Q1).
+- [ ] Side-chat output is rendered inline in the parent transcript; no overlay/popup surface is introduced (Q2).
+- [ ] No inject/handoff command is exposed in v1; documentation states copy/paste is the supported workflow until a future PRD addresses handoff (Q3).
+- [ ] The side-thread runtime exposes zero tools to the SDK call: no workspace, file, or shell tools are made available in either `/gremlins:chat` or `/gremlins:tangent` (Q4).
+- [ ] `/gremlins:chat` attaches parent-session context as input only; the parent transcript is not handed to the side-thread as a tool surface (Q4).
+- [ ] Side-chat is implemented on the existing `gremlin-session-factory` and the in-process SDK runtime per ADR-0002; no nested Pi CLI subprocess, temp prompt file, chain mode, or popup viewer is introduced (Q5).
+
+### `pi-gizmo` deprecation deliverables
+
+- [ ] `pi-gremlins` README documents `/gremlins:chat` and `/gremlins:tangent`, the fresh-per-invocation behavior, the inline rendering choice, and the no-tools guarantee.
+- [ ] `pi-gremlins` README includes a 1:N migration table from each retired `pi-gizmo` command (`gizmo:new`, `gizmo:recap`, `gizmo:inject`, `gizmo:summarize`, `gizmo:model`, `gizmo:thinking`, `gizmo:clear`, plus chat send/list verbs) to its replacement behavior or explicit out-of-scope status.
+- [ ] CHANGELOG entry references PRD-0004 and issue #47 for the side-chat absorption.
+- [ ] `pi-gizmo` README/changelog is updated to mark the package deprecated and point users to `pi-gremlins` only after `/gremlins:chat` and `/gremlins:tangent` ship.
+- [ ] Migration guidance tells users not to run both `pi-gizmo` and `pi-gremlins` side-chat commands concurrently if conflicting command names or shortcuts exist.
+- [ ] Bun coverage exists for: `/gremlins:chat` parent-context attachment, `/gremlins:tangent` clean-session behavior, fresh-per-invocation isolation between consecutive calls, and absence of tool access from the side-thread runtime.
+
+## Technical Surface
+
+- **Commands and extension hooks:** `extensions/pi-gremlins/index.ts` (or extracted modules) for registering `/gremlins:chat` and `/gremlins:tangent`, argument parsing, and inline transcript rendering.
+- **Side-thread runtime:** new module under `extensions/pi-gremlins/` built on the existing `gremlin-session-factory` and the in-process SDK runtime; produces a side-thread per invocation and exposes no tools.
+- **Parent-context attachment (`/gremlins:chat`):** helper that captures the parent transcript or a defined context slice and passes it to the side-thread as input only — never as a tool or workspace handle.
+- **Isolation guarantees:** confirm side-thread invocations cannot reach gremlin tools, primary-agent prompt injection, or workspace mutation paths owned by PRD-0002 / PRD-0003 surfaces.
+- **Docs:** `README.md`, `CHANGELOG.md`, and later `pi-gizmo` README/changelog deprecation notes after support ships.
+- **Tests:** Bun tests beside the new side-chat modules under `extensions/pi-gremlins/`.
+- **Related ADRs:** [ADR-0002](../adr/0002-in-process-sdk-based-gremlin-runtime.md) for the in-process SDK runtime that side-chat must reuse rather than replace; [ADR-0003](../adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md) for the surrounding agent-discovery and primary-agent injection contracts that side-chat must not regress.
+
+## UX Notes
+
+- Both commands take a single free-form prompt argument: `/gremlins:chat <prompt>` and `/gremlins:tangent <prompt>`.
+- Side-chat output is rendered inline in the parent transcript with a clear visual delimiter so the user can distinguish side-chat turns from parent-session output, parent-session tool calls, and gremlin delegation output.
+- Empty-argument invocation should produce a transcript-visible usage hint rather than starting an empty side-thread.
+- Because v1 is fresh-per-invocation, command help/docs must explicitly state that prior side-chat turns do not carry over; this is a deliberate v1 simplification, not a bug.
+- The no-tools guarantee should be visible in user-facing docs so operators understand the side-thread cannot read or modify the workspace.
+- Migration copy should make clear that `gizmo:model`, `gizmo:thinking`, `gizmo:recap`, `gizmo:summarize`, `gizmo:inject`, `gizmo:clear`, and `gizmo:new` have no v1 replacement, and that fresh-per-invocation makes `gizmo:new` and `gizmo:clear` structurally unnecessary.
+
+## Risks
+
+- **Regression of existing `pi-gremlins` flows.** Adding side-chat must not perturb the gremlin delegation tool schema (PRD-0002) or primary-agent selection/prompt injection (PRD-0003). Mitigation: reuse the session factory without changing its public shape; cover existing flows in CI before and after the change.
+- **Isolation breach.** A misconfigured side-thread could inherit gremlin tools, primary-agent prompt injection, or workspace tools. Mitigation: explicit no-tools assertion in the side-thread runtime and a Bun test that fails if any tool surface is reachable.
+- **Inline rendering UX for multi-turn conversation.** Inline-only side-chat may feel cramped for longer exchanges and could be confused with parent-session output. Mitigation: clear visual delimiters and explicit docs; revisit overlay via a future ADR if real usage shows pain.
+- **Migration friction for `pi-gizmo` power users.** Users relying on `gizmo:model`, `gizmo:thinking`, `gizmo:recap`, `gizmo:summarize`, or `gizmo:inject` lose those affordances. Mitigation: explicit 1:N migration table calling each retired command out by name, with rationale and any planned follow-ups.
+- **Dual-package conflict during deprecation.** If both `pi-gizmo` and `pi-gremlins` are installed, command/shortcut overlap could confuse users. Mitigation: deprecation notes tell users to migrate before relying on `/gremlins:chat` and `/gremlins:tangent`, mirroring the `pi-mohawk` deprecation pattern in PRD-0003.
+- **Scope creep back toward the nine-command surface.** Pressure to re-add recap/inject/model/thinking/clear after v1 lands. Mitigation: this PRD names each retired command as explicitly out of scope; future additions require a new PRD.
+
+## Open Questions
+
+- Should `/gremlins:chat` attach the full parent transcript or a bounded recent window in v1, and how is that boundary defined?
+- What exact visual delimiter should mark side-chat turns inline so they are unambiguous against parent output, gremlin delegation output, and primary-agent prompt blocks?
+- Should empty-argument `/gremlins:chat` and `/gremlins:tangent` print a usage hint, open a picker (where UI supports it), or both?
+- After v1 ships, what real usage signal would justify revisiting Q1 (persistence), Q2 (overlay), or Q3 (inject/handoff) in a follow-up PRD?
+- Should the `pi-gizmo` deprecation note set a removal target (version/date), or leave the package in deprecated-but-installed status indefinitely?
+
+## Revision History
+
+- 2026-04-29: Draft created for GitHub issue #47 product scope.
+- 2026-04-29: Promoted Draft → Active. PLAN_REVIEW PASS; commit-to-build per orchestrator Step 5.

--- a/docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md
+++ b/docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md
@@ -1,6 +1,6 @@
 # PRD-0004: Pi Gremlins Side-Chat Absorption and pi-gizmo Deprecation
 
-- **Status:** Active
+- **Status:** Completed
 - **Date:** 2026-04-29
 - **Author:** Magi Metal
 - **Related:** `extensions/pi-gremlins`, `extensions/pi-gizmo`, `README.md`, `CHANGELOG.md`, GitHub issue [#47](https://github.com/magimetal/pi-gremlins/issues/47), [ADR-0002](../adr/0002-in-process-sdk-based-gremlin-runtime.md), [ADR-0003](../adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md)
@@ -141,3 +141,4 @@ These answers are normative for v1 and drive the acceptance criteria below.
 
 - 2026-04-29: Draft created for GitHub issue #47 product scope.
 - 2026-04-29: Promoted Draft → Active. PLAN_REVIEW PASS; commit-to-build per orchestrator Step 5.
+- 2026-04-29: Completed via PR #48 (commit ab2c856). All Q1-Q5 decisions and acceptance criteria delivered. Post-merge cross-package pi-gizmo deprecation items (5) tracked in plan; not blocking PR merge.

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -86,4 +86,4 @@ Maintain in `docs/prd/README.md`:
 | 0001 | Pi Gremlins Immersive Theming and Viewer UX Overhaul      | Completed | 2026-04-21 |
 | 0002 | Pi Gremlins V1 SDK Rewrite                                | Draft | 2026-04-22 |
 | 0003 | Primary Agent Selection and pi-mohawk Deprecation         | Completed | 2026-04-25 |
-| 0004 | Pi Gremlins Side-Chat Absorption and pi-gizmo Deprecation | Active | 2026-04-29 |
+| 0004 | Pi Gremlins Side-Chat Absorption and pi-gizmo Deprecation | Completed | 2026-04-29 |

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -86,3 +86,4 @@ Maintain in `docs/prd/README.md`:
 | 0001 | Pi Gremlins Immersive Theming and Viewer UX Overhaul      | Completed | 2026-04-21 |
 | 0002 | Pi Gremlins V1 SDK Rewrite                                | Draft | 2026-04-22 |
 | 0003 | Primary Agent Selection and pi-mohawk Deprecation         | Completed | 2026-04-25 |
+| 0004 | Pi Gremlins Side-Chat Absorption and pi-gizmo Deprecation | Active | 2026-04-29 |

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -39,7 +39,10 @@ describe("pi-gremlins index execute v1", () => {
 		const { tool, commands, shortcuts } = createExtensionHarness();
 
 		expect(tool.name).toBe("pi-gremlins");
-		expect(Array.from(commands.keys())).toEqual(["gremlins:primary"]);
+		expect(commands.size).toBe(3);
+		expect(commands.has("gremlins:primary")).toBe(true);
+		expect(commands.has("gremlins:chat")).toBe(true);
+		expect(commands.has("gremlins:tangent")).toBe(true);
 		expect(commands.has("gremlins:view")).toBe(false);
 		expect(commands.has("gremlins:steer")).toBe(false);
 		expect(Array.from(shortcuts.keys())).toEqual(["ctrl+shift+m"]);

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -38,6 +38,11 @@ import {
 } from "./primary-agent-controls.js";
 import { applyPrimaryAgentPromptInjection } from "./primary-agent-prompt.js";
 import {
+	registerSideChatCommands,
+	sideChatMessageRenderer,
+	SIDE_CHAT_MESSAGE_TYPE,
+} from "./side-chat-command.js";
+import {
 	clearPersistedPrimaryAgentSelection,
 	readPersistedPrimaryAgentSelectionWithDiagnostics,
 } from "./primary-agent-persistence.js";
@@ -160,6 +165,14 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 				);
 			},
 		});
+
+		registerSideChatCommands(pi);
+		// Defensive: some legacy in-repo test harnesses provide a fake pi without
+		// `registerMessageRenderer`. The real pi runtime always supplies it
+		// (see types.d.ts:815). Guard so registration is a no-op in those mocks.
+		if (typeof pi.registerMessageRenderer === "function") {
+			pi.registerMessageRenderer(SIDE_CHAT_MESSAGE_TYPE, sideChatMessageRenderer);
+		}
 
 		pi.on("before_agent_start", async (event, ctx) => {
 			const injection = await applyPrimaryAgentPromptInjection({

--- a/extensions/pi-gremlins/side-chat-command.test.js
+++ b/extensions/pi-gremlins/side-chat-command.test.js
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import "./v1-contract-harness.js";
+
+function createFakePi() {
+	const commands = new Map();
+	const messages = [];
+	const renderers = new Map();
+	return {
+		commands,
+		messages,
+		renderers,
+		registerCommand(name, options) {
+			commands.set(name, options);
+		},
+		registerMessageRenderer(customType, renderer) {
+			renderers.set(customType, renderer);
+		},
+		sendMessage(message) {
+			messages.push(message);
+		},
+	};
+}
+
+function createFakeCtx({
+	branchEntries = [],
+	hasUI = true,
+	signal,
+	model,
+} = {}) {
+	const notifications = [];
+	return {
+		cwd: "/tmp",
+		hasUI,
+		ui: {
+			notify(message, type = "info") {
+				notifications.push({ message, type });
+			},
+		},
+		notifications,
+		sessionManager: {
+			getBranch() {
+				return branchEntries;
+			},
+		},
+		modelRegistry: undefined,
+		model,
+		signal,
+	};
+}
+
+function createFakeSessionFactory({ events = [], onPrompt } = {}) {
+	const calls = [];
+	const created = {
+		session: {
+			subscribe(listener) {
+				const handle = setTimeout(() => {
+					for (const event of events) listener(event);
+				}, 0);
+				return () => clearTimeout(handle);
+			},
+			async prompt(text) {
+				if (onPrompt) await onPrompt(text);
+				// emit events synchronously for deterministic ordering
+				// (subscribe also schedules them, but the listener fires both)
+			},
+			async abort() {},
+			dispose() {},
+		},
+		extensionsResult: {},
+	};
+	return {
+		calls,
+		impl: async (options) => {
+			calls.push(options);
+			return created;
+		},
+	};
+}
+
+async function loadCommandModule() {
+	return await import("./side-chat-command.ts");
+}
+
+describe("side-chat command v1 contract", () => {
+	let pi;
+	beforeEach(() => {
+		pi = createFakePi();
+	});
+
+	test("T1 empty arg prints chat usage via ctx.ui.notify and does not start session", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		const factory = createFakeSessionFactory();
+		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
+		const handler = pi.commands.get("gremlins:chat").handler;
+		const ctx = createFakeCtx();
+		await handler("", ctx);
+		expect(ctx.notifications.length).toBe(1);
+		expect(ctx.notifications[0].message).toMatch(/Usage: \/gremlins:chat/);
+		expect(factory.calls.length).toBe(0);
+	});
+
+	test("T2 empty arg prints tangent usage and does not start session", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		const factory = createFakeSessionFactory();
+		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
+		const handler = pi.commands.get("gremlins:tangent").handler;
+		const ctx = createFakeCtx();
+		await handler("", ctx);
+		expect(ctx.notifications.length).toBe(1);
+		expect(ctx.notifications[0].message).toMatch(/Usage: \/gremlins:tangent/);
+		expect(factory.calls.length).toBe(0);
+	});
+
+	test("T3 whitespace-only arg is treated as empty", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		const factory = createFakeSessionFactory();
+		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
+		const handler = pi.commands.get("gremlins:chat").handler;
+		const ctx = createFakeCtx();
+		await handler("   \t  ", ctx);
+		expect(ctx.notifications.length).toBe(1);
+		expect(factory.calls.length).toBe(0);
+	});
+
+	test("T4 chat handler captures parent transcript snapshot and forwards it", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		const factory = createFakeSessionFactory();
+		registerSideChatCommands(pi, {
+			createSideChatSession: factory.impl,
+			capturedAtFactory: () => "CAPTURED_AT_T4",
+		});
+		const handler = pi.commands.get("gremlins:chat").handler;
+		const ctx = createFakeCtx({
+			branchEntries: [
+				{
+					type: "message",
+					message: { role: "user", content: [{ type: "text", text: "U1" }] },
+				},
+				{
+					type: "message",
+					message: {
+						role: "assistant",
+						content: [{ type: "text", text: "A1" }],
+					},
+				},
+				// non-message entries must be ignored
+				{ type: "modelChange", model: "openai/gpt-5" },
+			],
+		});
+		await handler("summarize", ctx);
+		expect(factory.calls.length).toBe(1);
+		const call = factory.calls[0];
+		expect(call.mode).toBe("chat");
+		expect(call.userPrompt).toBe("summarize");
+		expect(call.parentSnapshot).toBeDefined();
+		expect(call.parentSnapshot.capturedAt).toBe("CAPTURED_AT_T4");
+		expect(call.parentSnapshot.entries).toEqual([
+			{ role: "user", text: "U1" },
+			{ role: "assistant", text: "A1" },
+		]);
+	});
+
+	test("T5 tangent handler does NOT capture parent transcript", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		const factory = createFakeSessionFactory();
+		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
+		const handler = pi.commands.get("gremlins:tangent").handler;
+		const ctx = createFakeCtx({
+			branchEntries: [
+				{
+					type: "message",
+					message: {
+						role: "user",
+						content: [{ type: "text", text: "PARENT_USER" }],
+					},
+				},
+			],
+		});
+		await handler("explore", ctx);
+		expect(factory.calls.length).toBe(1);
+		expect(factory.calls[0].mode).toBe("tangent");
+		expect(factory.calls[0].parentSnapshot).toBeUndefined();
+	});
+
+	test("T6 consecutive chat invocations are independent (fresh transcript each time)", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		const factory = createFakeSessionFactory();
+		let branch = [
+			{
+				type: "message",
+				message: { role: "user", content: [{ type: "text", text: "FIRST" }] },
+			},
+		];
+		registerSideChatCommands(pi, {
+			createSideChatSession: factory.impl,
+			capturedAtFactory: () => `t-${factory.calls.length}`,
+		});
+		const handler = pi.commands.get("gremlins:chat").handler;
+		const ctx = {
+			...createFakeCtx(),
+			sessionManager: { getBranch: () => branch },
+		};
+		await handler("first prompt", ctx);
+		// mutate parent transcript between invocations
+		branch = [
+			{
+				type: "message",
+				message: { role: "user", content: [{ type: "text", text: "SECOND" }] },
+			},
+		];
+		await handler("second prompt", ctx);
+		expect(factory.calls.length).toBe(2);
+		expect(factory.calls[0].userPrompt).toBe("first prompt");
+		expect(factory.calls[1].userPrompt).toBe("second prompt");
+		expect(factory.calls[0].parentSnapshot.entries[0].text).toBe("FIRST");
+		expect(factory.calls[1].parentSnapshot.entries[0].text).toBe("SECOND");
+	});
+
+	test("T7 tangent invocation does not see chat-mode transcript sentinel", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		const factory = createFakeSessionFactory();
+		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
+		const chatHandler = pi.commands.get("gremlins:chat").handler;
+		const tangentHandler = pi.commands.get("gremlins:tangent").handler;
+		const ctx = createFakeCtx({
+			branchEntries: [
+				{
+					type: "message",
+					message: {
+						role: "user",
+						content: [{ type: "text", text: "CHAT_SENTINEL_X" }],
+					},
+				},
+			],
+		});
+		await chatHandler("c-prompt", ctx);
+		await tangentHandler("t-prompt", ctx);
+		expect(factory.calls.length).toBe(2);
+		expect(factory.calls[1].mode).toBe("tangent");
+		expect(factory.calls[1].parentSnapshot).toBeUndefined();
+		// And user prompts must not bleed across:
+		expect(factory.calls[0].userPrompt).toBe("c-prompt");
+		expect(factory.calls[1].userPrompt).toBe("t-prompt");
+	});
+
+	test("T8 abort signal triggers session.abort during prompt", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		let aborted = false;
+		let promptResolve;
+		const factory = {
+			calls: [],
+			impl: async (options) => {
+				factory.calls.push(options);
+				return {
+					session: {
+						subscribe: () => () => {},
+						prompt: () =>
+							new Promise((resolve) => {
+								promptResolve = resolve;
+							}),
+						abort: async () => {
+							aborted = true;
+							promptResolve?.();
+						},
+						dispose() {},
+					},
+					extensionsResult: {},
+				};
+			},
+		};
+		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
+		const handler = pi.commands.get("gremlins:tangent").handler;
+		const controller = new AbortController();
+		const ctx = createFakeCtx({ signal: controller.signal });
+		const handlerPromise = handler("explore", ctx);
+		// Schedule abort on next tick
+		await new Promise((r) => setTimeout(r, 5));
+		controller.abort();
+		await handlerPromise;
+		expect(aborted).toBe(true);
+	});
+
+	test("T9 inline rendering: pi.sendMessage called with SIDE_CHAT_MESSAGE_TYPE and assistant text", async () => {
+		const {
+			registerSideChatCommands,
+			SIDE_CHAT_MESSAGE_TYPE,
+		} = await loadCommandModule();
+		const factory = {
+			calls: [],
+			impl: async (options) => {
+				factory.calls.push(options);
+				let listener;
+				return {
+					session: {
+						subscribe(l) {
+							listener = l;
+							return () => {};
+						},
+						prompt: async () => {
+							listener?.({
+								type: "message_end",
+								message: {
+									role: "assistant",
+									content: [
+										{
+											type: "text",
+											text: "side-chat answer payload",
+										},
+									],
+								},
+							});
+						},
+						abort: async () => {},
+						dispose() {},
+					},
+					extensionsResult: {},
+				};
+			},
+		};
+		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
+		const handler = pi.commands.get("gremlins:tangent").handler;
+		const ctx = createFakeCtx();
+		await handler("ping", ctx);
+		expect(pi.messages.length).toBeGreaterThanOrEqual(1);
+		const last = pi.messages[pi.messages.length - 1];
+		expect(last.customType).toBe(SIDE_CHAT_MESSAGE_TYPE);
+		expect(last.display).toBe(true);
+		expect(typeof last.content).toBe("string");
+		expect(last.content).toContain("side-chat answer payload");
+		expect(last.details.mode).toBe("tangent");
+	});
+
+	test("T10 visual delimiter labels exported and distinct", async () => {
+		const {
+			SIDE_CHAT_CHAT_LABEL,
+			SIDE_CHAT_TANGENT_LABEL,
+			SIDE_CHAT_FOOTER,
+		} = await loadCommandModule();
+		expect(typeof SIDE_CHAT_CHAT_LABEL).toBe("string");
+		expect(SIDE_CHAT_CHAT_LABEL.length).toBeGreaterThan(0);
+		expect(typeof SIDE_CHAT_TANGENT_LABEL).toBe("string");
+		expect(SIDE_CHAT_TANGENT_LABEL.length).toBeGreaterThan(0);
+		expect(SIDE_CHAT_CHAT_LABEL).not.toBe(SIDE_CHAT_TANGENT_LABEL);
+		expect(typeof SIDE_CHAT_FOOTER).toBe("string");
+		expect(SIDE_CHAT_FOOTER.length).toBeGreaterThan(0);
+	});
+});

--- a/extensions/pi-gremlins/side-chat-command.ts
+++ b/extensions/pi-gremlins/side-chat-command.ts
@@ -1,0 +1,347 @@
+/**
+ * Side-chat command surface (PRD-0004 / ADR-0004).
+ *
+ * Registers `/gremlins:chat` and `/gremlins:tangent`. Chat captures a
+ * snapshot of the parent transcript at invocation time via
+ * `ctx.sessionManager.getBranch()` and feeds it to the side-chat session as
+ * conversational input only (never as system prompt, tool, or extension).
+ * Tangent gets a clean child session.
+ *
+ * Confirmed surfaces (Observed):
+ * - `pi.registerCommand(name, { description?, handler: (args, ctx) => Promise<void> })`
+ *   — extensions/types.d.ts:758, 800.
+ * - `pi.registerMessageRenderer<T>(customType, renderer)` — types.d.ts:815.
+ * - `pi.sendMessage({ customType, content, display, details })` is
+ *   fire-and-forget — types.d.ts:817.
+ * - `ctx.ui.notify(text, "info" | "warning" | "error")` — types.d.ts:74.
+ * - `ctx.sessionManager.getBranch()` returns `SessionEntry[]`; project
+ *   only `SessionMessageEntry` (entry.type === "message") with role
+ *   user|assistant — session-manager.d.ts:23–25, 244.
+ *
+ * Guardrails (ADR-0004):
+ * - No overlay/popup viewer (D1).
+ * - No `pi.appendEntry` for side-chat messages (D2).
+ * - Tangent never captures parent transcript (D3).
+ * - Zero tools on session (D4).
+ * - No primary-agent injection (PRD-0003 isolation).
+ * - No nested CLI / temp prompt files / subprocess (ADR-0002).
+ */
+
+import type { TextContent } from "@mariozechner/pi-ai";
+import {
+	getMarkdownTheme,
+	type CreateAgentSessionResult,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type MessageRenderer,
+} from "@mariozechner/pi-coding-agent";
+import {
+	Container,
+	Markdown,
+	type MarkdownTheme,
+	Spacer,
+	Text,
+} from "@mariozechner/pi-tui";
+import {
+	buildSideChatSessionConfig,
+	createSideChatSession as defaultCreateSideChatSession,
+	type ParentTranscriptEntry,
+	type ParentTranscriptSnapshot,
+	type SideChatMode,
+} from "./side-chat-session-factory.js";
+
+export const SIDE_CHAT_CHAT_COMMAND = "gremlins:chat";
+export const SIDE_CHAT_TANGENT_COMMAND = "gremlins:tangent";
+export const SIDE_CHAT_MESSAGE_TYPE = "pi-gremlins:side-chat";
+
+export const SIDE_CHAT_CHAT_LABEL = "💬 side-chat (chat)";
+export const SIDE_CHAT_TANGENT_LABEL = "🧭 side-chat (tangent)";
+export const SIDE_CHAT_FOOTER = "└─ side-chat ended ─";
+
+const CHAT_DESCRIPTION =
+	"Side-chat with parent-transcript context (zero tools, fresh per invocation).";
+const TANGENT_DESCRIPTION =
+	"Side-chat in a clean child session, no parent context (zero tools, fresh per invocation).";
+
+const CHAT_USAGE = `Usage: /gremlins:chat <prompt>\n${CHAT_DESCRIPTION}`;
+const TANGENT_USAGE = `Usage: /gremlins:tangent <prompt>\n${TANGENT_DESCRIPTION}`;
+
+export interface SideChatCommandDeps {
+	createSideChatSession?: typeof defaultCreateSideChatSession;
+	capturedAtFactory?: () => string;
+}
+
+export interface SideChatMessageDetails {
+	mode: SideChatMode;
+	capturedAt?: string;
+	label: string;
+	footer: string;
+}
+
+interface SideChatEvent {
+	type?: string;
+	assistantMessageEvent?: { type?: string; delta?: unknown };
+	message?: {
+		role?: unknown;
+		content?: unknown;
+	};
+}
+
+type SideChatSession = CreateAgentSessionResult["session"] & {
+	subscribe?: (listener: (event: SideChatEvent) => void) => () => void;
+	prompt: (text: string) => Promise<void>;
+	abort?: () => Promise<void>;
+	dispose: () => void;
+};
+
+function extractTextFromContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.flatMap((item) => {
+			if (!item || typeof item !== "object") return [];
+			if ((item as { type?: string }).type !== "text") return [];
+			const text = (item as TextContent).text;
+			return typeof text === "string" ? [text] : [];
+		})
+		.join("");
+}
+
+export function parseSideChatArgs(
+	args: string,
+): { ok: true; userPrompt: string } | { ok: false } {
+	const trimmed = (args ?? "").trim();
+	if (!trimmed) return { ok: false };
+	return { ok: true, userPrompt: trimmed };
+}
+
+export function captureParentTranscriptSnapshot(
+	ctx: ExtensionCommandContext,
+	capturedAtFactory: () => string = () => new Date().toISOString(),
+): ParentTranscriptSnapshot | undefined {
+	try {
+		const branch = ctx.sessionManager?.getBranch?.();
+		if (!Array.isArray(branch)) return undefined;
+		const entries: ParentTranscriptEntry[] = [];
+		for (const entry of branch) {
+			if (!entry || typeof entry !== "object") continue;
+			if ((entry as { type?: unknown }).type !== "message") continue;
+			const message = (entry as { message?: { role?: unknown; content?: unknown } })
+				.message;
+			if (!message || typeof message !== "object") continue;
+			const role = message.role;
+			if (role !== "user" && role !== "assistant") continue;
+			const text = extractTextFromContent(message.content).trim();
+			if (!text) continue;
+			entries.push({ role, text });
+		}
+		return { entries, capturedAt: capturedAtFactory() };
+	} catch {
+		return undefined;
+	}
+}
+
+function emitUsage(ctx: ExtensionCommandContext, usageText: string): void {
+	if (ctx.hasUI && ctx.ui?.notify) {
+		ctx.ui.notify(usageText, "info");
+		return;
+	}
+	// Fallback: emit a non-LLM-bound notification via console for non-UI modes.
+	// eslint-disable-next-line no-console
+	console.log(usageText);
+}
+
+async function driveSideChatSession(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	created: CreateAgentSessionResult,
+	prompt: string,
+	details: SideChatMessageDetails,
+): Promise<void> {
+	const session = created.session as SideChatSession;
+	let aggregatedDeltaText = "";
+	let lastAssistantMessageText = "";
+	const unsubscribe = session.subscribe?.((event) => {
+		if (!event || typeof event !== "object") return;
+		if (
+			event.type === "message_update" &&
+			event.assistantMessageEvent?.type === "text_delta"
+		) {
+			const delta = event.assistantMessageEvent.delta;
+			if (typeof delta === "string") aggregatedDeltaText += delta;
+			return;
+		}
+		if (event.type === "message_end") {
+			const message = event.message;
+			if (!message) return;
+			if (message.role === "assistant") {
+				const text = extractTextFromContent(message.content).trim();
+				if (text) lastAssistantMessageText = text;
+			}
+		}
+	});
+
+	const abortListener = () => {
+		void session.abort?.();
+	};
+	const signal = ctx.signal;
+	if (signal) {
+		if (signal.aborted) {
+			abortListener();
+		} else {
+			signal.addEventListener("abort", abortListener, { once: true });
+		}
+	}
+
+	let errorMessage: string | undefined;
+	try {
+		await session.prompt(prompt);
+	} catch (error) {
+		errorMessage = error instanceof Error ? error.message : String(error);
+	} finally {
+		signal?.removeEventListener("abort", abortListener);
+		unsubscribe?.();
+		try {
+			session.dispose();
+		} catch {
+			// dispose may throw on already-disposed sessions; ignore.
+		}
+	}
+
+	const aborted = Boolean(signal?.aborted);
+	const finalText =
+		(lastAssistantMessageText || aggregatedDeltaText.trim()) || "";
+
+	let content = finalText;
+	if (aborted && !content) content = "(side-chat aborted)";
+	if (errorMessage && !content) content = `(side-chat error: ${errorMessage})`;
+	if (!content) content = "(side-chat produced no response)";
+
+	pi.sendMessage<SideChatMessageDetails>({
+		customType: SIDE_CHAT_MESSAGE_TYPE,
+		content,
+		display: true,
+		details: { ...details },
+	});
+}
+
+function makeHandler(
+	pi: ExtensionAPI,
+	mode: SideChatMode,
+	deps: SideChatCommandDeps,
+): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
+	const createSession =
+		deps.createSideChatSession ?? defaultCreateSideChatSession;
+	const capturedAtFactory =
+		deps.capturedAtFactory ?? (() => new Date().toISOString());
+	const usageText = mode === "chat" ? CHAT_USAGE : TANGENT_USAGE;
+	const label = mode === "chat" ? SIDE_CHAT_CHAT_LABEL : SIDE_CHAT_TANGENT_LABEL;
+
+	return async function sideChatHandler(args, ctx) {
+		const parsed = parseSideChatArgs(args);
+		if (!parsed.ok) {
+			emitUsage(ctx, usageText);
+			return;
+		}
+
+		const parentSnapshot =
+			mode === "chat"
+				? captureParentTranscriptSnapshot(ctx, capturedAtFactory)
+				: undefined;
+
+		let created: CreateAgentSessionResult;
+		try {
+			created = await createSession({
+				mode,
+				userPrompt: parsed.userPrompt,
+				parentSnapshot,
+				parentModel: ctx.model,
+				parentThinking: undefined,
+				cwd: ctx.cwd,
+				modelRegistry: ctx.modelRegistry,
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			pi.sendMessage<SideChatMessageDetails>({
+				customType: SIDE_CHAT_MESSAGE_TYPE,
+				content: `(side-chat failed to start: ${message})`,
+				display: true,
+				details: {
+					mode,
+					capturedAt: parentSnapshot?.capturedAt,
+					label,
+					footer: SIDE_CHAT_FOOTER,
+				},
+			});
+			return;
+		}
+
+		// Build the session plan to get plan.prompt for `session.prompt(...)`.
+		// createSideChatSession may have built its own plan internally; that
+		// duplication is cheap (pure data construction) and lets the test stub
+		// receive flat options without coordinating session config exchange.
+		const plan = buildSideChatSessionConfig({
+			mode,
+			userPrompt: parsed.userPrompt,
+			parentSnapshot,
+			parentModel: ctx.model,
+			cwd: ctx.cwd,
+			modelRegistry: ctx.modelRegistry,
+		});
+
+		await driveSideChatSession(pi, ctx, created, plan.prompt, {
+			mode,
+			capturedAt: parentSnapshot?.capturedAt,
+			label,
+			footer: SIDE_CHAT_FOOTER,
+		});
+	};
+}
+
+export function registerSideChatCommands(
+	pi: ExtensionAPI,
+	deps: SideChatCommandDeps = {},
+): void {
+	pi.registerCommand(SIDE_CHAT_CHAT_COMMAND, {
+		description: CHAT_DESCRIPTION,
+		handler: makeHandler(pi, "chat", deps),
+	});
+	pi.registerCommand(SIDE_CHAT_TANGENT_COMMAND, {
+		description: TANGENT_DESCRIPTION,
+		handler: makeHandler(pi, "tangent", deps),
+	});
+}
+
+/**
+ * Inline message renderer for `pi-gremlins:side-chat` custom messages.
+ * Returns a Container with a label header, the assistant markdown body,
+ * and a fixed footer line. ADR-0004 D1: inline only.
+ */
+export const sideChatMessageRenderer: MessageRenderer<SideChatMessageDetails> =
+	(message, _options, _theme) => {
+		const details = message.details ?? {
+			mode: "chat",
+			label: SIDE_CHAT_CHAT_LABEL,
+			footer: SIDE_CHAT_FOOTER,
+		};
+		const container = new Container();
+		container.addChild(new Text(details.label));
+		container.addChild(new Spacer(1));
+		const body =
+			typeof message.content === "string"
+				? message.content
+				: extractTextFromContent(message.content);
+		container.addChild(new Markdown(body, 0, 0, getMarkdownThemeSafely()));
+		/* prettier-ignore */
+		container.addChild(new Spacer(1));
+		container.addChild(new Text(details.footer));
+		return container;
+	};
+
+function getMarkdownThemeSafely(): MarkdownTheme {
+	try {
+		return (getMarkdownTheme?.() ?? ({} as MarkdownTheme)) as MarkdownTheme;
+	} catch {
+		return {} as MarkdownTheme;
+	}
+}

--- a/extensions/pi-gremlins/side-chat-session-factory.test.js
+++ b/extensions/pi-gremlins/side-chat-session-factory.test.js
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import "./v1-contract-harness.js";
+
+const PARENT_PRIMARY_BLOCK_START = "<!-- pi-gremlins primary agent:start -->";
+
+function makeSnapshot(entries, capturedAt = "2026-04-29T00:00:00.000Z") {
+	return { entries, capturedAt };
+}
+
+describe("side-chat session factory v1 contract", () => {
+	test("T1 chat mode emits zero tools (empty array, not undefined)", async () => {
+		const { buildSideChatSessionConfig } = await import(
+			"./side-chat-session-factory.ts"
+		);
+		const config = buildSideChatSessionConfig({
+			mode: "chat",
+			userPrompt: "hello",
+		});
+		expect(Array.isArray(config.tools)).toBe(true);
+		expect(config.tools.length).toBe(0);
+		expect(config.tools).toEqual([]);
+	});
+
+	test("T2 tangent mode emits zero tools", async () => {
+		const { buildSideChatSessionConfig } = await import(
+			"./side-chat-session-factory.ts"
+		);
+		const config = buildSideChatSessionConfig({
+			mode: "tangent",
+			userPrompt: "hello",
+		});
+		expect(Array.isArray(config.tools)).toBe(true);
+		expect(config.tools.length).toBe(0);
+	});
+
+	test("T3 resources are empty (ADR-0003 isolation primitive)", async () => {
+		const { buildSideChatSessionConfig } = await import(
+			"./side-chat-session-factory.ts"
+		);
+		const config = buildSideChatSessionConfig({
+			mode: "chat",
+			userPrompt: "hello",
+		});
+		expect(config.resources).toEqual({
+			agents: [],
+			extensions: [],
+			prompts: [],
+			skills: [],
+			themes: [],
+		});
+	});
+
+	test("T4 resourceLoader getters return empty results", async () => {
+		const { buildSideChatSessionConfig } = await import(
+			"./side-chat-session-factory.ts"
+		);
+		const config = buildSideChatSessionConfig({
+			mode: "tangent",
+			userPrompt: "hello",
+		});
+		expect(config.resourceLoader.getExtensions().extensions).toEqual([]);
+		expect(config.resourceLoader.getSkills().skills).toEqual([]);
+		expect(config.resourceLoader.getPrompts().prompts).toEqual([]);
+		expect(config.resourceLoader.getThemes().themes).toEqual([]);
+		expect(config.resourceLoader.getAgentsFiles().agentsFiles).toEqual([]);
+		expect(config.resourceLoader.getAppendSystemPrompt()).toEqual([]);
+		expect(config.resourceLoader.getSystemPrompt()).toBe(config.systemPrompt);
+	});
+
+	test("T5 system prompt is fixed and isolated from any parent text", async () => {
+		const {
+			buildSideChatSessionConfig,
+			SIDE_CHAT_SYSTEM_PROMPT_CHAT,
+			SIDE_CHAT_SYSTEM_PROMPT_TANGENT,
+		} = await import("./side-chat-session-factory.ts");
+		const sentinel = "PARENT_SENTINEL_BANNED_DO_NOT_LEAK";
+		const chat = buildSideChatSessionConfig({
+			mode: "chat",
+			userPrompt: "hi",
+			parentSnapshot: makeSnapshot([
+				{ role: "user", text: sentinel },
+				{ role: "assistant", text: PARENT_PRIMARY_BLOCK_START },
+			]),
+		});
+		const tangent = buildSideChatSessionConfig({
+			mode: "tangent",
+			userPrompt: "hi",
+			parentSnapshot: makeSnapshot([{ role: "user", text: sentinel }]),
+		});
+		expect(chat.systemPrompt).toBe(SIDE_CHAT_SYSTEM_PROMPT_CHAT);
+		expect(tangent.systemPrompt).toBe(SIDE_CHAT_SYSTEM_PROMPT_TANGENT);
+		expect(chat.systemPrompt).not.toContain(sentinel);
+		expect(chat.systemPrompt).not.toContain(PARENT_PRIMARY_BLOCK_START);
+		expect(chat.systemPrompt).not.toContain("AGENTS.md");
+		expect(tangent.systemPrompt).not.toContain(sentinel);
+	});
+
+	test("T6 tangent mode passes no parent transcript even if supplied", async () => {
+		const { buildSideChatSessionConfig } = await import(
+			"./side-chat-session-factory.ts"
+		);
+		const sentinel = "TANGENT_LEAK_SENTINEL";
+		const config = buildSideChatSessionConfig({
+			mode: "tangent",
+			userPrompt: "what about this?",
+			parentSnapshot: makeSnapshot([{ role: "user", text: sentinel }]),
+		});
+		expect(config.prompt).not.toContain("parent-transcript-snapshot");
+		expect(config.prompt).not.toContain(sentinel);
+		expect(config.prompt).toContain("<side-chat-question>");
+		expect(config.prompt).toContain("what about this?");
+	});
+
+	test("T7 chat mode embeds snapshot only as input prompt, not system prompt", async () => {
+		const { buildSideChatSessionConfig } = await import(
+			"./side-chat-session-factory.ts"
+		);
+		const config = buildSideChatSessionConfig({
+			mode: "chat",
+			userPrompt: "summarize",
+			parentSnapshot: makeSnapshot([
+				{ role: "user", text: "X1_USER_TURN" },
+				{ role: "assistant", text: "X2_ASSISTANT_TURN" },
+			]),
+		});
+		expect(config.prompt).toContain("X1_USER_TURN");
+		expect(config.prompt).toContain("X2_ASSISTANT_TURN");
+		expect(config.prompt).toContain("parent-transcript-snapshot");
+		expect(config.systemPrompt).not.toContain("X1_USER_TURN");
+		expect(config.systemPrompt).not.toContain("X2_ASSISTANT_TURN");
+		expect(config.tools).toEqual([]);
+		expect(config.resources.extensions).toEqual([]);
+	});
+
+	test("T8 empty snapshot in chat mode is allowed and omits transcript block", async () => {
+		const { buildSideChatSessionConfig } = await import(
+			"./side-chat-session-factory.ts"
+		);
+		const config = buildSideChatSessionConfig({
+			mode: "chat",
+			userPrompt: "first message",
+			parentSnapshot: makeSnapshot([]),
+		});
+		expect(config.prompt).toContain("<side-chat-question>");
+		expect(config.prompt).toContain("first message");
+		expect(config.prompt).not.toContain("parent-transcript-snapshot");
+	});
+
+	test("T9 model and thinking inherit from parent when supplied", async () => {
+		const { buildSideChatSessionConfig } = await import(
+			"./side-chat-session-factory.ts"
+		);
+		const config = buildSideChatSessionConfig({
+			mode: "chat",
+			userPrompt: "hi",
+			parentModel: "openai/gpt-5",
+			parentThinking: "medium",
+		});
+		expect(config.model).toBe("openai/gpt-5");
+		expect(config.thinking).toBe("medium");
+	});
+});

--- a/extensions/pi-gremlins/side-chat-session-factory.ts
+++ b/extensions/pi-gremlins/side-chat-session-factory.ts
@@ -1,0 +1,194 @@
+/**
+ * Side-chat session factory (PRD-0004 / ADR-0004).
+ *
+ * Produces an isolated, zero-tool, fresh-per-invocation SDK session for a
+ * single `/gremlins:chat` or `/gremlins:tangent` invocation. Composes the
+ * gremlin-session-factory primitives to inherit ADR-0003 isolation
+ * (no parent extensions / skills / prompts / themes / AGENTS / primary-agent
+ * markdown leakage) without modifying the gremlin factory's surface.
+ *
+ * Confirmed (Observed) symbols:
+ * - `createAgentSession.tools?: string[]` — explicit allowlist.
+ *   Empty array `[]` => zero tools enabled. Source:
+ *   node_modules/@mariozechner/pi-coding-agent/dist/core/sdk.d.ts:36.
+ * - `pi.sendMessage({ customType, content, display, details })` is the
+ *   inline rendering path (types.d.ts:817).
+ * - `pi.registerMessageRenderer<T>(customType, renderer)` provides the
+ *   inline renderer hook (types.d.ts:815, 752).
+ * - `ctx.sessionManager.getBranch()` returns `SessionEntry[]` whose
+ *   `SessionMessageEntry.message` carries the `AgentMessage` shape
+ *   (session-manager.d.ts:23–25, 244).
+ *
+ * Guardrails:
+ * - Does NOT import `gremlin-prompt.ts` / `buildGremlinPrompt`.
+ * - Does NOT mutate or re-export `gremlin-session-factory.ts` shapes.
+ * - Does NOT register any tools, even default ones.
+ * - Does NOT expose per-side-chat model/thinking overrides (D8).
+ */
+
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { Model } from "@mariozechner/pi-ai";
+import type {
+	CreateAgentSessionResult,
+	ModelRegistry,
+	ResourceLoader,
+} from "@mariozechner/pi-coding-agent";
+import {
+	createEmptyGremlinResources,
+	createGremlinSession,
+	createIsolatedGremlinResourceLoader,
+	resolveGremlinModel,
+	resolveGremlinThinking,
+} from "./gremlin-session-factory.js";
+
+export type SideChatMode = "chat" | "tangent";
+
+export interface ParentTranscriptEntry {
+	role: "user" | "assistant";
+	text: string;
+}
+
+export interface ParentTranscriptSnapshot {
+	entries: ParentTranscriptEntry[];
+	capturedAt: string;
+}
+
+export interface BuildSideChatSessionConfigOptions {
+	mode: SideChatMode;
+	userPrompt: string;
+	parentSnapshot?: ParentTranscriptSnapshot;
+	parentModel?: string | Model<any>;
+	parentThinking?: ThinkingLevel;
+	cwd?: string;
+	modelRegistry?: ModelRegistry;
+}
+
+export interface SideChatSessionConfig {
+	systemPrompt: string;
+	prompt: string;
+	model?: string;
+	resolvedModel?: Model<any>;
+	modelResolutionError?: string;
+	thinking?: ThinkingLevel;
+	tools: [];
+	cwd?: string;
+	usesSubprocess: false;
+	writesTempPromptFile: false;
+	resources: ReturnType<typeof createEmptyGremlinResources>;
+	resourceLoader: ResourceLoader;
+}
+
+export interface CreateSideChatSessionOptions
+	extends BuildSideChatSessionConfigOptions {
+	sessionConfig?: SideChatSessionConfig;
+}
+
+export const SIDE_CHAT_SYSTEM_PROMPT_CHAT = [
+	"You are a side-chat conversational assistant for the Gremlins🧌 host session.",
+	"You have NO tools, no workspace access, and cannot read or modify files.",
+	"You receive a snapshot of the parent transcript only as conversational context.",
+	"Do not pretend to run commands, edit files, or call tools — you cannot.",
+	"Be terse by default. Answer directly. Ask one focused question if input is ambiguous.",
+].join("\n");
+
+export const SIDE_CHAT_SYSTEM_PROMPT_TANGENT = [
+	"You are a side-chat tangent assistant for the Gremlins🧌 host session.",
+	"You have NO tools, no workspace access, and cannot read or modify files.",
+	"You start with a clean slate: no parent transcript, no project context.",
+	"Do not pretend to run commands, edit files, or call tools — you cannot.",
+	"Be terse by default. Answer directly. Ask one focused question if input is ambiguous.",
+].join("\n");
+
+function formatTranscriptEntries(entries: ParentTranscriptEntry[]): string {
+	return entries
+		.map((entry) => `[${entry.role}] ${entry.text}`)
+		.join("\n");
+}
+
+function buildChatPrompt(
+	userPrompt: string,
+	parentSnapshot: ParentTranscriptSnapshot | undefined,
+): string {
+	const trimmedUserPrompt = userPrompt.trim();
+	const questionBlock = `<side-chat-question>\n${trimmedUserPrompt}\n</side-chat-question>`;
+	if (!parentSnapshot || parentSnapshot.entries.length === 0) {
+		return questionBlock;
+	}
+	const transcriptBody = formatTranscriptEntries(parentSnapshot.entries);
+	const transcriptBlock = [
+		`<parent-transcript-snapshot capturedAt="${parentSnapshot.capturedAt}">`,
+		transcriptBody,
+		"</parent-transcript-snapshot>",
+	].join("\n");
+	return `${transcriptBlock}\n\n${questionBlock}`;
+}
+
+function buildTangentPrompt(userPrompt: string): string {
+	const trimmedUserPrompt = userPrompt.trim();
+	return `<side-chat-question>\n${trimmedUserPrompt}\n</side-chat-question>`;
+}
+
+export function buildSideChatSessionConfig(
+	options: BuildSideChatSessionConfigOptions,
+): SideChatSessionConfig {
+	const systemPrompt =
+		options.mode === "chat"
+			? SIDE_CHAT_SYSTEM_PROMPT_CHAT
+			: SIDE_CHAT_SYSTEM_PROMPT_TANGENT;
+
+	// D8: no per-side-chat model/thinking overrides; reuse parent fallback only.
+	const resolvedModel = resolveGremlinModel(
+		undefined,
+		options.parentModel,
+		options.modelRegistry,
+	);
+	const thinking = resolveGremlinThinking(undefined, options.parentThinking);
+
+	const prompt =
+		options.mode === "chat"
+			? buildChatPrompt(options.userPrompt, options.parentSnapshot)
+			: buildTangentPrompt(options.userPrompt);
+
+	return {
+		systemPrompt,
+		prompt,
+		model: resolvedModel.label,
+		resolvedModel: resolvedModel.model,
+		modelResolutionError: resolvedModel.error,
+		thinking,
+		tools: [],
+		cwd: options.cwd,
+		usesSubprocess: false,
+		writesTempPromptFile: false,
+		resources: createEmptyGremlinResources(),
+		resourceLoader: createIsolatedGremlinResourceLoader(systemPrompt),
+	};
+}
+
+export async function createSideChatSession(
+	options: CreateSideChatSessionOptions,
+): Promise<CreateAgentSessionResult> {
+	const plan = options.sessionConfig ?? buildSideChatSessionConfig(options);
+	// Compose through createGremlinSession by passing a synthetic gremlin
+	// definition that yields the same plan. We bypass that path by passing
+	// the prebuilt sessionConfig directly — createGremlinSession honors
+	// `options.sessionConfig` and uses its `tools`, `resourceLoader`,
+	// `resolvedModel`, and `thinking` verbatim.
+	return createGremlinSession({
+		sessionConfig: plan,
+		// `gremlin`, `intent`, `context` are unused when sessionConfig is provided,
+		// but the type requires them for the build path. Provide inert shapes.
+		gremlin: {
+			name: "side-chat",
+			source: "user",
+			rawMarkdown: plan.systemPrompt,
+			frontmatter: {},
+		},
+		intent: "",
+		context: "",
+		cwd: options.cwd,
+		parentModel: options.parentModel,
+		parentThinking: options.parentThinking,
+		modelRegistry: options.modelRegistry,
+	});
+}

--- a/extensions/pi-gremlins/v1-contract-harness.js
+++ b/extensions/pi-gremlins/v1-contract-harness.js
@@ -105,6 +105,7 @@ export function createExtensionHarness() {
 	const handlers = new Map();
 	const entries = [];
 	const messages = [];
+	const messageRenderers = new Map();
 	registerPiGremlins({
 		on: (event, handler) => {
 			handlers.set(event, handler);
@@ -118,6 +119,9 @@ export function createExtensionHarness() {
 		registerTool: (tool) => {
 			registeredTool = tool;
 		},
+		registerMessageRenderer: (customType, renderer) => {
+			messageRenderers.set(customType, renderer);
+		},
 		appendEntry: (customType, data) => {
 			entries.push({ customType, data });
 		},
@@ -125,7 +129,7 @@ export function createExtensionHarness() {
 			messages.push(message);
 		},
 	});
-	return { tool: registeredTool, commands, shortcuts, handlers, entries, messages };
+	return { tool: registeredTool, commands, shortcuts, handlers, entries, messages, messageRenderers };
 }
 
 export function createRegisteredTool() {


### PR DESCRIPTION
## Summary

- Adds `/gremlins:chat` (parent-transcript snapshot attached as input-only) and `/gremlins:tangent` (clean child session) to absorb the `pi-gizmo` side-chat surface into `pi-gremlins`.
- Built on the existing in-process SDK runtime (ADR-0002) and `gremlin-session-factory` primitives — no nested Pi CLI subprocess, zero tools exposed, inline rendering with a clear delimiter, fresh per invocation.
- Documents the absorption and `pi-gizmo` retirement: README migration table from each retired `gizmo:*` command, CHANGELOG entry, PRD-0004 / ADR-0004 added and indexed.

## Decisions (PRD-0004 Q1–Q5)

- **Q1 — State carryover:** Each invocation creates a new side-thread; no state leaks between consecutive `/gremlins:chat` or `/gremlins:tangent` calls. No custom session entry type introduced in v1.
- **Q2 — Surface:** Side-chat output is rendered inline in the parent transcript with a clear delimiter; no overlay/popup surface in v1.
- **Q3 — Inject/handoff:** No `inject`/handoff command in v1; copy/paste is the documented workflow until a future PRD addresses handoff.
- **Q4 — Tools:** Side-thread runtime exposes **zero** tools to the SDK call (no workspace, file, or shell tools). Parent transcript is attached as input only, never as a tool surface.
- **Q5 — Runtime:** Implemented on the existing `gremlin-session-factory` and the in-process SDK runtime per ADR-0002 — no subprocess, temp prompt file, chain mode, or popup viewer is introduced.

## Tests

- 84/84 green via Bun (`extensions/pi-gremlins/side-chat-session-factory.test.js`, `side-chat-command.test.js`, plus existing suites).
- Coverage includes: `/gremlins:chat` parent-context attachment, `/gremlins:tangent` clean-session behavior, fresh-per-invocation isolation between consecutive calls, and absence of tool access from the side-thread runtime.

## Docs

- New: `docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md`
- New: `docs/adr/0004-side-chat-absorption-from-pi-gizmo.md`
- Plan: `docs/plans/issue-47-side-chat-absorption.md`
- Updated: `README.md` (commands + migration table), `CHANGELOG.md`, `docs/prd/README.md`, `docs/adr/README.md` index tables.

## Post-merge items (cross-package coordination, NOT in this PR)

Tracked in the plan; executed in the **`pi-gizmo` repo** after this merges:

1. `pi-gizmo` README — replace "What this does" with a deprecation banner pointing at `pi-gremlins`, `/gremlins:chat`, and `/gremlins:tangent`; link the migration section and reference PRD-0004 / ADR-0004 by absolute URL.
2. `pi-gizmo` CHANGELOG — `## [Unreleased]` deprecation entry pointing at `/gremlins:chat` and `/gremlins:tangent` with PRD-0004 / ADR-0004 references.
3. `pi-gizmo` final release — bump version, ship the deprecation README/CHANGELOG, tag the release.
4. npm deprecation marker (out-of-band) — `npm deprecate <pi-gizmo-package-name>@"*" "Deprecated; use pi-gremlins. See https://github.com/magimetal/pi-gremlins"` once the final release is published.
5. Verification — `npm view <pi-gizmo-package-name>` shows the deprecation message and the `pi-gizmo` README's first paragraph references `pi-gremlins`; track completion in the issue #47 thread before closing.

Closes #47
