### PR TITLE
feat: add persistent overlay side-chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Persistent overlay side-chat** (PRD-0005, ADR-0005, issue #49): `/gremlins:chat` and `/gremlins:tangent` now open persistent multi-turn overlays instead of inline one-shot responses; `:new` variants reset only the selected mode while preserving zero-tool isolation.
 - **`/mohawk` renamed to `/gremlins:primary`** (issue #45): the `/mohawk` slash command is replaced by `/gremlins:primary`, consolidating primary-agent selection under the `pi-gremlins` tool namespace; all underlying behavior, shortcut cycling, and session state are preserved.
 - README documentation now reflects the current `pi-gremlins` contract, discovery precedence, runtime behavior, primary-agent controls, and test command details.
 - Generated `AGENTS.md` guidance for the root, docs, and extension scopes now reflects the current primary-agent, runtime, and governance boundaries.

--- a/README.md
+++ b/README.md
@@ -151,66 +151,59 @@ Runtime behavior:
 - collapsed tool row shows source, status, intent/task preview, latest activity, usage, and errors
 - expanded tool row shows intent, task, cwd, model, thinking, latest text/tool data, usage, and errors
 
-## Side-chat: `/gremlins:chat` and `/gremlins:tangent`
+## Side-chat overlay: `/gremlins:chat` and `/gremlins:tangent`
 
-Side-chat support is absorbed from the standalone `pi-gizmo` package (PRD-0004,
-ADR-0004, issue #47). It exposes two slash commands inside `pi-gremlins`,
-built on the same in-process Pi SDK runtime as gremlin delegation, with zero
-tools and inline rendering.
+Side-chat support now uses persistent Pi overlays (PRD-0005, ADR-0005,
+issue #49). The older PRD-0004/ADR-0004 inline one-shot behavior has been
+superseded for side-chat UX, while its isolation rules remain: zero tools,
+no tangent parent transcript, and no per-side-chat model/thinking override.
 
 ### Commands
 
-- `/gremlins:chat <prompt>` — opens a fresh side-thread seeded with a
-  snapshot of the parent transcript captured at invocation time. Output is
-  rendered inline.
-- `/gremlins:tangent <prompt>` — opens a clean child session with no parent
-  transcript and no project context. Output is rendered inline.
-- Empty or whitespace-only argument prints a usage hint and does not start
-  a session.
+| Command | Behavior |
+| --- | --- |
+| `/gremlins:chat` | Open the side-chat overlay; resume the existing chat thread if one exists, otherwise start a new one. |
+| `/gremlins:chat:new` | Open the overlay with a fresh chat thread and discard prior chat history for chat only. |
+| `/gremlins:tangent` | Open the side-chat overlay; resume the existing tangent thread if one exists, otherwise start a new one. |
+| `/gremlins:tangent:new` | Open the overlay with a fresh tangent thread and discard prior tangent history only. |
 
-### v1 guarantees
+Optional inline prompt compatibility is retained: `/gremlins:chat <prompt>` and
+`/gremlins:tangent <prompt>` open the overlay and submit the prompt into the
+current thread.
 
-- Fresh side-thread per invocation; no thread persistence across invocations.
-- Inline rendering only — no overlay or popup viewer (ADR-0004 D1).
-- Zero tools — pure conversation surface; cannot read or modify the workspace
-  (ADR-0004 D4).
-- Built on `gremlin-session-factory` primitives; same isolation as gremlin
-  delegation (ADR-0003, ADR-0004 D3, D5): no parent extensions, skills,
-  prompts, themes, AGENTS files, or primary-agent markdown leak into the
-  side-thread.
-- Copy/paste is the supported handoff mechanism in v1; there is no
-  `inject` command.
+### Overlay behavior
 
-### Visual delimiter
+- Overlay is top-center, non-capturing, approximately 78% terminal width and
+  max height, with margin from terminal edges.
+- Header shows the active mode (`💬 chat` or `🧭 tangent`) and status.
+- Draft input is edited in the overlay; `Enter` submits and `Escape` closes
+  the overlay without losing completed thread history.
+- Transcript rows stream assistant text and support basic scroll keys
+  (`Up`, `Down`, `PageUp`, `PageDown`, `Home`, `End`).
 
-Side-chat turns are rendered with a fixed header and footer so they are
-unambiguous next to gremlin tool rows and parent assistant turns:
+### Persistence and isolation guarantees
 
-- Chat header: `💬 side-chat (chat)`
-- Tangent header: `🧭 side-chat (tangent)`
-- Common footer: `└─ side-chat ended ─`
+- Chat and tangent are independent threads.
+- Completed exchanges persist as Pi custom entries and restore on reload and
+  `/tree` navigation for the active branch.
+- `:new` writes a reset marker and discards only that mode's prior restored
+  thread.
+- Side-chat custom entries are filtered from parent LLM context as
+  defense-in-depth.
+- Chat captures the parent transcript snapshot once at thread origin; resumed
+  chat does not recapture later parent turns.
+- Tangent never captures parent transcript or project context.
+- Side-chat child sessions run with `tools: []`; they cannot read or modify
+  the workspace.
+- Side-chat child sessions do not load parent extensions, skills, prompts,
+  themes, AGENTS files, or primary-agent markdown.
 
-### Migration from `pi-gizmo`
+See [PRD-0005](docs/prd/0005-persistent-overlay-side-chat.md) and
+[ADR-0005](docs/adr/0005-persistent-overlay-side-chat.md).
 
-| Retired pi-gizmo command | pi-gremlins replacement | Notes |
-| --- | --- | --- |
-| `gizmo` (chat send) | `/gremlins:chat <prompt>` | Parent-context attached, fresh per invocation. |
-| `gizmo:tangent` | `/gremlins:tangent <prompt>` | Clean child session. |
-| `gizmo:new` | (none — structurally unnecessary) | Fresh-per-invocation makes explicit "new" redundant. |
-| `gizmo:recap` | (deferred) | No v1 replacement; revisit via future PRD. |
-| `gizmo:clear` | (none — structurally unnecessary) | Fresh-per-invocation makes "clear" redundant. |
-| `gizmo:inject` | (deferred) | Use copy/paste in v1; revisit via future PRD. |
-| `gizmo:summarize` | (deferred) | No v1 replacement. |
-| `gizmo:model` | (deferred) | No per-side-chat model override in v1. |
-| `gizmo:thinking` | (deferred) | No per-side-chat thinking override in v1. |
-
-See [PRD-0004](docs/prd/0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md)
-and [ADR-0004](docs/adr/0004-side-chat-absorption-from-pi-gizmo.md).
-
-Note: do not run `pi-gizmo` and `pi-gremlins` side-chat commands
-concurrently if both are installed in the same Pi profile; migrate to
-`pi-gremlins` and disable / uninstall `pi-gizmo` to avoid duplicate command
-registration.
+Note: do not run `pi-gizmo` and `pi-gremlins` side-chat commands concurrently
+if both are installed in the same Pi profile; migrate to `pi-gremlins` and
+disable / uninstall `pi-gizmo` to avoid duplicate command registration.
 
 ## Primary agents
 

--- a/docs/adr/0005-persistent-overlay-side-chat.md
+++ b/docs/adr/0005-persistent-overlay-side-chat.md
@@ -1,0 +1,88 @@
+# ADR-0005: Persistent Overlay Side-Chat
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Decision Maker:** magimetal
+- **Related:** PRD-0005, PRD-0004, ADR-0004, ADR-0003, GitHub issue #49
+- **Supersedes:** ADR-0004 decisions D1 (inline-only/no overlay) and D2 (no `pi.appendEntry` side-chat persistence).
+
+## Context
+
+ADR-0004 deliberately absorbed side-chat from pi-gizmo in the smallest safe shape: fresh zero-tool child sessions, inline result messages, and no persistence. That was appropriate for issue #47 because it eliminated the legacy nested Pi CLI runtime and avoided restoring pi-gizmo's broad command surface.
+
+Issue #49 provides direct user feedback that the product need is a persistent multi-turn side conversation. Pi now exposes a canonical custom overlay API (`ctx.ui.custom` with `overlay: true`) and custom entries (`pi.appendEntry`) are the standard extension persistence primitive. We can therefore restore the desired UX without reviving the rejected pi-gizmo runtime.
+
+## Decision
+
+Implement side-chat as two persistent overlay-backed threads: one `chat` thread and one `tangent` thread.
+
+- `/gremlins:chat` opens the overlay and resumes chat if present, otherwise starts chat.
+- `/gremlins:chat:new` writes a chat reset marker and opens a fresh chat thread.
+- `/gremlins:tangent` opens the overlay and resumes tangent if present, otherwise starts tangent.
+- `/gremlins:tangent:new` writes a tangent reset marker and opens a fresh tangent thread.
+- Completed exchanges are persisted as `pi-gremlins:side-chat-thread` custom entries.
+- Resets are persisted as `pi-gremlins:side-chat-reset` custom entries.
+- Restore scans the active branch and keeps only thread entries after the latest per-mode reset.
+- A context hook filters side-chat custom data defensively from parent LLM context.
+- Chat captures parent transcript once at thread origin; resumes do not re-capture later parent turns.
+- Tangent never captures parent transcript.
+- Side-chat child sessions keep `tools: []` and inherit parent model/thinking fallback without exposing per-thread overrides.
+
+## Preserved Decisions
+
+ADR-0004 decisions still in force:
+
+- **D3:** tangent never captures parent transcript context.
+- **D4:** side-chat sessions have zero tools.
+- **D8:** no per-side-chat model/thinking overrides.
+
+ADR-0003 isolation remains binding: side-chat child sessions must not inherit parent extensions, skills, prompts, themes, AGENTS files, primary-agent markdown, or unapproved parent prompt material.
+
+## Superseded Decisions
+
+- **ADR-0004 D1:** Inline-only/no overlay is superseded. Side-chat now uses Pi's canonical custom overlay API.
+- **ADR-0004 D2:** No side-chat `pi.appendEntry` persistence is superseded. Side-chat uses custom entries for completed exchanges and reset markers.
+
+## Consequences
+
+### Positive
+
+- Side-chat supports the requested multi-turn workflow.
+- Threads survive reloads and tree navigation on the active branch.
+- The overlay separates side conversation from parent transcript rendering.
+- Persistence uses Pi-native custom entries instead of a separate store.
+- Reset markers make thread discard explicit and auditable.
+
+### Negative / Tradeoffs
+
+- Runtime state is more complex than PRD-0004's one-shot command path.
+- In-flight streaming turns are not restored after shutdown; only completed exchanges persist.
+- Optional inline argument compatibility is retained, so command parsing is not purely argument-less.
+
+## Alternatives Considered
+
+### Keep inline one-shot side-chat
+
+Rejected. It does not satisfy issue #49's multi-turn persistence requirement.
+
+### Reintroduce pi-gizmo wholesale
+
+Rejected. It would revive the nested runtime and broad command surface ADR-0002/ADR-0004 intentionally retired.
+
+### Persist complete child session state
+
+Rejected for now. Persisting completed exchanges is enough to reconstruct user-visible thread history and avoid coupling to SDK-private session internals.
+
+### Store thread state outside Pi session entries
+
+Rejected. Custom entries follow Pi extension conventions and preserve per-branch behavior naturally.
+
+## Validation
+
+- `npm run typecheck`
+- `npm test`
+- `npm run check`
+
+## Status History
+
+- 2026-04-30 — Accepted with issue #49 implementation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,3 +69,4 @@ Reference ADR IDs in changelog entries for significant changes:
 | 0002 | In-Process SDK-Based Gremlin Runtime                             | Accepted | 2026-04-22 |
 | 0003 | Unified Agent Discovery and Primary-Agent Prompt Injection in pi-gremlins | Accepted | 2026-04-25 |
 | 0004 | Side-Chat Absorption from pi-gizmo into pi-gremlins              | Accepted | 2026-04-29 |
+| 0005 | Persistent Overlay Side-Chat                                    | Accepted | 2026-04-30 |

--- a/docs/prd/0005-persistent-overlay-side-chat.md
+++ b/docs/prd/0005-persistent-overlay-side-chat.md
@@ -1,0 +1,84 @@
+# PRD-0005: Persistent Overlay Side-Chat
+
+- **Status:** Completed
+- **Date:** 2026-04-30
+- **Author:** Magi Metal
+- **Related:** GitHub issue [#49](https://github.com/magimetal/pi-gremlins/issues/49), [PRD-0004](0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md), [ADR-0005](../adr/0005-persistent-overlay-side-chat.md), [ADR-0004](../adr/0004-side-chat-absorption-from-pi-gizmo.md), [ADR-0003](../adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md)
+- **Supersedes:** PRD-0004 side-chat UX decisions for fresh-per-invocation inline side-chat.
+
+## Problem Statement
+
+PRD-0004 intentionally shipped a conservative side-chat v1: `/gremlins:chat <prompt>` and `/gremlins:tangent <prompt>` ran fresh zero-tool child sessions and rendered one answer inline. That removed pi-gizmo's legacy runtime but also removed the actual working shape users wanted: a persistent side conversation that can stay open while the parent session continues.
+
+Issue #49 requests the inverse UX: persistent multi-turn side-chat threads, surfaced in a canonical Pi overlay, surviving reload and `/tree` navigation, while preserving the isolation guarantees from ADR-0003 and the side-chat constraints that remain valid from ADR-0004.
+
+## Goals
+
+- Replace inline-only one-shot side-chat with a persistent overlay TUI.
+- Expose four commands:
+  - `/gremlins:chat`
+  - `/gremlins:chat:new`
+  - `/gremlins:tangent`
+  - `/gremlins:tangent:new`
+- Keep chat and tangent as independent threads.
+- Persist completed exchanges through Pi custom session entries.
+- Keep side-chat entries out of parent LLM context.
+- Preserve zero-tool side-chat sessions and tangent's clean-context guarantee.
+
+## User Stories
+
+- As an operator, I can run `/gremlins:chat` to reopen my current contextual side-chat thread without losing prior turns.
+- As an operator, I can run `/gremlins:chat:new` to discard the current chat thread and start over.
+- As an operator exploring unrelated ideas, I can run `/gremlins:tangent` to reopen a clean side thread that never captured parent transcript context.
+- As an operator, I can keep a side-chat overlay open, type multiple messages, close/reopen it, reload Pi, or navigate `/tree` without losing completed exchanges.
+- As a maintainer, I can reason about side-chat persistence from explicit `pi.appendEntry` custom entries and tests.
+
+## Scope
+
+### In Scope
+
+- Overlay TUI component for side-chat transcript, status, draft input, keyboard submit/close, and scroll handling.
+- Persistent exchange entries with one reset marker per `:new` command.
+- Restore logic from the active branch after `session_start` and `session_tree`.
+- Context filter for side-chat custom data as defense-in-depth.
+- Four-command side-chat surface.
+- Optional inline argument compatibility: `/gremlins:chat <prompt>` and `/gremlins:tangent <prompt>` open the overlay and auto-submit the prompt.
+- Tests for command dispatch, persistence restore, transcript reducer, and overlay input.
+- README and changelog updates.
+
+### Out of Scope
+
+- Tool access inside side-chat sessions.
+- Per-side-chat model or thinking overrides.
+- Inject/summarize/handoff from side-chat into parent.
+- Multiple simultaneous chat or tangent threads of the same mode.
+- Restoring in-flight, uncompleted streaming turns after process shutdown.
+
+## Acceptance Criteria
+
+- [x] `/gremlins:chat` opens overlay and resumes chat thread or creates a new thread.
+- [x] `/gremlins:chat:new` appends a chat reset marker, clears only chat state, and opens overlay.
+- [x] `/gremlins:tangent` opens overlay and resumes tangent thread or creates a new thread.
+- [x] `/gremlins:tangent:new` appends a tangent reset marker, clears only tangent state, and opens overlay.
+- [x] Overlay uses Pi `ctx.ui.custom(..., { overlay: true })` with top-center, 78% width/max-height, margin, and non-capturing options.
+- [x] Overlay renders mode label, transcript rows, status, draft input, submit/close controls, and scroll keys.
+- [x] Completed exchanges persist through `pi.appendEntry("pi-gremlins:side-chat-thread", ...)`.
+- [x] `:new` writes `pi-gremlins:side-chat-reset` and restore ignores older entries for that mode only.
+- [x] Restore runs on session start and tree navigation from the current branch.
+- [x] Context hook filters side-chat custom messages defensively.
+- [x] Side-chat session config keeps `tools: []`.
+- [x] Tangent never captures parent transcript.
+- [x] Chat captures parent transcript once at thread origin.
+- [x] Automated tests cover command surface, persistence restore, reducer folding, and overlay key handling.
+
+## Technical Surface
+
+- **Runtime:** `extensions/pi-gremlins/side-chat-command.ts`
+- **Overlay:** `extensions/pi-gremlins/side-chat-overlay.ts`
+- **Persistence:** `extensions/pi-gremlins/side-chat-persistence.ts`
+- **Transcript reducer:** `extensions/pi-gremlins/side-chat-transcript-state.ts`
+- **Related ADR:** ADR-0005
+
+## Revision History
+
+- 2026-04-30 — Created and completed with issue #49 implementation.

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -87,3 +87,4 @@ Maintain in `docs/prd/README.md`:
 | 0002 | Pi Gremlins V1 SDK Rewrite                                | Draft | 2026-04-22 |
 | 0003 | Primary Agent Selection and pi-mohawk Deprecation         | Completed | 2026-04-25 |
 | 0004 | Pi Gremlins Side-Chat Absorption and pi-gizmo Deprecation | Completed | 2026-04-29 |
+| 0005 | Persistent Overlay Side-Chat                            | Completed | 2026-04-30 |

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -39,13 +39,15 @@ describe("pi-gremlins index execute v1", () => {
 		const { tool, commands, shortcuts } = createExtensionHarness();
 
 		expect(tool.name).toBe("pi-gremlins");
-		expect(commands.size).toBe(3);
+		expect(commands.size).toBe(5);
 		expect(commands.has("gremlins:primary")).toBe(true);
 		expect(commands.has("gremlins:chat")).toBe(true);
+		expect(commands.has("gremlins:chat:new")).toBe(true);
 		expect(commands.has("gremlins:tangent")).toBe(true);
+		expect(commands.has("gremlins:tangent:new")).toBe(true);
 		expect(commands.has("gremlins:view")).toBe(false);
 		expect(commands.has("gremlins:steer")).toBe(false);
-		expect(Array.from(shortcuts.keys())).toEqual(["ctrl+shift+m"]);
+		expect(Array.from(shortcuts.keys()).sort()).toEqual(["alt+/", "ctrl+shift+m"]);
 	});
 
 	test("rejects legacy parameter shapes at execute boundary", async () => {

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -37,11 +37,7 @@ import {
 	updatePrimaryAgentStatus,
 } from "./primary-agent-controls.js";
 import { applyPrimaryAgentPromptInjection } from "./primary-agent-prompt.js";
-import {
-	registerSideChatCommands,
-	sideChatMessageRenderer,
-	SIDE_CHAT_MESSAGE_TYPE,
-} from "./side-chat-command.js";
+import { registerSideChatCommands } from "./side-chat-command.js";
 import {
 	clearPersistedPrimaryAgentSelection,
 	readPersistedPrimaryAgentSelectionWithDiagnostics,
@@ -106,6 +102,8 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 			});
 		let primaryAgentState: PrimaryAgentState = createInitialPrimaryAgentState();
 
+		registerSideChatCommands(pi);
+
 		pi.on("session_start", async (_event, ctx) => {
 			discovery.clear();
 			primaryAgentDiscovery.clear();
@@ -165,14 +163,6 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 				);
 			},
 		});
-
-		registerSideChatCommands(pi);
-		// Defensive: some legacy in-repo test harnesses provide a fake pi without
-		// `registerMessageRenderer`. The real pi runtime always supplies it
-		// (see types.d.ts:815). Guard so registration is a no-op in those mocks.
-		if (typeof pi.registerMessageRenderer === "function") {
-			pi.registerMessageRenderer(SIDE_CHAT_MESSAGE_TYPE, sideChatMessageRenderer);
-		}
 
 		pi.on("before_agent_start", async (event, ctx) => {
 			const injection = await applyPrimaryAgentPromptInjection({

--- a/extensions/pi-gremlins/side-chat-command.test.js
+++ b/extensions/pi-gremlins/side-chat-command.test.js
@@ -3,31 +3,29 @@ import "./v1-contract-harness.js";
 
 function createFakePi() {
 	const commands = new Map();
-	const messages = [];
-	const renderers = new Map();
+	const entries = [];
+	const handlers = new Map();
 	return {
 		commands,
-		messages,
-		renderers,
+		entries,
+		handlers,
 		registerCommand(name, options) {
 			commands.set(name, options);
 		},
-		registerMessageRenderer(customType, renderer) {
-			renderers.set(customType, renderer);
+		on(name, handler) {
+			handlers.set(name, handler);
 		},
-		sendMessage(message) {
-			messages.push(message);
+		appendEntry(customType, data) {
+			entries.push({ customType, data });
 		},
+		registerShortcut() {},
 	};
 }
 
-function createFakeCtx({
-	branchEntries = [],
-	hasUI = true,
-	signal,
-	model,
-} = {}) {
+function createFakeCtx({ branchEntries = [], hasUI = true, model } = {}) {
 	const notifications = [];
+	const customCalls = [];
+	let customComponent;
 	return {
 		cwd: "/tmp",
 		hasUI,
@@ -35,8 +33,30 @@ function createFakeCtx({
 			notify(message, type = "info") {
 				notifications.push({ message, type });
 			},
+			custom(factory, _options) {
+				customCalls.push(_options);
+				customComponent = factory(
+					{ requestRender() {} },
+					{},
+					{},
+					() => {},
+				);
+				_options?.onHandle?.({
+					hide() {},
+					setHidden() {},
+					isHidden: () => false,
+					focus() {},
+					unfocus() {},
+					isFocused: () => true,
+				});
+				return Promise.resolve();
+			},
 		},
 		notifications,
+		customCalls,
+		get customComponent() {
+			return customComponent;
+		},
 		sessionManager: {
 			getBranch() {
 				return branchEntries;
@@ -44,304 +64,110 @@ function createFakeCtx({
 		},
 		modelRegistry: undefined,
 		model,
-		signal,
+		signal: undefined,
 	};
 }
 
-function createFakeSessionFactory({ events = [], onPrompt } = {}) {
+function createFakeSessionFactory({ events = [] } = {}) {
 	const calls = [];
-	const created = {
-		session: {
-			subscribe(listener) {
-				const handle = setTimeout(() => {
-					for (const event of events) listener(event);
-				}, 0);
-				return () => clearTimeout(handle);
+	const sessions = [];
+	const impl = async (options) => {
+		calls.push(options);
+		let listener;
+		const session = {
+			subscribe(l) {
+				listener = l;
+				return () => {};
 			},
-			async prompt(text) {
-				if (onPrompt) await onPrompt(text);
-				// emit events synchronously for deterministic ordering
-				// (subscribe also schedules them, but the listener fires both)
+			async prompt() {
+				for (const event of events) listener?.(event);
 			},
 			async abort() {},
 			dispose() {},
-		},
-		extensionsResult: {},
+		};
+		sessions.push(session);
+		return { session, extensionsResult: {} };
 	};
-	return {
-		calls,
-		impl: async (options) => {
-			calls.push(options);
-			return created;
-		},
-	};
+	return { calls, sessions, impl };
 }
 
 async function loadCommandModule() {
 	return await import("./side-chat-command.ts");
 }
 
-describe("side-chat command v1 contract", () => {
+describe("side-chat overlay command contract", () => {
 	let pi;
 	beforeEach(() => {
 		pi = createFakePi();
 	});
 
-	test("T1 empty arg prints chat usage via ctx.ui.notify and does not start session", async () => {
+	test("registers four command surface", async () => {
 		const { registerSideChatCommands } = await loadCommandModule();
-		const factory = createFakeSessionFactory();
-		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
-		const handler = pi.commands.get("gremlins:chat").handler;
-		const ctx = createFakeCtx();
-		await handler("", ctx);
-		expect(ctx.notifications.length).toBe(1);
-		expect(ctx.notifications[0].message).toMatch(/Usage: \/gremlins:chat/);
-		expect(factory.calls.length).toBe(0);
-	});
-
-	test("T2 empty arg prints tangent usage and does not start session", async () => {
-		const { registerSideChatCommands } = await loadCommandModule();
-		const factory = createFakeSessionFactory();
-		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
-		const handler = pi.commands.get("gremlins:tangent").handler;
-		const ctx = createFakeCtx();
-		await handler("", ctx);
-		expect(ctx.notifications.length).toBe(1);
-		expect(ctx.notifications[0].message).toMatch(/Usage: \/gremlins:tangent/);
-		expect(factory.calls.length).toBe(0);
-	});
-
-	test("T3 whitespace-only arg is treated as empty", async () => {
-		const { registerSideChatCommands } = await loadCommandModule();
-		const factory = createFakeSessionFactory();
-		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
-		const handler = pi.commands.get("gremlins:chat").handler;
-		const ctx = createFakeCtx();
-		await handler("   \t  ", ctx);
-		expect(ctx.notifications.length).toBe(1);
-		expect(factory.calls.length).toBe(0);
-	});
-
-	test("T4 chat handler captures parent transcript snapshot and forwards it", async () => {
-		const { registerSideChatCommands } = await loadCommandModule();
-		const factory = createFakeSessionFactory();
-		registerSideChatCommands(pi, {
-			createSideChatSession: factory.impl,
-			capturedAtFactory: () => "CAPTURED_AT_T4",
-		});
-		const handler = pi.commands.get("gremlins:chat").handler;
-		const ctx = createFakeCtx({
-			branchEntries: [
-				{
-					type: "message",
-					message: { role: "user", content: [{ type: "text", text: "U1" }] },
-				},
-				{
-					type: "message",
-					message: {
-						role: "assistant",
-						content: [{ type: "text", text: "A1" }],
-					},
-				},
-				// non-message entries must be ignored
-				{ type: "modelChange", model: "openai/gpt-5" },
-			],
-		});
-		await handler("summarize", ctx);
-		expect(factory.calls.length).toBe(1);
-		const call = factory.calls[0];
-		expect(call.mode).toBe("chat");
-		expect(call.userPrompt).toBe("summarize");
-		expect(call.parentSnapshot).toBeDefined();
-		expect(call.parentSnapshot.capturedAt).toBe("CAPTURED_AT_T4");
-		expect(call.parentSnapshot.entries).toEqual([
-			{ role: "user", text: "U1" },
-			{ role: "assistant", text: "A1" },
+		registerSideChatCommands(pi, { createSideChatSession: createFakeSessionFactory().impl });
+		expect([...pi.commands.keys()].sort()).toEqual([
+			"gremlins:chat",
+			"gremlins:chat:new",
+			"gremlins:tangent",
+			"gremlins:tangent:new",
 		]);
 	});
 
-	test("T5 tangent handler does NOT capture parent transcript", async () => {
+	test("argument-less chat opens overlay and captures parent snapshot at thread origin", async () => {
 		const { registerSideChatCommands } = await loadCommandModule();
 		const factory = createFakeSessionFactory();
-		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
-		const handler = pi.commands.get("gremlins:tangent").handler;
-		const ctx = createFakeCtx({
-			branchEntries: [
-				{
-					type: "message",
-					message: {
-						role: "user",
-						content: [{ type: "text", text: "PARENT_USER" }],
-					},
-				},
-			],
-		});
-		await handler("explore", ctx);
-		expect(factory.calls.length).toBe(1);
-		expect(factory.calls[0].mode).toBe("tangent");
-		expect(factory.calls[0].parentSnapshot).toBeUndefined();
-	});
-
-	test("T6 consecutive chat invocations are independent (fresh transcript each time)", async () => {
-		const { registerSideChatCommands } = await loadCommandModule();
-		const factory = createFakeSessionFactory();
-		let branch = [
-			{
-				type: "message",
-				message: { role: "user", content: [{ type: "text", text: "FIRST" }] },
-			},
-		];
 		registerSideChatCommands(pi, {
 			createSideChatSession: factory.impl,
-			capturedAtFactory: () => `t-${factory.calls.length}`,
+			capturedAtFactory: () => "CAPTURED_AT",
 		});
-		const handler = pi.commands.get("gremlins:chat").handler;
-		const ctx = {
-			...createFakeCtx(),
-			sessionManager: { getBranch: () => branch },
-		};
-		await handler("first prompt", ctx);
-		// mutate parent transcript between invocations
-		branch = [
-			{
-				type: "message",
-				message: { role: "user", content: [{ type: "text", text: "SECOND" }] },
-			},
-		];
-		await handler("second prompt", ctx);
-		expect(factory.calls.length).toBe(2);
-		expect(factory.calls[0].userPrompt).toBe("first prompt");
-		expect(factory.calls[1].userPrompt).toBe("second prompt");
-		expect(factory.calls[0].parentSnapshot.entries[0].text).toBe("FIRST");
-		expect(factory.calls[1].parentSnapshot.entries[0].text).toBe("SECOND");
-	});
-
-	test("T7 tangent invocation does not see chat-mode transcript sentinel", async () => {
-		const { registerSideChatCommands } = await loadCommandModule();
-		const factory = createFakeSessionFactory();
-		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
-		const chatHandler = pi.commands.get("gremlins:chat").handler;
-		const tangentHandler = pi.commands.get("gremlins:tangent").handler;
 		const ctx = createFakeCtx({
 			branchEntries: [
-				{
-					type: "message",
-					message: {
-						role: "user",
-						content: [{ type: "text", text: "CHAT_SENTINEL_X" }],
-					},
-				},
+				{ type: "message", message: { role: "user", content: [{ type: "text", text: "U1" }] } },
 			],
 		});
-		await chatHandler("c-prompt", ctx);
-		await tangentHandler("t-prompt", ctx);
-		expect(factory.calls.length).toBe(2);
-		expect(factory.calls[1].mode).toBe("tangent");
-		expect(factory.calls[1].parentSnapshot).toBeUndefined();
-		// And user prompts must not bleed across:
-		expect(factory.calls[0].userPrompt).toBe("c-prompt");
-		expect(factory.calls[1].userPrompt).toBe("t-prompt");
+		await pi.commands.get("gremlins:chat").handler("", ctx);
+		expect(ctx.customCalls.length).toBe(1);
+		expect(factory.calls.length).toBe(0);
 	});
 
-	test("T8 abort signal triggers session.abort during prompt", async () => {
+	test("inline argument auto-submits into overlay for backward convenience", async () => {
 		const { registerSideChatCommands } = await loadCommandModule();
-		let aborted = false;
-		let promptResolve;
-		const factory = {
-			calls: [],
-			impl: async (options) => {
-				factory.calls.push(options);
-				return {
-					session: {
-						subscribe: () => () => {},
-						prompt: () =>
-							new Promise((resolve) => {
-								promptResolve = resolve;
-							}),
-						abort: async () => {
-							aborted = true;
-							promptResolve?.();
-						},
-						dispose() {},
-					},
-					extensionsResult: {},
-				};
-			},
-		};
+		const factory = createFakeSessionFactory({
+			events: [
+				{ type: "message_start", message: { role: "assistant" } },
+				{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "answer" } },
+				{ type: "turn_end", turnIndex: 1 },
+			],
+		});
 		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
-		const handler = pi.commands.get("gremlins:tangent").handler;
-		const controller = new AbortController();
-		const ctx = createFakeCtx({ signal: controller.signal });
-		const handlerPromise = handler("explore", ctx);
-		// Schedule abort on next tick
-		await new Promise((r) => setTimeout(r, 5));
-		controller.abort();
-		await handlerPromise;
-		expect(aborted).toBe(true);
-	});
-
-	test("T9 inline rendering: pi.sendMessage called with SIDE_CHAT_MESSAGE_TYPE and assistant text", async () => {
-		const {
-			registerSideChatCommands,
-			SIDE_CHAT_MESSAGE_TYPE,
-		} = await loadCommandModule();
-		const factory = {
-			calls: [],
-			impl: async (options) => {
-				factory.calls.push(options);
-				let listener;
-				return {
-					session: {
-						subscribe(l) {
-							listener = l;
-							return () => {};
-						},
-						prompt: async () => {
-							listener?.({
-								type: "message_end",
-								message: {
-									role: "assistant",
-									content: [
-										{
-											type: "text",
-											text: "side-chat answer payload",
-										},
-									],
-								},
-							});
-						},
-						abort: async () => {},
-						dispose() {},
-					},
-					extensionsResult: {},
-				};
-			},
-		};
-		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
-		const handler = pi.commands.get("gremlins:tangent").handler;
 		const ctx = createFakeCtx();
-		await handler("ping", ctx);
-		expect(pi.messages.length).toBeGreaterThanOrEqual(1);
-		const last = pi.messages[pi.messages.length - 1];
-		expect(last.customType).toBe(SIDE_CHAT_MESSAGE_TYPE);
-		expect(last.display).toBe(true);
-		expect(typeof last.content).toBe("string");
-		expect(last.content).toContain("side-chat answer payload");
-		expect(last.details.mode).toBe("tangent");
+		await pi.commands.get("gremlins:tangent").handler("explore", ctx);
+		expect(factory.calls.length).toBe(1);
+		expect(factory.calls[0].mode).toBe("tangent");
+		expect(factory.calls[0].sessionConfig.tools).toEqual([]);
+		expect(pi.entries.some((entry) => entry.customType === "pi-gremlins:side-chat-thread")).toBe(true);
 	});
 
-	test("T10 visual delimiter labels exported and distinct", async () => {
-		const {
-			SIDE_CHAT_CHAT_LABEL,
-			SIDE_CHAT_TANGENT_LABEL,
-			SIDE_CHAT_FOOTER,
-		} = await loadCommandModule();
-		expect(typeof SIDE_CHAT_CHAT_LABEL).toBe("string");
-		expect(SIDE_CHAT_CHAT_LABEL.length).toBeGreaterThan(0);
-		expect(typeof SIDE_CHAT_TANGENT_LABEL).toBe("string");
-		expect(SIDE_CHAT_TANGENT_LABEL.length).toBeGreaterThan(0);
-		expect(SIDE_CHAT_CHAT_LABEL).not.toBe(SIDE_CHAT_TANGENT_LABEL);
-		expect(typeof SIDE_CHAT_FOOTER).toBe("string");
-		expect(SIDE_CHAT_FOOTER.length).toBeGreaterThan(0);
+	test(":new appends reset and only resets requested mode", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		registerSideChatCommands(pi, { createSideChatSession: createFakeSessionFactory().impl });
+		const ctx = createFakeCtx();
+		await pi.commands.get("gremlins:chat:new").handler("", ctx);
+		expect(pi.entries).toContainEqual({
+			customType: "pi-gremlins:side-chat-reset",
+			data: expect.objectContaining({ mode: "chat" }),
+		});
+	});
+
+	test("context handler filters side-chat custom messages defensively", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		registerSideChatCommands(pi, { createSideChatSession: createFakeSessionFactory().impl });
+		const result = pi.handlers.get("context")({
+			type: "context",
+			messages: [
+				{ role: "user", content: "keep" },
+				{ role: "user", content: "drop", customType: "pi-gremlins:side-chat-thread" },
+			],
+		});
+		expect(result.messages).toEqual([{ role: "user", content: "keep" }]);
 	});
 });

--- a/extensions/pi-gremlins/side-chat-command.ts
+++ b/extensions/pi-gremlins/side-chat-command.ts
@@ -250,8 +250,8 @@ export function registerSideChatCommands(
 			},
 		};
 		runtime.overlayPromise = ctx.ui.custom<void>(
-			(tui, theme, _keybindings, done) =>
-				new SideChatOverlayComponent(tui, theme, controller, done),
+			(tui, _theme, _keybindings, done) =>
+				new SideChatOverlayComponent(tui, controller, done),
 			{
 				overlay: true,
 				overlayOptions: SIDE_CHAT_OVERLAY_OPTIONS,

--- a/extensions/pi-gremlins/side-chat-command.ts
+++ b/extensions/pi-gremlins/side-chat-command.ts
@@ -1,47 +1,11 @@
-/**
- * Side-chat command surface (PRD-0004 / ADR-0004).
- *
- * Registers `/gremlins:chat` and `/gremlins:tangent`. Chat captures a
- * snapshot of the parent transcript at invocation time via
- * `ctx.sessionManager.getBranch()` and feeds it to the side-chat session as
- * conversational input only (never as system prompt, tool, or extension).
- * Tangent gets a clean child session.
- *
- * Confirmed surfaces (Observed):
- * - `pi.registerCommand(name, { description?, handler: (args, ctx) => Promise<void> })`
- *   — extensions/types.d.ts:758, 800.
- * - `pi.registerMessageRenderer<T>(customType, renderer)` — types.d.ts:815.
- * - `pi.sendMessage({ customType, content, display, details })` is
- *   fire-and-forget — types.d.ts:817.
- * - `ctx.ui.notify(text, "info" | "warning" | "error")` — types.d.ts:74.
- * - `ctx.sessionManager.getBranch()` returns `SessionEntry[]`; project
- *   only `SessionMessageEntry` (entry.type === "message") with role
- *   user|assistant — session-manager.d.ts:23–25, 244.
- *
- * Guardrails (ADR-0004):
- * - No overlay/popup viewer (D1).
- * - No `pi.appendEntry` for side-chat messages (D2).
- * - Tangent never captures parent transcript (D3).
- * - Zero tools on session (D4).
- * - No primary-agent injection (PRD-0003 isolation).
- * - No nested CLI / temp prompt files / subprocess (ADR-0002).
- */
-
 import type { TextContent } from "@mariozechner/pi-ai";
-import {
-	getMarkdownTheme,
-	type CreateAgentSessionResult,
-	type ExtensionAPI,
-	type ExtensionCommandContext,
-	type MessageRenderer,
+import type {
+	CreateAgentSessionResult,
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
 } from "@mariozechner/pi-coding-agent";
-import {
-	Container,
-	Markdown,
-	type MarkdownTheme,
-	Spacer,
-	Text,
-} from "@mariozechner/pi-tui";
+import type { OverlayHandle } from "@mariozechner/pi-tui";
 import {
 	buildSideChatSessionConfig,
 	createSideChatSession as defaultCreateSideChatSession,
@@ -49,74 +13,98 @@ import {
 	type ParentTranscriptSnapshot,
 	type SideChatMode,
 } from "./side-chat-session-factory.js";
+import {
+	SIDE_CHAT_OVERLAY_OPTIONS,
+	SideChatOverlayComponent,
+	type SideChatOverlayController,
+} from "./side-chat-overlay.js";
+import {
+	buildThreadHistoryPrompt,
+	createEmptySideChatThreads,
+	filterSideChatMessagesFromContext,
+	restoreSideChatThreadsFromBranch,
+	SIDE_CHAT_RESET_ENTRY_TYPE,
+	SIDE_CHAT_THREAD_ENTRY_TYPE,
+	type RestoredSideChatThreads,
+	type SideChatThreadEntryData,
+} from "./side-chat-persistence.js";
+import {
+	appendSideChatError,
+	appendSideChatUserMessage,
+	createInitialSideChatTranscriptState,
+	reduceSideChatTranscriptEvent,
+	sideChatRowsFromThread,
+	type SideChatTranscriptEvent,
+	type SideChatTranscriptState,
+} from "./side-chat-transcript-state.js";
 
 export const SIDE_CHAT_CHAT_COMMAND = "gremlins:chat";
+export const SIDE_CHAT_CHAT_NEW_COMMAND = "gremlins:chat:new";
 export const SIDE_CHAT_TANGENT_COMMAND = "gremlins:tangent";
-export const SIDE_CHAT_MESSAGE_TYPE = "pi-gremlins:side-chat";
+export const SIDE_CHAT_TANGENT_NEW_COMMAND = "gremlins:tangent:new";
 
 export const SIDE_CHAT_CHAT_LABEL = "💬 side-chat (chat)";
 export const SIDE_CHAT_TANGENT_LABEL = "🧭 side-chat (tangent)";
-export const SIDE_CHAT_FOOTER = "└─ side-chat ended ─";
+export const SIDE_CHAT_FOOTER = "└─ side-chat persists in overlay ─";
 
 const CHAT_DESCRIPTION =
-	"Side-chat with parent-transcript context (zero tools, fresh per invocation).";
+	"Open the persistent Gremlins side-chat overlay; resumes the chat thread.";
+const CHAT_NEW_DESCRIPTION =
+	"Open the Gremlins side-chat overlay with a fresh chat thread.";
 const TANGENT_DESCRIPTION =
-	"Side-chat in a clean child session, no parent context (zero tools, fresh per invocation).";
-
-const CHAT_USAGE = `Usage: /gremlins:chat <prompt>\n${CHAT_DESCRIPTION}`;
-const TANGENT_USAGE = `Usage: /gremlins:tangent <prompt>\n${TANGENT_DESCRIPTION}`;
+	"Open the persistent Gremlins tangent overlay; resumes the tangent thread.";
+const TANGENT_NEW_DESCRIPTION =
+	"Open the Gremlins tangent overlay with a fresh tangent thread.";
 
 export interface SideChatCommandDeps {
 	createSideChatSession?: typeof defaultCreateSideChatSession;
 	capturedAtFactory?: () => string;
 }
 
-export interface SideChatMessageDetails {
-	mode: SideChatMode;
-	capturedAt?: string;
-	label: string;
-	footer: string;
-}
-
-interface SideChatEvent {
-	type?: string;
-	assistantMessageEvent?: { type?: string; delta?: unknown };
-	message?: {
-		role?: unknown;
-		content?: unknown;
-	};
-}
-
 type SideChatSession = CreateAgentSessionResult["session"] & {
-	subscribe?: (listener: (event: SideChatEvent) => void) => () => void;
+	subscribe?: (listener: (event: SideChatTranscriptEvent) => void) => () => void;
 	prompt: (text: string) => Promise<void>;
 	abort?: () => Promise<void>;
 	dispose: () => void;
 };
 
-function extractTextFromContent(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (!Array.isArray(content)) return "";
-	return content
-		.flatMap((item) => {
-			if (!item || typeof item !== "object") return [];
-			if ((item as { type?: string }).type !== "text") return [];
-			const text = (item as TextContent).text;
-			return typeof text === "string" ? [text] : [];
-		})
-		.join("");
+interface SideChatRuntime {
+	threads: RestoredSideChatThreads;
+	activeMode: SideChatMode;
+	activeSession: SideChatSession | null;
+	activeSessionMode: SideChatMode | null;
+	overlayHandle: OverlayHandle | null;
+	overlayPromise: Promise<void> | null;
+	overlayDraft: string;
+	transcriptState: SideChatTranscriptState;
+	subscriptions: Set<() => void>;
+	lastSubmittedQuestion: string | null;
+}
+
+function createRuntime(): SideChatRuntime {
+	return {
+		threads: createEmptySideChatThreads(),
+		activeMode: "chat",
+		activeSession: null,
+		activeSessionMode: null,
+		overlayHandle: null,
+		overlayPromise: null,
+		overlayDraft: "",
+		transcriptState: createInitialSideChatTranscriptState(),
+		subscriptions: new Set(),
+		lastSubmittedQuestion: null,
+	};
 }
 
 export function parseSideChatArgs(
 	args: string,
-): { ok: true; userPrompt: string } | { ok: false } {
+): { ok: true; userPrompt?: string } {
 	const trimmed = (args ?? "").trim();
-	if (!trimmed) return { ok: false };
-	return { ok: true, userPrompt: trimmed };
+	return trimmed ? { ok: true, userPrompt: trimmed } : { ok: true };
 }
 
 export function captureParentTranscriptSnapshot(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionCommandContext | ExtensionContext,
 	capturedAtFactory: () => string = () => new Date().toISOString(),
 ): ParentTranscriptSnapshot | undefined {
 	try {
@@ -141,207 +129,259 @@ export function captureParentTranscriptSnapshot(
 	}
 }
 
-function emitUsage(ctx: ExtensionCommandContext, usageText: string): void {
-	if (ctx.hasUI && ctx.ui?.notify) {
-		ctx.ui.notify(usageText, "info");
-		return;
-	}
-	// Fallback: emit a non-LLM-bound notification via console for non-UI modes.
-	// eslint-disable-next-line no-console
-	console.log(usageText);
-}
-
-async function driveSideChatSession(
-	pi: ExtensionAPI,
-	ctx: ExtensionCommandContext,
-	created: CreateAgentSessionResult,
-	prompt: string,
-	details: SideChatMessageDetails,
-): Promise<void> {
-	const session = created.session as SideChatSession;
-	let aggregatedDeltaText = "";
-	let lastAssistantMessageText = "";
-	const unsubscribe = session.subscribe?.((event) => {
-		if (!event || typeof event !== "object") return;
-		if (
-			event.type === "message_update" &&
-			event.assistantMessageEvent?.type === "text_delta"
-		) {
-			const delta = event.assistantMessageEvent.delta;
-			if (typeof delta === "string") aggregatedDeltaText += delta;
-			return;
-		}
-		if (event.type === "message_end") {
-			const message = event.message;
-			if (!message) return;
-			if (message.role === "assistant") {
-				const text = extractTextFromContent(message.content).trim();
-				if (text) lastAssistantMessageText = text;
-			}
-		}
-	});
-
-	const abortListener = () => {
-		void session.abort?.();
-	};
-	const signal = ctx.signal;
-	if (signal) {
-		if (signal.aborted) {
-			abortListener();
-		} else {
-			signal.addEventListener("abort", abortListener, { once: true });
-		}
-	}
-
-	let errorMessage: string | undefined;
-	try {
-		await session.prompt(prompt);
-	} catch (error) {
-		errorMessage = error instanceof Error ? error.message : String(error);
-	} finally {
-		signal?.removeEventListener("abort", abortListener);
-		unsubscribe?.();
-		try {
-			session.dispose();
-		} catch {
-			// dispose may throw on already-disposed sessions; ignore.
-		}
-	}
-
-	const aborted = Boolean(signal?.aborted);
-	const finalText =
-		(lastAssistantMessageText || aggregatedDeltaText.trim()) || "";
-
-	let content = finalText;
-	if (aborted && !content) content = "(side-chat aborted)";
-	if (errorMessage && !content) content = `(side-chat error: ${errorMessage})`;
-	if (!content) content = "(side-chat produced no response)";
-
-	pi.sendMessage<SideChatMessageDetails>({
-		customType: SIDE_CHAT_MESSAGE_TYPE,
-		content,
-		display: true,
-		details: { ...details },
-	});
-}
-
-function makeHandler(
-	pi: ExtensionAPI,
-	mode: SideChatMode,
-	deps: SideChatCommandDeps,
-): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
-	const createSession =
-		deps.createSideChatSession ?? defaultCreateSideChatSession;
-	const capturedAtFactory =
-		deps.capturedAtFactory ?? (() => new Date().toISOString());
-	const usageText = mode === "chat" ? CHAT_USAGE : TANGENT_USAGE;
-	const label = mode === "chat" ? SIDE_CHAT_CHAT_LABEL : SIDE_CHAT_TANGENT_LABEL;
-
-	return async function sideChatHandler(args, ctx) {
-		const parsed = parseSideChatArgs(args);
-		if (!parsed.ok) {
-			emitUsage(ctx, usageText);
-			return;
-		}
-
-		const parentSnapshot =
-			mode === "chat"
-				? captureParentTranscriptSnapshot(ctx, capturedAtFactory)
-				: undefined;
-
-		let created: CreateAgentSessionResult;
-		try {
-			created = await createSession({
-				mode,
-				userPrompt: parsed.userPrompt,
-				parentSnapshot,
-				parentModel: ctx.model,
-				parentThinking: undefined,
-				cwd: ctx.cwd,
-				modelRegistry: ctx.modelRegistry,
-			});
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			pi.sendMessage<SideChatMessageDetails>({
-				customType: SIDE_CHAT_MESSAGE_TYPE,
-				content: `(side-chat failed to start: ${message})`,
-				display: true,
-				details: {
-					mode,
-					capturedAt: parentSnapshot?.capturedAt,
-					label,
-					footer: SIDE_CHAT_FOOTER,
-				},
-			});
-			return;
-		}
-
-		// Build the session plan to get plan.prompt for `session.prompt(...)`.
-		// createSideChatSession may have built its own plan internally; that
-		// duplication is cheap (pure data construction) and lets the test stub
-		// receive flat options without coordinating session config exchange.
-		const plan = buildSideChatSessionConfig({
-			mode,
-			userPrompt: parsed.userPrompt,
-			parentSnapshot,
-			parentModel: ctx.model,
-			cwd: ctx.cwd,
-			modelRegistry: ctx.modelRegistry,
-		});
-
-		await driveSideChatSession(pi, ctx, created, plan.prompt, {
-			mode,
-			capturedAt: parentSnapshot?.capturedAt,
-			label,
-			footer: SIDE_CHAT_FOOTER,
-		});
-	};
-}
-
 export function registerSideChatCommands(
 	pi: ExtensionAPI,
 	deps: SideChatCommandDeps = {},
 ): void {
+	let runtime = createRuntime();
+	const createSession = deps.createSideChatSession ?? defaultCreateSideChatSession;
+	const capturedAtFactory = deps.capturedAtFactory ?? (() => new Date().toISOString());
+
+	function restore(ctx: ExtensionContext): void {
+		runtime.threads = restoreSideChatThreadsFromBranch(
+			ctx.sessionManager?.getBranch?.(),
+		);
+		resetActiveSession(runtime);
+		runtime.transcriptState = createInitialSideChatTranscriptState(
+			sideChatRowsFromThread(runtime.threads[runtime.activeMode].exchanges),
+		);
+	}
+
+	pi.on("session_start", (_event, ctx) => {
+		runtime = createRuntime();
+		restore(ctx);
+	});
+	pi.on("session_tree", (_event, ctx) => {
+		restore(ctx);
+	});
+	pi.on("session_shutdown", () => {
+		resetActiveSession(runtime);
+		for (const unsubscribe of runtime.subscriptions) unsubscribe();
+		runtime.subscriptions.clear();
+		runtime.overlayHandle?.hide();
+		runtime.overlayHandle = null;
+		runtime.overlayPromise = null;
+	});
+	pi.on("context", (event) => {
+		return { messages: filterSideChatMessagesFromContext(event.messages) };
+	});
+
 	pi.registerCommand(SIDE_CHAT_CHAT_COMMAND, {
 		description: CHAT_DESCRIPTION,
-		handler: makeHandler(pi, "chat", deps),
+		handler: makeHandler("chat", false),
+	});
+	pi.registerCommand(SIDE_CHAT_CHAT_NEW_COMMAND, {
+		description: CHAT_NEW_DESCRIPTION,
+		handler: makeHandler("chat", true),
 	});
 	pi.registerCommand(SIDE_CHAT_TANGENT_COMMAND, {
 		description: TANGENT_DESCRIPTION,
-		handler: makeHandler(pi, "tangent", deps),
+		handler: makeHandler("tangent", false),
 	});
+	pi.registerCommand(SIDE_CHAT_TANGENT_NEW_COMMAND, {
+		description: TANGENT_NEW_DESCRIPTION,
+		handler: makeHandler("tangent", true),
+	});
+	pi.registerShortcut("alt+/", {
+		description: "Toggle focus for the Gremlins side-chat overlay",
+		handler: (ctx) => {
+			if (!runtime.overlayHandle) {
+				ctx.ui?.notify?.("Open /gremlins:chat or /gremlins:tangent first.", "info");
+				return;
+			}
+			if (runtime.overlayHandle.isFocused()) runtime.overlayHandle.unfocus();
+			else runtime.overlayHandle.focus();
+		},
+	});
+
+	function makeHandler(mode: SideChatMode, forceNew: boolean) {
+		return async (args: string, ctx: ExtensionCommandContext) => {
+			const parsed = parseSideChatArgs(args);
+			runtime.activeMode = mode;
+			if (forceNew) {
+				pi.appendEntry(SIDE_CHAT_RESET_ENTRY_TYPE, {
+					mode,
+					timestamp: Date.now(),
+				});
+				runtime.threads[mode] = { mode, exchanges: [] };
+				if (runtime.activeSessionMode === mode) resetActiveSession(runtime);
+			}
+			if (mode === "chat" && runtime.threads.chat.exchanges.length === 0) {
+				const parentSnapshot = captureParentTranscriptSnapshot(
+					ctx,
+					capturedAtFactory,
+				);
+				runtime.threads.chat.parentSnapshot = parentSnapshot;
+				runtime.threads.chat.originCapturedAt = parentSnapshot?.capturedAt;
+			}
+			runtime.transcriptState = createInitialSideChatTranscriptState(
+				sideChatRowsFromThread(runtime.threads[mode].exchanges),
+			);
+			ensureOverlay(ctx);
+			if (parsed.userPrompt) {
+				await submitSideChatPrompt(ctx, parsed.userPrompt);
+			}
+		};
+	}
+
+	function ensureOverlay(ctx: ExtensionCommandContext): void {
+		if (!ctx.hasUI || !ctx.ui?.custom) {
+			ctx.ui?.notify?.("Side-chat overlay requires interactive UI.", "warning");
+			return;
+		}
+		if (runtime.overlayHandle) {
+			runtime.overlayHandle.setHidden(false);
+			runtime.overlayHandle.focus();
+			return;
+		}
+		const controller: SideChatOverlayController = {
+			getMode: () => runtime.activeMode,
+			getTranscriptState: () => runtime.transcriptState,
+			getDraft: () => runtime.overlayDraft,
+			setDraft: (value) => {
+				runtime.overlayDraft = value;
+			},
+			submitDraft: (value) => {
+				runtime.overlayDraft = "";
+				void submitSideChatPrompt(ctx, value);
+			},
+			close: () => {
+				runtime.overlayHandle?.setHidden(true);
+			},
+		};
+		runtime.overlayPromise = ctx.ui.custom<void>(
+			(tui, theme, _keybindings, done) =>
+				new SideChatOverlayComponent(tui, theme, controller, done),
+			{
+				overlay: true,
+				overlayOptions: SIDE_CHAT_OVERLAY_OPTIONS,
+				onHandle: (handle) => {
+					runtime.overlayHandle = handle;
+					handle.focus();
+				},
+			},
+		);
+		runtime.overlayPromise.finally(() => {
+			runtime.overlayHandle = null;
+			runtime.overlayPromise = null;
+		});
+	}
+
+	async function submitSideChatPrompt(
+		ctx: ExtensionCommandContext,
+		userPrompt: string,
+	): Promise<void> {
+		const mode = runtime.activeMode;
+		const thread = runtime.threads[mode];
+		runtime.lastSubmittedQuestion = userPrompt;
+		runtime.transcriptState = appendSideChatUserMessage(
+			runtime.transcriptState,
+			userPrompt,
+		);
+		let session = runtime.activeSession;
+		if (!session || runtime.activeSessionMode !== mode) {
+			resetActiveSession(runtime);
+			try {
+				const config = buildSideChatSessionConfig({
+					mode,
+					userPrompt: buildThreadHistoryPrompt(thread, userPrompt),
+					parentSnapshot: mode === "chat" ? thread.parentSnapshot : undefined,
+					parentModel: ctx.model,
+					parentThinking: undefined,
+					cwd: ctx.cwd,
+					modelRegistry: ctx.modelRegistry,
+				});
+				const created = await createSession({
+					mode,
+					userPrompt,
+					parentSnapshot: mode === "chat" ? thread.parentSnapshot : undefined,
+					parentModel: ctx.model,
+					parentThinking: undefined,
+					cwd: ctx.cwd,
+					modelRegistry: ctx.modelRegistry,
+					sessionConfig: config,
+				});
+				session = created.session as SideChatSession;
+				runtime.activeSession = session;
+				runtime.activeSessionMode = mode;
+				const unsubscribe = session.subscribe?.((event) => {
+					runtime.transcriptState = reduceSideChatTranscriptEvent(
+						runtime.transcriptState,
+						event,
+					);
+					if (event.type === "turn_end") finalizeExchange(pi, runtime, mode);
+				});
+				if (unsubscribe) runtime.subscriptions.add(unsubscribe);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				runtime.transcriptState = appendSideChatError(runtime.transcriptState, message);
+				ctx.ui?.notify?.(`Side-chat failed to start: ${message}`, "error");
+				return;
+			}
+		}
+
+		const prompt = buildSideChatSessionConfig({
+			mode,
+			userPrompt: buildThreadHistoryPrompt(thread, userPrompt),
+			parentSnapshot: mode === "chat" ? thread.parentSnapshot : undefined,
+			parentModel: ctx.model,
+			parentThinking: undefined,
+			cwd: ctx.cwd,
+			modelRegistry: ctx.modelRegistry,
+		}).prompt;
+		try {
+			await session.prompt(prompt);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			runtime.transcriptState = appendSideChatError(runtime.transcriptState, message);
+			ctx.ui?.notify?.(`Side-chat prompt failed: ${message}`, "error");
+		}
+	}
 }
 
-/**
- * Inline message renderer for `pi-gremlins:side-chat` custom messages.
- * Returns a Container with a label header, the assistant markdown body,
- * and a fixed footer line. ADR-0004 D1: inline only.
- */
-export const sideChatMessageRenderer: MessageRenderer<SideChatMessageDetails> =
-	(message, _options, _theme) => {
-		const details = message.details ?? {
-			mode: "chat",
-			label: SIDE_CHAT_CHAT_LABEL,
-			footer: SIDE_CHAT_FOOTER,
-		};
-		const container = new Container();
-		container.addChild(new Text(details.label));
-		container.addChild(new Spacer(1));
-		const body =
-			typeof message.content === "string"
-				? message.content
-				: extractTextFromContent(message.content);
-		container.addChild(new Markdown(body, 0, 0, getMarkdownThemeSafely()));
-		/* prettier-ignore */
-		container.addChild(new Spacer(1));
-		container.addChild(new Text(details.footer));
-		return container;
+function finalizeExchange(
+	pi: ExtensionAPI,
+	runtime: SideChatRuntime,
+	mode: SideChatMode,
+): void {
+	const question = runtime.lastSubmittedQuestion;
+	if (!question) return;
+	const answer = runtime.transcriptState.lastAssistantText.trim();
+	const thread = runtime.threads[mode];
+	const data: SideChatThreadEntryData = {
+		mode,
+		question,
+		answer,
+		capturedAt: thread.originCapturedAt,
+		parentSnapshot: mode === "chat" ? thread.parentSnapshot : undefined,
+		timestamp: Date.now(),
 	};
+	thread.exchanges.push(data);
+	pi.appendEntry(SIDE_CHAT_THREAD_ENTRY_TYPE, data);
+	runtime.lastSubmittedQuestion = null;
+}
 
-function getMarkdownThemeSafely(): MarkdownTheme {
+function resetActiveSession(runtime: SideChatRuntime): void {
+	for (const unsubscribe of runtime.subscriptions) unsubscribe();
+	runtime.subscriptions.clear();
 	try {
-		return (getMarkdownTheme?.() ?? ({} as MarkdownTheme)) as MarkdownTheme;
+		runtime.activeSession?.dispose();
 	} catch {
-		return {} as MarkdownTheme;
+		// Ignore already-disposed child sessions.
 	}
+	runtime.activeSession = null;
+	runtime.activeSessionMode = null;
+}
+
+function extractTextFromContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.flatMap((item) => {
+			if (!item || typeof item !== "object") return [];
+			if ((item as { type?: string }).type !== "text") return [];
+			const text = (item as TextContent).text;
+			return typeof text === "string" ? [text] : [];
+		})
+		.join("");
 }

--- a/extensions/pi-gremlins/side-chat-overlay.test.js
+++ b/extensions/pi-gremlins/side-chat-overlay.test.js
@@ -11,7 +11,6 @@ describe("side-chat overlay component", () => {
 		let done = false;
 		const component = new SideChatOverlayComponent(
 			{ requestRender() {} },
-			{},
 			{
 				getMode: () => "chat",
 				getTranscriptState: () => createInitialSideChatTranscriptState(),

--- a/extensions/pi-gremlins/side-chat-overlay.test.js
+++ b/extensions/pi-gremlins/side-chat-overlay.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import "./v1-contract-harness.js";
+import { SideChatOverlayComponent } from "./side-chat-overlay.ts";
+import { createInitialSideChatTranscriptState } from "./side-chat-transcript-state.ts";
+
+describe("side-chat overlay component", () => {
+	test("edits draft, submits enter, and closes escape", () => {
+		let draft = "";
+		let submitted = "";
+		let closed = false;
+		let done = false;
+		const component = new SideChatOverlayComponent(
+			{ requestRender() {} },
+			{},
+			{
+				getMode: () => "chat",
+				getTranscriptState: () => createInitialSideChatTranscriptState(),
+				getDraft: () => draft,
+				setDraft: (value) => { draft = value; },
+				submitDraft: (value) => { submitted = value; draft = ""; },
+				close: () => { closed = true; },
+			},
+			() => { done = true; },
+		);
+		component.handleInput("h");
+		component.handleInput("i");
+		expect(draft).toBe("hi");
+		component.handleInput("\r");
+		expect(submitted).toBe("hi");
+		component.handleInput("\u001b");
+		expect(closed).toBe(true);
+		expect(done).toBe(true);
+	});
+});

--- a/extensions/pi-gremlins/side-chat-overlay.ts
+++ b/extensions/pi-gremlins/side-chat-overlay.ts
@@ -10,7 +10,7 @@ import {
 } from "@mariozechner/pi-tui";
 
 const CURSOR_MARKER = "\u001b_pi:c\u0007";
-import { getMarkdownTheme, type Theme } from "@mariozechner/pi-coding-agent";
+import { getMarkdownTheme } from "@mariozechner/pi-coding-agent";
 import type { SideChatMode } from "./side-chat-session-factory.js";
 import type {
 	SideChatTranscriptRow,
@@ -41,7 +41,6 @@ export class SideChatOverlayComponent implements Component {
 
 	constructor(
 		private readonly tui: TUI | undefined,
-		private readonly theme: Theme | undefined,
 		private readonly controller: SideChatOverlayController,
 		private readonly done: () => void,
 	) {}

--- a/extensions/pi-gremlins/side-chat-overlay.ts
+++ b/extensions/pi-gremlins/side-chat-overlay.ts
@@ -1,0 +1,190 @@
+import {
+	Container,
+	Markdown,
+	Spacer,
+	Text,
+	type Component,
+	type MarkdownTheme,
+	type OverlayOptions,
+	type TUI,
+} from "@mariozechner/pi-tui";
+
+const CURSOR_MARKER = "\u001b_pi:c\u0007";
+import { getMarkdownTheme, type Theme } from "@mariozechner/pi-coding-agent";
+import type { SideChatMode } from "./side-chat-session-factory.js";
+import type {
+	SideChatTranscriptRow,
+	SideChatTranscriptState,
+} from "./side-chat-transcript-state.js";
+
+export const SIDE_CHAT_OVERLAY_OPTIONS: OverlayOptions = {
+	anchor: "top-center",
+	width: "78%",
+	minWidth: 72,
+	maxHeight: "78%",
+	margin: { top: 1, left: 2, right: 2 },
+	nonCapturing: true,
+};
+
+export interface SideChatOverlayController {
+	getMode(): SideChatMode;
+	getTranscriptState(): SideChatTranscriptState;
+	getDraft(): string;
+	setDraft(value: string): void;
+	submitDraft(value: string): void;
+	close(): void;
+}
+
+export class SideChatOverlayComponent implements Component {
+	private scrollOffset = 0;
+	private focused = true;
+
+	constructor(
+		private readonly tui: TUI | undefined,
+		private readonly theme: Theme | undefined,
+		private readonly controller: SideChatOverlayController,
+		private readonly done: () => void,
+	) {}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const mode = this.controller.getMode();
+		const state = this.controller.getTranscriptState();
+		const draft = this.controller.getDraft();
+		const container = new Container();
+		container.addChild(
+			new Text(
+				`${mode === "chat" ? "💬 chat" : "🧭 tangent"} │ ${formatStatus(state.status)} │ Enter submits · Esc closes · Alt+/ focuses`,
+				1,
+				0,
+			),
+		);
+		container.addChild(new Text("─".repeat(Math.max(8, width - 2)), 1, 0));
+		const body = new Container();
+		const visibleRows = this.getVisibleRows(state.rows, 18);
+		if (visibleRows.length === 0) {
+			body.addChild(new Text("No side-chat messages yet.", 1, 0));
+		} else {
+			for (const row of visibleRows) body.addChild(this.renderRow(row));
+		}
+		container.addChild(body);
+		container.addChild(new Spacer(1));
+		container.addChild(
+			new Text(
+				`› ${draft}${this.focused ? CURSOR_MARKER : ""}`,
+				1,
+				0,
+			),
+		);
+		container.addChild(new Text("Scroll: ↑/↓ PgUp/PgDn Home/End", 1, 0));
+		return container.render(width);
+	}
+
+	handleInput(data: string): void {
+		if (data === "\u001b") {
+			this.controller.close();
+			this.done();
+			this.tui?.requestRender();
+			return;
+		}
+		if (data === "\r" || data === "\n") {
+			const draft = this.controller.getDraft().trim();
+			if (draft) this.controller.submitDraft(draft);
+			this.tui?.requestRender();
+			return;
+		}
+		if (data === "\u007f" || data === "\b") {
+			const draft = this.controller.getDraft();
+			this.controller.setDraft(draft.slice(0, -1));
+			this.tui?.requestRender();
+			return;
+		}
+		if (data === "\u001b[A") {
+			this.scrollOffset += 1;
+			this.tui?.requestRender();
+			return;
+		}
+		if (data === "\u001b[B") {
+			this.scrollOffset = Math.max(0, this.scrollOffset - 1);
+			this.tui?.requestRender();
+			return;
+		}
+		if (data === "\u001b[5~") {
+			this.scrollOffset += 8;
+			this.tui?.requestRender();
+			return;
+		}
+		if (data === "\u001b[6~") {
+			this.scrollOffset = Math.max(0, this.scrollOffset - 8);
+			this.tui?.requestRender();
+			return;
+		}
+		if (data === "\u001b[H") {
+			this.scrollOffset = Number.MAX_SAFE_INTEGER;
+			this.tui?.requestRender();
+			return;
+		}
+		if (data === "\u001b[F") {
+			this.scrollOffset = 0;
+			this.tui?.requestRender();
+			return;
+		}
+		if (isPrintable(data)) {
+			this.controller.setDraft(this.controller.getDraft() + data);
+			this.tui?.requestRender();
+		}
+	}
+
+	setFocused(focused: boolean): void {
+		this.focused = focused;
+	}
+
+	private getVisibleRows(
+		rows: SideChatTranscriptRow[],
+		maxRows: number,
+	): SideChatTranscriptRow[] {
+		const maxOffset = Math.max(0, rows.length - maxRows);
+		const offset = Math.min(this.scrollOffset, maxOffset);
+		const end = rows.length - offset;
+		return rows.slice(Math.max(0, end - maxRows), end);
+	}
+
+	private renderRow(row: SideChatTranscriptRow): Component {
+		switch (row.type) {
+			case "user-message":
+				return new Text(`you: ${row.text}`, 0, 0);
+			case "assistant-text":
+				return new Markdown(
+					`${row.streaming ? "gremlin is typing…\n" : "gremlin:\n"}${row.text || "…"}`,
+					0,
+					0,
+					getMarkdownThemeSafely(),
+				);
+			case "turn-boundary":
+				return new Text(row.phase === "start" ? "↳ turn started" : "↲ turn ended", 0, 0);
+			case "status":
+				return new Text(row.text, 0, 0);
+		}
+	}
+}
+
+function isPrintable(data: string): boolean {
+	return data.length > 0 && !data.startsWith("\u001b") && data >= " ";
+}
+
+function formatStatus(status: SideChatTranscriptState["status"]): string {
+	if (status === "replying") return "replying";
+	if (status === "thinking") return "thinking";
+	if (status === "tool") return "running tool";
+	if (status === "error") return "error";
+	return "idle";
+}
+
+function getMarkdownThemeSafely(): MarkdownTheme {
+	try {
+		return (getMarkdownTheme?.() ?? ({} as MarkdownTheme)) as MarkdownTheme;
+	} catch {
+		return {} as MarkdownTheme;
+	}
+}

--- a/extensions/pi-gremlins/side-chat-persistence.test.js
+++ b/extensions/pi-gremlins/side-chat-persistence.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import "./v1-contract-harness.js";
+import {
+	restoreSideChatThreadsFromBranch,
+	SIDE_CHAT_RESET_ENTRY_TYPE,
+	SIDE_CHAT_THREAD_ENTRY_TYPE,
+} from "./side-chat-persistence.ts";
+
+describe("side-chat persistence", () => {
+	test("restores only entries after latest per-mode reset", () => {
+		const branch = [
+			{ type: "custom", customType: SIDE_CHAT_THREAD_ENTRY_TYPE, data: { mode: "chat", question: "old", answer: "old-a", timestamp: 1 } },
+			{ type: "custom", customType: SIDE_CHAT_THREAD_ENTRY_TYPE, data: { mode: "tangent", question: "t1", answer: "t-a", timestamp: 2 } },
+			{ type: "custom", customType: SIDE_CHAT_RESET_ENTRY_TYPE, data: { mode: "chat", timestamp: 3 } },
+			{ type: "custom", customType: SIDE_CHAT_THREAD_ENTRY_TYPE, data: { mode: "chat", question: "new", answer: "new-a", timestamp: 4 } },
+		];
+		const restored = restoreSideChatThreadsFromBranch(branch);
+		expect(restored.chat.exchanges.map((entry) => entry.question)).toEqual(["new"]);
+		expect(restored.tangent.exchanges.map((entry) => entry.question)).toEqual(["t1"]);
+	});
+});

--- a/extensions/pi-gremlins/side-chat-persistence.ts
+++ b/extensions/pi-gremlins/side-chat-persistence.ts
@@ -1,0 +1,153 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { SessionEntry } from "@mariozechner/pi-coding-agent";
+import type { ParentTranscriptSnapshot, SideChatMode } from "./side-chat-session-factory.js";
+
+export const SIDE_CHAT_THREAD_ENTRY_TYPE = "pi-gremlins:side-chat-thread";
+export const SIDE_CHAT_RESET_ENTRY_TYPE = "pi-gremlins:side-chat-reset";
+
+export interface SideChatThreadEntryData {
+	mode: SideChatMode;
+	question: string;
+	answer: string;
+	capturedAt?: string;
+	parentSnapshot?: ParentTranscriptSnapshot;
+	timestamp: number;
+}
+
+export interface SideChatResetEntryData {
+	mode: SideChatMode;
+	timestamp: number;
+}
+
+export interface SideChatThreadState {
+	mode: SideChatMode;
+	exchanges: SideChatThreadEntryData[];
+	parentSnapshot?: ParentTranscriptSnapshot;
+	originCapturedAt?: string;
+}
+
+export interface RestoredSideChatThreads {
+	chat: SideChatThreadState;
+	tangent: SideChatThreadState;
+}
+
+type CustomSessionEntry = SessionEntry & {
+	type: "custom";
+	customType: string;
+	data?: unknown;
+};
+
+export function createEmptySideChatThread(
+	mode: SideChatMode,
+): SideChatThreadState {
+	return { mode, exchanges: [] };
+}
+
+export function createEmptySideChatThreads(): RestoredSideChatThreads {
+	return {
+		chat: createEmptySideChatThread("chat"),
+		tangent: createEmptySideChatThread("tangent"),
+	};
+}
+
+export function restoreSideChatThreadsFromBranch(
+	branchEntries: readonly SessionEntry[] | undefined,
+): RestoredSideChatThreads {
+	const restored = createEmptySideChatThreads();
+	if (!Array.isArray(branchEntries)) return restored;
+
+	const lastResetIndex: Record<SideChatMode, number> = { chat: -1, tangent: -1 };
+	branchEntries.forEach((entry, index) => {
+		if (!isCustomEntry(entry, SIDE_CHAT_RESET_ENTRY_TYPE)) return;
+		const data = entry.data;
+		if (!isResetData(data)) return;
+		lastResetIndex[data.mode] = index;
+	});
+
+	branchEntries.forEach((entry, index) => {
+		if (!isCustomEntry(entry, SIDE_CHAT_THREAD_ENTRY_TYPE)) return;
+		const data = entry.data;
+		if (!isThreadData(data)) return;
+		if (index <= lastResetIndex[data.mode]) return;
+		const thread = restored[data.mode];
+		thread.exchanges.push(data);
+		if (!thread.parentSnapshot && data.parentSnapshot) {
+			thread.parentSnapshot = data.parentSnapshot;
+			thread.originCapturedAt = data.capturedAt ?? data.parentSnapshot.capturedAt;
+		}
+	});
+
+	return restored;
+}
+
+export function buildThreadHistoryPrompt(
+	thread: SideChatThreadState,
+	userPrompt: string,
+): string {
+	const trimmed = userPrompt.trim();
+	if (thread.exchanges.length === 0) return trimmed;
+	const history = thread.exchanges
+		.map(
+			(exchange, index) =>
+				`<exchange index="${index + 1}">\n<user>${escapeHistory(exchange.question)}</user>\n<assistant>${escapeHistory(exchange.answer)}</assistant>\n</exchange>`,
+		)
+		.join("\n");
+	return [
+		"<side-chat-thread-history>",
+		history,
+		"</side-chat-thread-history>",
+		"",
+		"<side-chat-question>",
+		trimmed,
+		"</side-chat-question>",
+	].join("\n");
+}
+
+export function isSideChatCustomEntry(entry: unknown): boolean {
+	return (
+		isCustomEntry(entry, SIDE_CHAT_THREAD_ENTRY_TYPE) ||
+		isCustomEntry(entry, SIDE_CHAT_RESET_ENTRY_TYPE)
+	);
+}
+
+export function filterSideChatMessagesFromContext(
+	messages: AgentMessage[],
+): AgentMessage[] {
+	return messages.filter((message) => {
+		const maybeCustom = message as { customType?: unknown; details?: unknown };
+		return (
+			maybeCustom.customType !== SIDE_CHAT_THREAD_ENTRY_TYPE &&
+			maybeCustom.customType !== SIDE_CHAT_RESET_ENTRY_TYPE
+		);
+	});
+}
+
+function isCustomEntry(entry: unknown, customType: string): entry is CustomSessionEntry {
+	return (
+		!!entry &&
+		typeof entry === "object" &&
+		(entry as { type?: unknown }).type === "custom" &&
+		(entry as { customType?: unknown }).customType === customType
+	);
+}
+
+function isResetData(data: unknown): data is SideChatResetEntryData {
+	return (
+		!!data &&
+		typeof data === "object" &&
+		((data as { mode?: unknown }).mode === "chat" ||
+			(data as { mode?: unknown }).mode === "tangent")
+	);
+}
+
+function isThreadData(data: unknown): data is SideChatThreadEntryData {
+	return (
+		isResetData(data) &&
+		typeof (data as { question?: unknown }).question === "string" &&
+		typeof (data as { answer?: unknown }).answer === "string"
+	);
+}
+
+function escapeHistory(text: string): string {
+	return text.replace(/]]>/g, "]]&gt;");
+}

--- a/extensions/pi-gremlins/side-chat-transcript-state.test.js
+++ b/extensions/pi-gremlins/side-chat-transcript-state.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import "./v1-contract-harness.js";
+import {
+	appendSideChatUserMessage,
+	createInitialSideChatTranscriptState,
+	reduceSideChatTranscriptEvent,
+} from "./side-chat-transcript-state.ts";
+
+describe("side-chat transcript reducer", () => {
+	test("folds user row and streaming assistant text", () => {
+		let state = createInitialSideChatTranscriptState();
+		state = appendSideChatUserMessage(state, "hello");
+		state = reduceSideChatTranscriptEvent(state, { type: "message_start", message: { role: "assistant" } });
+		state = reduceSideChatTranscriptEvent(state, { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hel" } });
+		state = reduceSideChatTranscriptEvent(state, { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "lo" } });
+		state = reduceSideChatTranscriptEvent(state, { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hello" }] } });
+		expect(state.status).toBe("idle");
+		expect(state.lastAssistantText).toBe("hello");
+		expect(state.rows).toContainEqual({ type: "user-message", text: "hello" });
+		expect(state.rows).toContainEqual({ type: "assistant-text", text: "hello", streaming: false });
+	});
+
+	test("records defensive tool events", () => {
+		let state = createInitialSideChatTranscriptState();
+		state = reduceSideChatTranscriptEvent(state, { type: "tool_execution_start", toolName: "bash" });
+		state = reduceSideChatTranscriptEvent(state, { type: "tool_execution_end", toolName: "bash", isError: true });
+		expect(state.status).toBe("error");
+		expect(state.rows.at(-1)).toEqual({ type: "status", text: "bash failed" });
+	});
+});

--- a/extensions/pi-gremlins/side-chat-transcript-state.ts
+++ b/extensions/pi-gremlins/side-chat-transcript-state.ts
@@ -1,0 +1,175 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { TextContent } from "@mariozechner/pi-ai";
+
+export type SideChatTranscriptRow =
+	| { type: "turn-boundary"; turnIndex?: number; phase: "start" | "end" }
+	| { type: "user-message"; text: string }
+	| { type: "assistant-text"; text: string; streaming: boolean }
+	| { type: "status"; text: string };
+
+export interface SideChatTranscriptState {
+	rows: SideChatTranscriptRow[];
+	status: "idle" | "thinking" | "replying" | "tool" | "error";
+	error?: string;
+	lastAssistantText: string;
+}
+
+export type SideChatTranscriptEvent = {
+	type?: string;
+	turnIndex?: number;
+	message?: Partial<AgentMessage> & { role?: unknown; content?: unknown };
+	assistantMessageEvent?: { type?: string; delta?: unknown };
+	toolName?: string;
+	isError?: boolean;
+	result?: unknown;
+};
+
+export function createInitialSideChatTranscriptState(
+	seedRows: SideChatTranscriptRow[] = [],
+): SideChatTranscriptState {
+	return {
+		rows: [...seedRows],
+		status: "idle",
+		lastAssistantText: "",
+	};
+}
+
+export function appendSideChatUserMessage(
+	state: SideChatTranscriptState,
+	text: string,
+): SideChatTranscriptState {
+	return {
+		...state,
+		rows: [...state.rows, { type: "user-message", text }],
+		status: "thinking",
+		error: undefined,
+	};
+}
+
+export function appendSideChatError(
+	state: SideChatTranscriptState,
+	message: string,
+): SideChatTranscriptState {
+	return {
+		...state,
+		rows: [...state.rows, { type: "status", text: `error: ${message}` }],
+		status: "error",
+		error: message,
+	};
+}
+
+export function reduceSideChatTranscriptEvent(
+	state: SideChatTranscriptState,
+	event: SideChatTranscriptEvent,
+): SideChatTranscriptState {
+	if (!event || typeof event !== "object") return state;
+	switch (event.type) {
+		case "turn_start":
+			return {
+				...state,
+				status: "thinking",
+				error: undefined,
+				rows: [
+					...state.rows,
+					{ type: "turn-boundary", phase: "start", turnIndex: event.turnIndex },
+				],
+			};
+		case "turn_end":
+			return {
+				...state,
+				status: "idle",
+				rows: [
+					...state.rows,
+					{ type: "turn-boundary", phase: "end", turnIndex: event.turnIndex },
+				],
+			};
+		case "message_start":
+			if (event.message?.role !== "assistant") return state;
+			return {
+				...state,
+				status: "replying",
+				lastAssistantText: "",
+				rows: [...state.rows, { type: "assistant-text", text: "", streaming: true }],
+			};
+		case "message_update": {
+			if (event.assistantMessageEvent?.type !== "text_delta") return state;
+			const delta = event.assistantMessageEvent.delta;
+			if (typeof delta !== "string" || delta.length === 0) return state;
+			const rows = [...state.rows];
+			const last = rows[rows.length - 1];
+			if (last?.type === "assistant-text" && last.streaming) {
+				rows[rows.length - 1] = { ...last, text: last.text + delta };
+			} else {
+				rows.push({ type: "assistant-text", text: delta, streaming: true });
+			}
+			return {
+				...state,
+				status: "replying",
+				lastAssistantText: state.lastAssistantText + delta,
+				rows,
+			};
+		}
+		case "message_end": {
+			if (event.message?.role !== "assistant") return state;
+			const text = extractTextFromContent(event.message.content).trim();
+			const finalText = text || state.lastAssistantText;
+			const rows = [...state.rows];
+			const last = rows[rows.length - 1];
+			if (last?.type === "assistant-text") {
+				rows[rows.length - 1] = {
+					...last,
+					text: finalText || last.text,
+					streaming: false,
+				};
+			} else {
+				rows.push({ type: "assistant-text", text: finalText, streaming: false });
+			}
+			return { ...state, status: "idle", lastAssistantText: finalText, rows };
+		}
+		case "tool_execution_start":
+			return {
+				...state,
+				status: "tool",
+				rows: [
+					...state.rows,
+					{ type: "status", text: `running tool: ${event.toolName ?? "unknown"}` },
+				],
+			};
+		case "tool_execution_end":
+			return {
+				...state,
+				status: event.isError ? "error" : "replying",
+				rows: [
+					...state.rows,
+					{
+						type: "status",
+						text: `${event.toolName ?? "tool"} ${event.isError ? "failed" : "finished"}`,
+					},
+				],
+			};
+		default:
+			return state;
+	}
+}
+
+export function sideChatRowsFromThread(
+	thread: Array<{ question: string; answer: string }>,
+): SideChatTranscriptRow[] {
+	return thread.flatMap((entry) => [
+		{ type: "user-message" as const, text: entry.question },
+		{ type: "assistant-text" as const, text: entry.answer, streaming: false },
+	]);
+}
+
+export function extractTextFromContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.flatMap((item) => {
+			if (!item || typeof item !== "object") return [];
+			if ((item as { type?: string }).type !== "text") return [];
+			const text = (item as TextContent).text;
+			return typeof text === "string" ? [text] : [];
+		})
+		.join("");
+}


### PR DESCRIPTION
## Summary
- Upgrade `/gremlins:chat` and `/gremlins:tangent` to persistent overlay-backed side-chat threads
- Add `/gremlins:chat:new` and `/gremlins:tangent:new` reset variants
- Add side-chat persistence, transcript reducer, overlay tests, PRD-0005, ADR-0005, README, and changelog updates

## Verification
- `npm run check`

Closes #49