### PR TITLE
Add active gremlin steering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repaired reliability audit findings for renderer cache uniqueness, same-size agent discovery changes, corrupt primary-agent settings recovery, effective request-cwd discovery, and ambiguous gremlin model reporting.
 
 ### Added
+- **Active gremlin session steering** (PRD-0006, ADR-0006, issue #53): `/gremlins:steer <G-id> <message>` now queues steering directly through the active child `AgentSession.steer(message)` API, with lifecycle-scoped registry cleanup, case-insensitive ids, duplicate-id ambiguity rejection, and fail-closed handling for stale or terminal sessions.
 - **Side-chat absorbed from pi-gizmo** (PRD-0004, ADR-0004, issue #47): pi-gremlins now ships `/gremlins:chat` (parent-transcript snapshot) and `/gremlins:tangent` (clean child session), rebuilt on the existing in-process SDK runtime with zero tools and inline rendering. See README "Side-chat" section for the pi-gizmo migration table.
 - Generated agent guidance now covers root, docs, and extension scopes so contributors get current PRD/ADR, primary-agent, and runtime boundaries before editing.
 - Shared role-aware agent parsing/discovery modules now load `agent_type: sub-agent` gremlins and `agent_type: primary` primary agents from user/project agent directories while preserving strict role separation and project-over-user precedence.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,27 @@ Runtime behavior:
 - collapsed tool row shows source, status, intent/task preview, latest activity, usage, and errors
 - expanded tool row shows intent, task, cwd, model, thinking, latest text/tool data, usage, and errors
 
+## Active gremlin steering: `/gremlins:steer`
+
+Use `/gremlins:steer <G-id> <message>` to steer an active gremlin child session through the official Pi SDK `AgentSession.steer(message)` API.
+
+Example:
+
+```text
+/gremlins:steer G1 keep investigating the auth flow before summarizing
+```
+
+Behavior:
+
+- `G-id` is the displayed gremlin id such as `g1`; matching is case-insensitive, so `G1` and `g1` target the same active id when unambiguous.
+- The id is parsed from the first non-empty token. The message is the remaining text after the id with separator whitespace normalized; internal multi-word spacing and punctuation are preserved and sent to `AgentSession.steer(message)`.
+- Only currently active gremlin sessions can be steered. Unknown, completed, canceled, failed, setup-failed, stale, or disposed ids are rejected.
+- Concurrent batches can each have a `g1`. If more than one active session shares an id, steering that id fails as ambiguous instead of guessing.
+- Pi SDK queues steering for the target child session after its current child tool calls finish and before its next child LLM call; it does not interrupt a running tool call immediately.
+- This is official child-session steering. It does not restore legacy subprocess/RPC steering, parent-message injection, prompt-history injection, popup UI, or `/gremlins:view` viewer controls.
+
+See [PRD-0006](docs/prd/0006-active-gremlin-session-steering.md) and [ADR-0006](docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md).
+
 ## Side-chat overlay: `/gremlins:chat` and `/gremlins:tangent`
 
 Side-chat support now uses persistent Pi overlays (PRD-0005, ADR-0005,

--- a/docs/adr/0002-in-process-sdk-based-gremlin-runtime.md
+++ b/docs/adr/0002-in-process-sdk-based-gremlin-runtime.md
@@ -14,7 +14,7 @@ Main complexity sits in:
 
 - `extensions/pi-gremlins/single-agent-runner.ts` — spawns nested Pi processes, manages stdout JSON parsing, temp prompt files, abort timers, late exit handling, and steerable RPC sessions.
 - `extensions/pi-gremlins/execution-modes.ts` — supports single, parallel, and chain execution.
-- `extensions/pi-gremlins/index.ts` plus viewer modules — manages popup overlay state, inline/viewer semantic projection, and targeted steering.
+- `extensions/pi-gremlins/index.ts` plus viewer modules — managed popup overlay state, inline/viewer semantic projection, and legacy targeted steering.
 
 This architecture solved isolation by process boundary, but it also created repeated failure surface:
 
@@ -122,7 +122,7 @@ Rationale: User asked for full rewrite because subprocess termination has been p
 - **Migration/ops:**
   - No persistence or config migration.
   - Public tool schema changes materially: old multi-mode params are removed in favor of `gremlins: [{ intent, agent, context, cwd? }, ...]`.
-  - Legacy commands `/gremlins:view` and `/gremlins:steer` are removed as part of rewrite.
+  - Legacy commands `/gremlins:view` and legacy `/gremlins:steer` are removed as part of rewrite. Official active child-session steering through `AgentSession.steer(message)` is governed separately by ADR-0006.
   - Extension entry remains under `./extensions/pi-gremlins`, but implementation beneath it is rewritten from scratch and legacy modules deleted after cutover verification.
 
 ## Verification
@@ -157,8 +157,11 @@ Research inputs driving this decision:
 
 This ADR intentionally supersedes ADR-0001. ADR-0001 optimized popup viewer and shared viewer-entry presentation surfaces. V1 rewrite removes popup viewer entirely and no longer treats viewer architecture as core runtime boundary.
 
+ADR-0006 supersedes this ADR only for the targeted-steering prohibition: official child `AgentSession.steer(message)` support is allowed for active gremlin sessions, while legacy subprocess/RPC/viewer steering remains prohibited.
+
 ## Status History
 
 - 2026-04-22: Accepted; supersedes ADR-0001 in favor of SDK-based in-process child sessions and inline-only v1 UI
 - 2026-04-24: Noted required per-gremlin `intent` field as part of public v1 request contract and child prompt framing
 - 2026-04-25: Clarified issue #41 prompt-isolation boundary after primary-agent merge: gremlin child sessions use selected sub-agent markdown as system prompt and do not propagate parent prompt snapshots or primary-agent blocks
+- 2026-04-30: Clarified issue #53 partial supersession by ADR-0006: official active child-session steering is allowed; legacy subprocess/RPC/viewer steering remains prohibited

--- a/docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md
+++ b/docs/adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md
@@ -22,7 +22,7 @@ Both packages inspect the same agent directories and parse similar markdown fron
 
 Keeping these behaviors split forces users to install and reason about two packages for one agent-orchestration workflow. Merging primary-agent behavior into `pi-gremlins` changes the extension/package boundary and adds a parent-session prompt mutation path beside existing gremlin child-session delegation, so the architecture decision needs to be explicit before implementation.
 
-ADR-0002 remains in force: gremlin execution stays in-process through SDK child sessions and must not reintroduce nested Pi CLI subprocess runtime, popup viewer surfaces, chain mode, targeted steering, package gremlin discovery, or scope toggles.
+ADR-0002 remains in force: gremlin execution stays in-process through SDK child sessions and must not reintroduce nested Pi CLI subprocess runtime, popup viewer surfaces, chain mode, legacy targeted steering, package gremlin discovery, or scope toggles. Official active child-session steering is governed separately by ADR-0006.
 
 ## Decision Drivers
 
@@ -142,9 +142,10 @@ The implementation must follow these architectural constraints:
 
 This ADR does not add external dependencies. It records package and runtime boundary choices for issue #39 before implementation.
 
-ADR-0002 still governs gremlin execution architecture. If implementation pressure suggests restoring nested Pi subprocess execution, popup viewers, chain mode, targeted steering, package gremlin discovery, or scope toggles, stop and write a new ADR instead of folding those changes into issue #39.
+ADR-0002 still governs gremlin execution architecture. If implementation pressure suggests restoring nested Pi subprocess execution, popup viewers, chain mode, legacy targeted steering, package gremlin discovery, or scope toggles, stop and write a new ADR instead of folding those changes into issue #39. ADR-0006 separately permits official child `AgentSession.steer(message)` support for active gremlin sessions only.
 
 ## Status History
 
 - 2026-04-25: Accepted; records issue #39 package-boundary decision to merge primary-agent selection and prompt injection into `pi-gremlins` while deprecating separate `pi-mohawk` package after equivalent behavior ships
 - 2026-04-25: Clarified issue #41 isolation constraint that primary-agent prompt injection stays parent-only and is excluded from gremlin child sessions
+- 2026-04-30: Clarified issue #53 partial supersession by ADR-0006: official active child-session steering is allowed; legacy targeted steering remains prohibited

--- a/docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md
+++ b/docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md
@@ -1,0 +1,127 @@
+# ADR-0006: Official SDK Steering for Active Gremlin Sessions
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Decision Maker:** magimetal
+- **Related:** GitHub issue [#53](https://github.com/magimetal/pi-gremlins/issues/53), [PRD-0006](../prd/0006-active-gremlin-session-steering.md), [ADR-0002](0002-in-process-sdk-based-gremlin-runtime.md), [ADR-0003](0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md)
+- **Supersedes:** ADR-0002 and ADR-0003 targeted-steering prohibition only. Legacy subprocess/RPC/viewer steering remains prohibited.
+
+## Context
+
+ADR-0002 moved gremlin execution from nested Pi subprocesses to isolated in-process SDK child `AgentSession`s and removed legacy `/gremlins:steer` with the old viewer/RPC surface. ADR-0003 preserved that prohibition while merging primary-agent controls into `pi-gremlins`.
+
+Issue #53 changes the available technical option: Pi SDK now provides official child `AgentSession.steer(message)` support. The old steering ban protected the v1 rewrite from reintroducing fragile subprocess/RPC/viewer architecture; it was not a permanent product claim that active child SDK sessions can never be steered. The architecture now needs a narrow official-SDK steering path that keeps the v1 child-session runtime and isolation model intact.
+
+The command must deliver steering to the target active child session after that child assistant turn finishes current tool calls and before the child makes its next LLM call. It must not wait for a later parent user turn and must not be implemented through parent-session message injection.
+
+## Decision Drivers
+
+- Correctness: steering must target the active child `AgentSession` that is already running the gremlin.
+- SDK alignment: use the official `AgentSession.steer(message)` API instead of inventing transport or prompt-mutation behavior.
+- Isolation: child sessions must remain isolated from parent history, parent system prompt, primary-agent markdown, extensions, skills, prompts, themes, and `AGENTS` loading.
+- Runtime containment: active session references must be short-lived, cleaned up deterministically, and never persisted.
+- Safety: stale, inactive, disposed, completed, failed, canceled, aborted, setup-failed, unknown, or ambiguous ids must fail closed.
+- Scope preservation: no legacy subprocess/RPC steering, popup viewer, chain mode, package-agent discovery, scope toggles, or old schema paths return.
+- Testability: parser, registry, lifecycle cleanup, negative legacy-path checks, and direct SDK steering call behavior must be covered by focused tests.
+
+## Options Considered
+
+### Option A: Keep steering unsupported
+
+- Pros:
+  - Preserves the narrowest v1 runtime surface.
+  - Avoids active-session registry lifecycle risk.
+  - Requires no new command UX or concurrency ambiguity policy.
+- Cons:
+  - Leaves official SDK capability unused.
+  - Prevents operators from correcting active long-running gremlins.
+  - Conflicts with issue #53's requested implementation-ready `/gremlins:steer` command.
+
+### Option B: Reintroduce legacy subprocess/RPC/viewer steering
+
+- Pros:
+  - Resembles historical command name and some historical tests.
+  - Could reuse old mental model if old code still existed.
+- Cons:
+  - Directly violates ADR-0002's reason for the v1 rewrite.
+  - Reopens subprocess lifecycle, viewer state, and protocol complexity that the package intentionally removed.
+  - Does not align with current in-process child SDK sessions.
+  - Risks parent/child prompt isolation regressions.
+
+### Option C: Register `/gremlins:steer` and call active child `AgentSession.steer(message)` through a short-lived registry
+
+- Pros:
+  - Uses official Pi SDK steering semantics.
+  - Keeps current in-process child-session architecture.
+  - Avoids parent `sendUserMessage`, `followUp`, prompt mutation, subprocess RPC, and popup/viewer UI.
+  - Makes lifecycle and stale-reference behavior explicit and testable.
+  - Allows safe ambiguity handling across concurrent batches.
+- Cons:
+  - Adds a new active-session registry and lifecycle cleanup responsibility.
+  - Requires careful id resolution policy because existing displayed ids such as `g1` can repeat across concurrent tool calls.
+  - Adds command UX and tests for a previously removed surface.
+
+## Decision
+
+Chosen: **Option C: Register `/gremlins:steer` and call active child `AgentSession.steer(message)` through a short-lived registry**.
+
+Rationale: Official child-session steering lets `pi-gremlins` restore useful active gremlin redirection without restoring the legacy architecture that ADR-0002 removed. The command is allowed only as a thin SDK-backed path to the currently active child `AgentSession`; all old subprocess/RPC/viewer steering mechanisms remain rejected.
+
+The implementation must follow these architectural constraints:
+
+- Register the command through `pi.registerCommand("gremlins:steer", ...)`.
+- Keep command handling in a focused module rather than expanding `index.ts` into a command monolith.
+- Track active child SDK sessions in a focused registry module.
+- Register a child session only while its gremlin can be steered.
+- Deregister on normal completion, failure, cancellation, abort, setup failure, disposal, and extension/session shutdown.
+- Resolve gremlin ids case-insensitively for `G1`/`g1` unless stricter behavior is intentionally documented and tested.
+- Fail ambiguous ids safely, or expose a stable namespace such as `toolCallId` and test it.
+- Invoke only the target child `AgentSession.steer(message)` on success.
+- Do not use parent `pi.sendUserMessage`, `deliverAs: "steer"`, `followUp`, legacy subprocess/RPC channels, popup viewer state, or prompt-history injection.
+- Preserve child-session factory isolation and do not load parent resources into child sessions.
+
+## Consequences
+
+- **Positive:** Operators gain a supported way to redirect active gremlins while they are still running.
+- **Positive:** Steering uses official SDK semantics and remains inside the accepted ADR-0002 in-process architecture.
+- **Positive:** Legacy steering paths stay prohibited, making regression tests clear: official child `AgentSession.steer` is allowed; parent/subprocess/viewer steering is not.
+- **Negative:** Runtime now needs an active session registry and cleanup paths across runner, scheduler, tool execution, and extension shutdown.
+- **Negative:** Gremlin ids that repeat across concurrent batches require explicit ambiguity handling or namespacing.
+- **Follow-on constraints:** Future changes to steering id format, registry persistence, or cross-session steering require a new PRD/ADR review because they affect user-visible command semantics and runtime boundaries.
+
+## Implementation Impact
+
+- **apps/api:** N/A. Standalone Pi package, no `apps/api` workspace.
+- **apps/web:** N/A. No web frontend package.
+- **packages/shared:** N/A. No shared package contract change.
+- **packages/utils:** N/A. No standalone utils package in this repository.
+- **Migration/ops:**
+  - No persistent config or data migration.
+  - Runtime gains an in-memory active child session registry only.
+  - README must document command syntax, active-lifetime limits, timing, ambiguity behavior, and legacy-path exclusions.
+  - CHANGELOG must cite PRD-0006 and ADR-0006 when implementation lands.
+  - Existing tests that asserted no `gremlins:steer` command must be updated to reject only legacy steering mechanisms.
+
+## Verification
+
+- **Automated:**
+  - Command registration test confirms `gremlins:steer` is registered and no legacy viewer/RPC steering command path is reintroduced.
+  - Parser tests cover missing id, missing message, multi-word message preservation, and documented `G1`/`g1` behavior.
+  - Registry tests cover register, resolve, ambiguity handling or namespace handling, completion cleanup, cancellation cleanup, abort cleanup, setup-failure cleanup, disposal cleanup, stale id rejection, and extension/session shutdown cleanup.
+  - Handler test verifies successful steering invokes child `AgentSession.steer(message)` exactly once.
+  - Negative tests verify no parent `pi.sendUserMessage`, `deliverAs: "steer"`, `followUp`, subprocess/RPC steering, popup viewer, or prompt-history path is used.
+  - Timing/queueing test uses an SDK fake or mocked child `AgentSession.steer` to prove steering is queued against the current child session and does not require a later parent turn.
+  - Isolation regression tests confirm child session creation still excludes parent history/system/primary-agent markdown/extensions/skills/prompts/themes/`AGENTS` content.
+  - Full repository verification after implementation: `npm run typecheck`, `npm test`, and `npm run check`.
+- **Manual:**
+  - Start a long-running gremlin, run `/gremlins:steer G1 <message>`, and verify a queued confirmation appears without popup/viewer UI.
+  - Verify steering affects the active child session at the next SDK steering boundary.
+  - Try unknown, completed, canceled, failed, stale, and ambiguous ids and confirm they fail with clear notifications.
+
+## Notes
+
+This ADR supersedes only the targeted-steering prohibition in ADR-0002 and ADR-0003 for the official Pi SDK child-session steering path. It does not supersede the bans on nested Pi subprocess execution, popup viewers, `/gremlins:view`, chain mode, package-agent discovery, scope toggles, parent prompt/history leakage, or old schema paths.
+
+## Status History
+
+- 2026-04-30: Accepted for issue #53; permits official child `AgentSession.steer(message)` for active gremlin sessions while preserving legacy steering prohibitions.

--- a/docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md
+++ b/docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md
@@ -125,3 +125,4 @@ This ADR supersedes only the targeted-steering prohibition in ADR-0002 and ADR-0
 ## Status History
 
 - 2026-04-30: Accepted for issue #53; permits official child `AgentSession.steer(message)` for active gremlin sessions while preserving legacy steering prohibitions.
+- 2026-04-30: Verified against implementation commit `f1e77d6b5eb1e82372c916cebb92a21e9dfd5b18` and PR [#55](https://github.com/magimetal/pi-gremlins/pull/55); decision remains aligned and status remains Accepted.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,3 +70,4 @@ Reference ADR IDs in changelog entries for significant changes:
 | 0003 | Unified Agent Discovery and Primary-Agent Prompt Injection in pi-gremlins | Accepted | 2026-04-25 |
 | 0004 | Side-Chat Absorption from pi-gizmo into pi-gremlins              | Accepted | 2026-04-29 |
 | 0005 | Persistent Overlay Side-Chat                                    | Accepted | 2026-04-30 |
+| 0006 | Official SDK Steering for Active Gremlin Sessions               | Accepted | 2026-04-30 |

--- a/docs/plans/issue-53-active-gremlin-session-steering.md
+++ b/docs/plans/issue-53-active-gremlin-session-steering.md
@@ -1,0 +1,266 @@
+# Issue 53 Plan: Active Gremlin Session Steering
+
+## Objective
+
+Implement `/gremlins:steer <G-id> <message>` for active in-process gremlin child sessions, aligned with [PRD-0006](../prd/0006-active-gremlin-session-steering.md) and [ADR-0006](../adr/0006-official-sdk-steering-for-active-gremlin-sessions.md).
+
+## Key Decisions To Preserve
+
+- Use `pi.registerCommand("gremlins:steer", ...)`.
+- On success, call the target child SDK `AgentSession.steer(message)` directly and exactly once.
+- Await `session.steer(message)` and catch rejection; steering rejection must produce a failure notification and must not also show success or fall back to any legacy path.
+- Maintain an in-memory active child-session registry scoped to the extension runtime.
+- Resolve `G1`/`g1` case-insensitively.
+- Fail closed for unknown, inactive, stale, disposed, terminal, or ambiguous ids.
+- For concurrent batches where more than one active `g1` exists, reject `g1` as ambiguous rather than guessing.
+- Use an opaque registration handle or composite key for exact unregister so removing one duplicate active `g1` never removes or corrupts another active `g1`.
+- Treat the command argument contract as `args: string` unless tests prove optional array forms are actually emitted by the harness/SDK; do not add untested parser surface.
+- Do not add parent `pi.sendUserMessage`, `deliverAs: "steer"`, `followUp`, subprocess/RPC steering, popup/viewer UI, prompt-history injection, or persistence.
+- Preserve explicit user authorization from the `git-issue-fix` workflow to commit, push, and open/update the PR, but perform those git/GitHub steps only after required verification passes and no blockers remain.
+
+## Implementation Tasks
+
+### 1. Add focused active-session registry
+
+**What**
+- Create `extensions/pi-gremlins/gremlin-session-registry.ts`.
+- Define a narrow steerable-session type containing `steer(message): Promise<unknown> | unknown` plus optional disposal/status metadata only if required for tests.
+- Store active entries with at least: normalized display id (`g1`), original display id, `toolCallId`/run key, agent name, session reference, and an internal opaque registration handle or composite key.
+- Make `registerActiveGremlinSession(...)` return the opaque registration handle/key. Require `unregisterActiveGremlinSession(handle)` to remove exactly that entry, not every entry with the same display id.
+- Provide operations such as `registerActiveGremlinSession`, `unregisterActiveGremlinSession`, `resolveActiveGremlinSession`, and `clearActiveGremlinSessions`.
+- Make `resolveActiveGremlinSession("G1")` case-insensitive and return discriminated results for `missing`, `ambiguous`, and `active`.
+- Treat removed entries as non-steerable; error copy can say no active gremlin was found and mention completed/canceled/failed/stale/disposed possibilities.
+
+**References**
+- `extensions/pi-gremlins/gremlin-session-registry.ts` (new)
+- `docs/prd/0006-active-gremlin-session-steering.md`
+- `docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md`
+
+**Acceptance criteria**
+- Active entries can be registered, resolved, unregistered by exact handle/key, and cleared.
+- `G1` and `g1` resolve to the same active session when unambiguous.
+- Duplicate active display ids from different run keys resolve as `ambiguous`.
+- Duplicate active `g1` entries stay independent: unregistering the first handle leaves the second `g1` registered and resolvable; unregistering the second handle then makes `g1` missing.
+- Unknown or removed ids do not expose any session and fail closed.
+
+**Guardrails**
+- Do not persist registry state.
+- Do not key unregister only by display id.
+- Do not expose parent transcript, prompt, resource-loader, or session-manager data through registry entries.
+- Do not add stale-session resurrection or cross-session steering.
+
+**Verification**
+- Add `extensions/pi-gremlins/gremlin-session-registry.test.js` covering registration, case-insensitive lookup, ambiguity, exact unregister by opaque handle/key, duplicate active `g1` ambiguity followed by exact unregister leaving the remaining `g1` resolvable, clear, and missing/stale rejection.
+- Run: `bun test extensions/pi-gremlins/gremlin-session-registry.test.js`.
+
+### 2. Add slash-command parser and handler
+
+**What**
+- Create `extensions/pi-gremlins/gremlin-steer-command.ts`.
+- Lock the command argument contract with tests before wiring behavior: observed harness registration stores command objects from `pi.registerCommand`, and the implementation must treat command invocation as receiving `args: string` unless tests demonstrate another current shape. Optional string-array support may be added only if a test proves the SDK/harness emits arrays.
+- Parse the first non-empty token in the raw `args: string` as the gremlin id.
+- Preserve the steering message as the remaining raw substring after the id, including internal spacing and punctuation. Normalize only leading separator whitespace between id and message and reject an all-whitespace remainder as missing message.
+- Return clear notifications for missing id, missing message, unknown/inactive/stale id, and ambiguous id.
+- For an active resolved entry, call `await entry.session.steer(message)` directly once and show a concise success notification only after it resolves.
+- If `session.steer(message)` rejects or throws, catch it, show a failure notification, and do not show success, retry through fallback APIs, or mutate registry state except through normal lifecycle cleanup.
+- Keep all command UX notification-based; no popup, overlay, viewer, or transcript mutation.
+
+**References**
+- `extensions/pi-gremlins/gremlin-steer-command.ts` (new)
+- `extensions/pi-gremlins/side-chat-command.ts` for local command-registration and notification style only
+- `extensions/pi-gremlins/v1-contract-harness.js` for command test harness support and observed command registration behavior
+
+**Acceptance criteria**
+- Handler tests lock `args: string` as the supported invocation shape; any optional array behavior is absent unless test-proven first.
+- Missing id and missing message notify and do not call `steer`.
+- Multi-word messages preserve the exact text after the id except for normalization of the separator whitespace between id and message.
+- `G1`/`g1` behavior is tested and documented.
+- Successful command handling awaits the target child session's `steer(message)` exactly once and only then notifies success.
+- Rejected `steer(message)` notifies failure, does not notify success, and does not call parent/fallback steering APIs.
+- Ambiguous ids notify and do not call any session.
+
+**Guardrails**
+- Do not call `pi.sendUserMessage`, `pi.sendMessage`, `followUp`, or any parent-session message injection API from the steer command. Existing unrelated harness message collection is not a steering mechanism.
+- Do not implement `deliverAs: "steer"` or any synthetic user turn.
+- Do not add `/gremlins:view` or viewer steering controls.
+- Do not broaden parser support beyond the tested command argument contract.
+
+**Verification**
+- Add `extensions/pi-gremlins/gremlin-steer-command.test.js` for parser and handler behavior.
+- Include tests for missing id/message, exact multi-word message preservation/whitespace normalization, case-insensitive id, ambiguity, successful awaited `steer`, and rejected `steer` failure notification with no success/fallback.
+- Run: `bun test extensions/pi-gremlins/gremlin-steer-command.test.js`.
+
+### 3. Register the command and wire registry lifecycle through execution
+
+**What**
+- In `extensions/pi-gremlins/index.ts`, instantiate one active-session registry inside `createPiGremlinsExtension`.
+- Register `gremlins:steer` beside existing commands via `pi.registerCommand("gremlins:steer", ...)`.
+- Pass the registry and tool call id from `tool.execute(_toolCallId, ...)` into `executePiGremlinsTool`, then into `runSingleGremlin` through the scheduler path.
+- Clear the registry on `session_shutdown`.
+- Register each child session after `createSession` succeeds and before `session.prompt(...)` starts; store the returned opaque handle/key in the local run scope.
+- Unregister by that exact handle/key in `finally` before/around `session.dispose()` so completion, failure, cancellation, abort, and disposal all remove steerability without affecting duplicate ids from other active runs.
+- Keep validation/discovery/setup failures unregistered so setup-failed or unknown gremlins are non-steerable.
+
+**References**
+- `extensions/pi-gremlins/index.ts`
+- `extensions/pi-gremlins/gremlin-tool-execution.ts`
+- `extensions/pi-gremlins/gremlin-scheduler.ts`
+- `extensions/pi-gremlins/gremlin-runner.ts`
+- `extensions/pi-gremlins/gremlin-session-factory.ts`
+
+**Acceptance criteria**
+- Command count and registration tests expect `gremlins:steer` and still reject `gremlins:view`.
+- Active child sessions become steerable only during their `runSingleGremlin` lifetime.
+- Lifecycle test proves: when `createSession` succeeds and later `session.prompt(...)` rejects, the session was registered before prompt and then unregistered/disposed in cleanup.
+- Registry cleanup happens on normal completion, thrown failure, parent abort/child cancellation, setup failure path, disposal, and `session_shutdown`.
+- Concurrent runs using duplicate display ids fail ambiguous while both are active, and after one exact handle is unregistered the remaining entry becomes resolvable.
+
+**Guardrails**
+- Do not change the public `pi-gremlins` tool schema.
+- Do not weaken `gremlin-session-factory.ts` isolation resources.
+- Do not change gremlin rendering ids except as needed to keep `g1`, `g2`, ... documented.
+- Avoid broad refactors; pass minimal dependencies through existing option objects.
+
+**Verification**
+- Update `extensions/pi-gremlins/index.execute.test.js` to expect `gremlins:steer` registration and no `gremlins:view`.
+- Update/add runner execution tests proving registration and cleanup across completion, prompt rejection after registration, failure, abort/cancel, and dispose.
+- Add an integration-style test using the harness: start a fake long-running session, invoke the registered command with `args: "G1 keep investigating auth flow"`, assert fake `steer` receives `keep investigating auth flow` without waiting for a parent turn, then finish and assert later steering is rejected.
+- Run: `bun test extensions/pi-gremlins/index.execute.test.js extensions/pi-gremlins/gremlin-runner.test.js`.
+
+### 4. Add negative legacy-path and isolation regression coverage
+
+**What**
+- Update tests that currently encode no `/gremlins:steer` support so they allow official SDK steering only.
+- Add focused negative assertions that implementation does not use parent `sendUserMessage`, `deliverAs: "steer"`, `followUp`, subprocess/RPC channels, popup/viewer UI, or prompt-history injection.
+- Prefer behavior-level mocks/assertions over brittle source-code string tests where possible.
+- For source/diff inspection of forbidden mechanisms, expect known documentation and test hits; manually verify that any hits are bans, assertions, docs, or unrelated pre-existing APIs rather than implementation of a forbidden steering path.
+- Preserve existing isolation tests around child resources and parent prompt/history exclusion.
+
+**References**
+- `extensions/pi-gremlins/index.execute.test.js`
+- `extensions/pi-gremlins/gremlin-rendering.test.js`
+- `extensions/pi-gremlins/index.render.test.js`
+- `extensions/pi-gremlins/gremlin-session-factory.test.js`
+- `extensions/pi-gremlins/v1-contract-harness.js`
+- `README.md`
+- `CHANGELOG.md`
+
+**Acceptance criteria**
+- Tests no longer assert `commands.has("gremlins:steer")` is false.
+- Tests still assert no `/gremlins:view`, popup viewer, subprocess steering, parent-message steering, or prompt leakage returns.
+- Any `grep` hits for `sendUserMessage`, `deliverAs`, `followUp`, `gremlins:view`, or legacy steering terms are manually classified as expected docs/tests/bans or unrelated non-steering references.
+- Child session creation remains isolated from parent system prompt snapshots, primary-agent markdown, extensions, skills, prompts, themes, and `AGENTS` files.
+
+**Guardrails**
+- Do not remove legacy bans to make tests pass.
+- Do not add brittle source-code string tests where behavior-level mocks can prove the same constraint.
+- Do not treat grep hits in documentation or negative tests as automatic failures; inspect them and fail only on forbidden implementation paths.
+
+**Verification**
+- Run: `bun test extensions/pi-gremlins/index.execute.test.js extensions/pi-gremlins/gremlin-rendering.test.js extensions/pi-gremlins/index.render.test.js extensions/pi-gremlins/gremlin-session-factory.test.js`.
+- Run for manual classification, not automatic pass/fail: `grep -R "sendUserMessage\|deliverAs.*steer\|followUp\|gremlins:view" -n extensions/pi-gremlins README.md CHANGELOG.md docs/prd/0006-active-gremlin-session-steering.md docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md`.
+
+### 5. Update user-facing docs and changelog
+
+**What**
+- Add README usage documentation for `/gremlins:steer <G-id> <message>`.
+- Document lifecycle limits: only active gremlins can be steered; completed/canceled/failed/stale/disposed/setup-failed/unknown ids are rejected.
+- Document timing: SDK queues steering for the target child session after current child tool calls complete and before the next child LLM call.
+- Document `G1`/`g1` case-insensitive behavior and duplicate-id ambiguity rejection across concurrent active batches.
+- Document whitespace behavior: the id is parsed from the first non-empty token; the message is the remaining text after the id with separator whitespace normalized, while internal multi-word spacing/punctuation is preserved as sent to `AgentSession.steer(message)`.
+- Document that this is official child `AgentSession.steer(message)` support, not restored legacy subprocess/RPC/viewer steering.
+- Add an Unreleased CHANGELOG entry referencing PRD-0006, ADR-0006, and issue #53.
+
+**References**
+- `README.md`
+- `CHANGELOG.md`
+- `docs/prd/0006-active-gremlin-session-steering.md`
+- `docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md`
+
+**Acceptance criteria**
+- README contains syntax, lifecycle limits, ambiguity behavior, expected timing, whitespace/multi-word message behavior, and legacy-path distinction.
+- CHANGELOG cites PRD-0006, ADR-0006, and issue #53.
+
+**Guardrails**
+- Do not document future namespace formats unless implemented and tested.
+- Do not imply archived/completed gremlins can be steered.
+- Do not imply steering interrupts currently running child tool calls immediately.
+
+**Verification**
+- Manual readback of README and CHANGELOG diffs.
+
+### 6. Final verification, authorized commit/push, and PR
+
+**What**
+- Run focused tests first, then full repository checks.
+- Inspect the diff for forbidden mechanisms and accidental scope expansion.
+- Commit only implementation, tests, README, and CHANGELOG changes for issue #53 after verification passes.
+- Push the issue branch and create or update the PR after the commit only if verification passes and no blockers remain.
+- Prepare PR notes linking issue #53, PRD-0006, and ADR-0006.
+
+**References**
+- `package.json`
+- full repository diff
+- GitHub issue `#53`
+- `docs/prd/0006-active-gremlin-session-steering.md`
+- `docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md`
+
+**Acceptance criteria**
+- `npm run typecheck` passes.
+- `npm test` passes.
+- `npm run check` passes.
+- Diff contains no forbidden parent-message, `deliverAs`, `followUp`, subprocess/RPC, popup/viewer, or prompt-history steering path.
+- Any forbidden-mechanism grep hits are manually classified as expected docs/tests/bans or unrelated non-steering references.
+- Commit is made only after verification passes and includes no unrelated files.
+- Push and PR creation/update are performed only after the verified commit and only if no blockers remain, using the explicit `git-issue-fix` authorization.
+- PR summary explains command syntax, registry lifecycle, exact unregister/ambiguity policy, rejection handling, and verification results.
+
+**Guardrails**
+- Do not commit, push, or open/update the PR if focused tests, full checks, or manual forbidden-path inspection have unresolved failures.
+- Do not commit unrelated files.
+- Do not include generated artifacts unless already tracked and intentionally updated.
+- Do not claim manual runtime verification unless actually performed in Pi.
+
+**Verification**
+- Run:
+  - `npm run typecheck`
+  - `npm test`
+  - `npm run check`
+  - `grep -R "sendUserMessage\|deliverAs.*steer\|followUp\|gremlins:view" -n extensions/pi-gremlins README.md CHANGELOG.md docs/prd/0006-active-gremlin-session-steering.md docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md`
+- Manually inspect grep output and full diff; expected hits in docs/tests/bans do not fail verification, but forbidden implementation paths do.
+- Manual PR checklist: issue linked, PRD/ADR linked, tests listed, risks stated, push/PR performed only after passing verification.
+
+## Risks / Unknowns
+
+- **Observed:** Existing display ids are per-batch (`g1`, `g2`, ...), so concurrent batches can produce duplicate active ids. First implementation should reject ambiguous ids and use exact opaque-handle/composite-key unregister.
+- **Observed:** Existing tests explicitly assert no `gremlins:steer`; they must be narrowed to ban legacy steering only.
+- **Observed:** The local command harness stores registered command objects via `registerCommand(name, command)`; plan tests must lock the command invocation `args: string` contract before implementation behavior depends on it.
+- **Inferred:** Pi SDK may expose additional command argument shapes in future, but optional array parsing should not be added unless current tests demonstrate it.
+- **Unknown:** Whether SDK `AgentSession.steer` rejects after a child session internally starts disposing. Handler must catch errors, notify failure, and not show success or use fallback steering.
+
+## Recommended Verification Sequence
+
+1. `bun test extensions/pi-gremlins/gremlin-session-registry.test.js`
+2. `bun test extensions/pi-gremlins/gremlin-steer-command.test.js`
+3. `bun test extensions/pi-gremlins/index.execute.test.js extensions/pi-gremlins/gremlin-runner.test.js`
+4. `bun test extensions/pi-gremlins/gremlin-rendering.test.js extensions/pi-gremlins/index.render.test.js extensions/pi-gremlins/gremlin-session-factory.test.js`
+5. `npm run typecheck`
+6. `npm test`
+7. `npm run check`
+8. Manual forbidden-mechanism grep/diff classification.
+9. If and only if all verification passes with no blockers: commit, push, and create/update the PR under the user's explicit `git-issue-fix` authorization.
+
+## Self-Review Checklist
+
+- [x] Plan references PRD-0006 and ADR-0006.
+- [x] Plan keeps implementation inside `extensions/pi-gremlins/`, README, and CHANGELOG.
+- [x] Plan includes parser, registry, command registration, lifecycle cleanup, tests, docs, changelog, verification, commit, push, and PR steps.
+- [x] Plan preserves all explicit forbidden paths.
+- [x] Plan includes opaque handle/composite key exact unregister and duplicate `g1` ambiguity/unregister tests.
+- [x] Plan requires awaiting/catching `session.steer(message)` rejection with failure notification and no success/fallback.
+- [x] Plan locks the command `args: string` contract unless optional arrays are test-proven.
+- [x] Plan includes createSession-success/prompt-reject lifecycle cleanup coverage.
+- [x] Plan treats forbidden-mechanism grep as manual inspection with expected docs/test hits.
+- [x] Plan clarifies whitespace preservation/normalization for multi-word messages.
+- [x] Plan avoids speculative namespace work and chooses fail-on-ambiguous for duplicate ids.
+- [x] Plan preserves explicit `git-issue-fix` commit/push/PR authorization while making git/GitHub steps conditional on passing verification and no blockers.

--- a/docs/prd/0002-pi-gremlins-v1-sdk-rewrite.md
+++ b/docs/prd/0002-pi-gremlins-v1-sdk-rewrite.md
@@ -21,7 +21,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - Each gremlin gets its own markdown definition as child system prompt, plus caller-supplied intent and caller-supplied context as the child user prompt.
 - No full parent conversation history.
 - No chain mode.
-- No popup viewer, no `/gremlins:view`, no targeted steering command.
+- No popup viewer or `/gremlins:view`; no legacy targeted steering command. Official SDK child-session steering is governed separately by [PRD-0006](0006-active-gremlin-session-steering.md).
 - Inline progress must stay visible and expand with Pi's existing `Ctrl+O` tool-row affordance.
 
 ## Product Goals
@@ -77,7 +77,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 
 - Chain mode.
 - Popup viewer and `/gremlins:view`.
-- Targeted steering and `/gremlins:steer`.
+- Legacy targeted steering and legacy `/gremlins:steer` mechanisms. Official active child-session steering through `AgentSession.steer(message)` is governed by [PRD-0006](0006-active-gremlin-session-steering.md).
 - `agentScope`, `confirmProjectAgents`, package-agent discovery, or any user-facing scope selector.
 - Package-provided gremlin definitions.
 - Session-local viewer snapshot architecture from current implementation.
@@ -116,7 +116,7 @@ V1 rewrite must keep premise and operator value, but deliberately cut scope unti
 - **Discovery:** new modules for gremlin definition loading, frontmatter parsing, `agent_type: sub-agent` gating, both-scope resolution, and duplicate-name precedence.
 - **Child-session runtime:** new SDK-based session factory using `createAgentSession()`, in-memory session state, and custom `ResourceLoader`/system prompt override.
 - **Execution:** new scheduler and invocation controller for 1-10 gremlins, structured cancellation, event fan-in, and aggregate result handling.
-- **Rendering:** new inline collapsed/expanded renderer only; no overlay, popup, viewer snapshot, or steering UI.
+- **Rendering:** new inline collapsed/expanded renderer only; no overlay, popup, viewer snapshot, or legacy steering UI. Official command-only SDK steering is governed by [PRD-0006](0006-active-gremlin-session-steering.md).
 - **Testing:** new Bun tests beside rewritten modules; no dependency on current viewer-specific test helpers except generic Bun mocking patterns.
 - **Related ADRs:** ADR-0002 — `docs/adr/0002-in-process-sdk-based-gremlin-runtime.md`
 
@@ -161,3 +161,4 @@ Primary references used for this PRD:
 - 2026-04-22: Draft created
 - 2026-04-24: V1 request contract updated to require per-gremlin `intent` separate from `context`
 - 2026-04-25: Prompt isolation refined for issue #41 so gremlin child sessions receive selected sub-agent markdown only as system prompt; parent snapshots and primary-agent prompt blocks stay out of child sessions
+- 2026-04-30: Targeted-steering non-goal narrowed for issue #53: legacy subprocess/RPC/viewer steering remains out of scope, while official active child-session steering is governed by PRD-0006

--- a/docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md
+++ b/docs/prd/0003-primary-agent-selection-and-pi-mohawk-deprecation.md
@@ -52,7 +52,7 @@ Issue #39 asks to deprecate `pi-mohawk` by moving primary-agent functionality in
 
 - Changing the `pi-gremlins` tool schema for gremlin delegation.
 - Renaming machine-facing package, extension, tool, schema, or runtime identifiers away from `pi-gremlins`.
-- Reintroducing chain mode, popup viewer, `/gremlins:view`, targeted steering, package gremlin discovery, or scope toggles.
+- Reintroducing chain mode, popup viewer, `/gremlins:view`, legacy targeted steering, package gremlin discovery, or scope toggles. Official active child-session steering is governed separately by [PRD-0006](0006-active-gremlin-session-steering.md).
 - Editing, creating, or deleting agent markdown definitions from the extension.
 - Loading untyped, malformed, or legacy-role markdown as primary agents or gremlins.
 - Persisting raw primary-agent markdown in session entries.
@@ -136,3 +136,4 @@ Docs now describe both agent roles, migration behavior, command/status semantics
 - 2026-04-25: Marked Completed after implementation review PASS; recorded delivered primary-agent behavior and verification evidence.
 - 2026-04-25: Activated for implementation after ADR-0003 acceptance; replaced placeholder ADR references with concrete ADR link.
 - 2026-04-25: Draft created for GitHub issue #39 product scope.
+- 2026-04-30: Clarified for issue #53 that only legacy targeted steering remains out of scope; official active child-session steering is governed by PRD-0006.

--- a/docs/prd/0006-active-gremlin-session-steering.md
+++ b/docs/prd/0006-active-gremlin-session-steering.md
@@ -1,6 +1,6 @@
 # PRD-0006: Active Gremlin Session Steering
 
-- **Status:** Active
+- **Status:** Completed
 - **Date:** 2026-04-30
 - **Author:** magimetal
 - **Related:** GitHub issue [#53](https://github.com/magimetal/pi-gremlins/issues/53), [ADR-0006](../adr/0006-official-sdk-steering-for-active-gremlin-sessions.md), [PRD-0002](0002-pi-gremlins-v1-sdk-rewrite.md), [PRD-0003](0003-primary-agent-selection-and-pi-mohawk-deprecation.md)
@@ -48,21 +48,21 @@ Current governance intentionally removed targeted steering during the v1 SDK rew
 
 ## Acceptance Criteria
 
-- [ ] `/gremlins:steer <G-id> <message>` is registered through `pi.registerCommand("gremlins:steer", ...)`.
-- [ ] The command parser treats the first argument as the gremlin id and the remaining text as the steering message.
-- [ ] Missing id and missing message produce clear notifications and do not call steering.
-- [ ] Successful command handling calls the target child SDK `AgentSession.steer(message)` exactly once with the parsed message.
-- [ ] The implementation does not use parent `pi.sendUserMessage`, `deliverAs: "steer"`, `followUp`, subprocess/RPC steering, or viewer/popup UI.
-- [ ] Active child SDK sessions are registered as soon as they can be steered and are keyed in a way that can safely resolve or reject user ids.
-- [ ] Registry entries exist only during the relevant active `runSingleGremlin` lifetime and are removed on completion, failure, cancellation, abort, setup failure, disposal, and extension/session shutdown.
-- [ ] Unknown, completed, canceled, disposed, failed, aborted, setup-failed, and stale gremlin ids are rejected safely.
-- [ ] `G1`/`g1` behavior is documented and covered by tests.
-- [ ] Concurrent-batch id ambiguity is handled safely by failing ambiguous references with a clear notification or by documenting/testing a stable namespace.
-- [ ] Steering observes official Pi SDK timing and does not wait for the parent user's next turn or gremlin completion.
-- [ ] Child isolation remains intact: no parent history/system/primary-agent markdown/extensions/skills/prompts/themes/`AGENTS` leakage is introduced.
-- [ ] Existing tests/docs that currently encode "no `/gremlins:steer`" are updated to permit official SDK steering only and still ban legacy steering mechanisms.
-- [ ] User-facing docs explain syntax, lifecycle limits, ambiguity behavior, expected timing, and the distinction from removed legacy steering.
-- [ ] CHANGELOG entry for implementation references PRD-0006 and ADR-0006.
+- [x] `/gremlins:steer <G-id> <message>` is registered through `pi.registerCommand("gremlins:steer", ...)`.
+- [x] The command parser treats the first argument as the gremlin id and the remaining text as the steering message.
+- [x] Missing id and missing message produce clear notifications and do not call steering.
+- [x] Successful command handling calls the target child SDK `AgentSession.steer(message)` exactly once with the parsed message.
+- [x] The implementation does not use parent `pi.sendUserMessage`, `deliverAs: "steer"`, `followUp`, subprocess/RPC steering, or viewer/popup UI.
+- [x] Active child SDK sessions are registered as soon as they can be steered and are keyed in a way that can safely resolve or reject user ids.
+- [x] Registry entries exist only during the relevant active `runSingleGremlin` lifetime and are removed on completion, failure, cancellation, abort, setup failure, disposal, and extension/session shutdown.
+- [x] Unknown, completed, canceled, disposed, failed, aborted, setup-failed, and stale gremlin ids are rejected safely.
+- [x] `G1`/`g1` behavior is documented and covered by tests.
+- [x] Concurrent-batch id ambiguity is handled safely by failing ambiguous references with a clear notification or by documenting/testing a stable namespace.
+- [x] Steering observes official Pi SDK timing and does not wait for the parent user's next turn or gremlin completion.
+- [x] Child isolation remains intact: no parent history/system/primary-agent markdown/extensions/skills/prompts/themes/`AGENTS` leakage is introduced.
+- [x] Existing tests/docs that currently encode "no `/gremlins:steer`" are updated to permit official SDK steering only and still ban legacy steering mechanisms.
+- [x] User-facing docs explain syntax, lifecycle limits, ambiguity behavior, expected timing, and the distinction from removed legacy steering.
+- [x] CHANGELOG entry for implementation references PRD-0006 and ADR-0006.
 
 ## Technical Surface
 
@@ -83,11 +83,12 @@ Current governance intentionally removed targeted steering during the v1 SDK rew
 - Ambiguity across concurrent batches should fail safe unless a namespaced id is made visible to users.
 - The visible gremlin id format should stay aligned with existing inline rendering (`g1`, `g2`, ...), with casing behavior explicitly documented.
 
-## Open Questions
+## Resolved Questions
 
-- Should concurrent batches expose a stable namespace such as `toolCallId:g1`, or is fail-on-ambiguous `g1` enough for the first implementation?
-- Should command success notifications include the gremlin display name/agent name in addition to the id?
+- Concurrent batches use fail-on-ambiguous `g1` behavior for the first implementation; no user-visible `toolCallId:g1` namespace was added.
+- Command success remains concise and id-based; no additional display-name/agent-name requirement was added.
 
 ## Revision History
 
 - 2026-04-30: Active PRD created for issue #53; supersedes only the prior targeted-steering non-goal for official SDK child-session steering.
+- 2026-04-30: Marked Completed after implementation commit `f1e77d6b5eb1e82372c916cebb92a21e9dfd5b18`, PR [#55](https://github.com/magimetal/pi-gremlins/pull/55), and passing execution review.

--- a/docs/prd/0006-active-gremlin-session-steering.md
+++ b/docs/prd/0006-active-gremlin-session-steering.md
@@ -1,0 +1,93 @@
+# PRD-0006: Active Gremlin Session Steering
+
+- **Status:** Active
+- **Date:** 2026-04-30
+- **Author:** magimetal
+- **Related:** GitHub issue [#53](https://github.com/magimetal/pi-gremlins/issues/53), [ADR-0006](../adr/0006-official-sdk-steering-for-active-gremlin-sessions.md), [PRD-0002](0002-pi-gremlins-v1-sdk-rewrite.md), [PRD-0003](0003-primary-agent-selection-and-pi-mohawk-deprecation.md)
+- **Supersedes:** PRD-0002 and PRD-0003 targeted-steering non-goal only. Legacy subprocess/RPC/viewer steering remains out of scope.
+
+## Problem Statement
+
+Pi SDK now exposes first-class child `AgentSession.steer(message)` support. `pi-gremlins` already runs gremlins as isolated in-process SDK child sessions, but it has no supported way for an operator to steer an active gremlin while that child session is still running.
+
+Current governance intentionally removed targeted steering during the v1 SDK rewrite because the old implementation was tied to subprocess/RPC and popup-viewer machinery. Issue #53 asks to add steering back through the official SDK API, not through legacy mechanisms. Product scope must therefore reopen steering for active child SDK sessions while preserving the v1 bans on subprocess steering, viewer UI, `followUp`, parent-message injection, chain mode, and prompt isolation leaks.
+
+## User Stories
+
+- As an operator, I want `/gremlins:steer <G-id> <message>` so that I can redirect an active gremlin without waiting for a later parent turn.
+- As an operator running parallel gremlins, I want invalid, stale, completed, or ambiguous ids rejected clearly so that steering goes only to the intended child session.
+- As a maintainer, I want steering implemented through official child `AgentSession.steer(message)` so that no legacy subprocess/RPC/viewer steering path returns.
+- As a cautious user, I want gremlin prompt isolation preserved so that steering does not leak parent history, primary-agent markdown, extensions, skills, prompts, themes, or `AGENTS` content into child sessions.
+
+## Scope
+
+### In Scope
+
+- Register `/gremlins:steer <G-id> <message>` through `pi.registerCommand("gremlins:steer", ...)`.
+- Parse the first argument as the gremlin id and the remaining text as the steering message.
+- Preserve multi-word steering messages exactly after the id.
+- Show clear notifications for missing id, missing message, unknown id, inactive id, stale id, disposed session, completed gremlin, canceled gremlin, failed gremlin, aborted gremlin, setup-failed gremlin, or ambiguous id.
+- Accept `G1` and `g1` case-insensitively unless implementation explicitly documents and tests a stricter casing policy.
+- Track active child SDK `AgentSession`s only for the lifetime in which a gremlin can be steered.
+- Deregister sessions promptly on normal completion, failure, cancellation, abort, setup failure, disposal, and extension/session shutdown.
+- Handle concurrent-batch `g1` ambiguity safely by failing ambiguous references with a clear notification, unless implementation chooses and documents a stable namespace such as `toolCallId`.
+- Invoke the target child session's `AgentSession.steer(message)` directly on successful command handling.
+- Rely on official SDK steering timing: queued after the current child assistant turn finishes current tool calls and before the next child LLM call.
+- Update tests and docs that previously asserted no `/gremlins:steer` support so they now describe official SDK steering and still reject legacy steering mechanisms.
+
+### Out of Scope
+
+- Reintroducing legacy subprocess/RPC steering.
+- Reintroducing popup viewer UI, `/gremlins:view`, viewer snapshots, or steering controls inside a viewer surface.
+- Steering through parent `pi.sendUserMessage`, `deliverAs: "steer"`, `followUp`, parent transcript mutation, or a later parent user turn.
+- Chain mode, package-agent discovery, scope toggles, or old multi-mode tool schemas.
+- Cross-session steering, steering completed gremlins, steering archived gremlin results, or retaining stale sessions after a run ends.
+- Persisting steering messages or active session registry state beyond the active runtime lifetime.
+- Relaxing child isolation or loading parent extensions, prompts, skills, themes, `AGENTS` files, parent system prompt snapshots, primary-agent markdown, or parent conversation history into child sessions.
+- Adding decorative popup/overlay UX for steering confirmation.
+
+## Acceptance Criteria
+
+- [ ] `/gremlins:steer <G-id> <message>` is registered through `pi.registerCommand("gremlins:steer", ...)`.
+- [ ] The command parser treats the first argument as the gremlin id and the remaining text as the steering message.
+- [ ] Missing id and missing message produce clear notifications and do not call steering.
+- [ ] Successful command handling calls the target child SDK `AgentSession.steer(message)` exactly once with the parsed message.
+- [ ] The implementation does not use parent `pi.sendUserMessage`, `deliverAs: "steer"`, `followUp`, subprocess/RPC steering, or viewer/popup UI.
+- [ ] Active child SDK sessions are registered as soon as they can be steered and are keyed in a way that can safely resolve or reject user ids.
+- [ ] Registry entries exist only during the relevant active `runSingleGremlin` lifetime and are removed on completion, failure, cancellation, abort, setup failure, disposal, and extension/session shutdown.
+- [ ] Unknown, completed, canceled, disposed, failed, aborted, setup-failed, and stale gremlin ids are rejected safely.
+- [ ] `G1`/`g1` behavior is documented and covered by tests.
+- [ ] Concurrent-batch id ambiguity is handled safely by failing ambiguous references with a clear notification or by documenting/testing a stable namespace.
+- [ ] Steering observes official Pi SDK timing and does not wait for the parent user's next turn or gremlin completion.
+- [ ] Child isolation remains intact: no parent history/system/primary-agent markdown/extensions/skills/prompts/themes/`AGENTS` leakage is introduced.
+- [ ] Existing tests/docs that currently encode "no `/gremlins:steer`" are updated to permit official SDK steering only and still ban legacy steering mechanisms.
+- [ ] User-facing docs explain syntax, lifecycle limits, ambiguity behavior, expected timing, and the distinction from removed legacy steering.
+- [ ] CHANGELOG entry for implementation references PRD-0006 and ADR-0006.
+
+## Technical Surface
+
+- **Extension entry:** `extensions/pi-gremlins/index.ts` registers `gremlins:steer` beside the existing tool and primary-agent controls.
+- **Command handler:** new focused module such as `extensions/pi-gremlins/gremlin-steer-command.ts` for parsing, validation, notifications, and direct `AgentSession.steer(message)` invocation.
+- **Active session registry:** new focused module such as `extensions/pi-gremlins/gremlin-session-registry.ts` to register active child sessions, resolve ids, reject stale/ambiguous references, and clean up lifecycle state.
+- **Runner/scheduler/tool execution:** `extensions/pi-gremlins/gremlin-runner.ts`, `gremlin-scheduler.ts`, and `gremlin-tool-execution.ts` integrate registry registration and cleanup without changing the public tool schema.
+- **Session factory:** `extensions/pi-gremlins/gremlin-session-factory.ts` remains responsible for isolated child session construction; steering must not weaken its resource-loader boundaries.
+- **Docs:** README and CHANGELOG need implementation-phase updates; governance links are [ADR-0006](../adr/0006-official-sdk-steering-for-active-gremlin-sessions.md) and this PRD.
+- **Related ADRs:** [ADR-0006](../adr/0006-official-sdk-steering-for-active-gremlin-sessions.md).
+
+## UX Notes
+
+- Command syntax is terse: `/gremlins:steer <G-id> <message>`.
+- Confirmation should be inline/notification-based, not popup-based.
+- Error copy should distinguish malformed usage from inactive/stale/ambiguous gremlin ids.
+- Steering should be described as queued by the SDK for the target child session's next LLM boundary, not as an immediate tool interruption.
+- Ambiguity across concurrent batches should fail safe unless a namespaced id is made visible to users.
+- The visible gremlin id format should stay aligned with existing inline rendering (`g1`, `g2`, ...), with casing behavior explicitly documented.
+
+## Open Questions
+
+- Should concurrent batches expose a stable namespace such as `toolCallId:g1`, or is fail-on-ambiguous `g1` enough for the first implementation?
+- Should command success notifications include the gremlin display name/agent name in addition to the id?
+
+## Revision History
+
+- 2026-04-30: Active PRD created for issue #53; supersedes only the prior targeted-steering non-goal for official SDK child-session steering.

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -88,4 +88,4 @@ Maintain in `docs/prd/README.md`:
 | 0003 | Primary Agent Selection and pi-mohawk Deprecation         | Completed | 2026-04-25 |
 | 0004 | Pi Gremlins Side-Chat Absorption and pi-gizmo Deprecation | Completed | 2026-04-29 |
 | 0005 | Persistent Overlay Side-Chat                            | Completed | 2026-04-30 |
-| 0006 | Active Gremlin Session Steering                         | Active | 2026-04-30 |
+| 0006 | Active Gremlin Session Steering                         | Completed | 2026-04-30 |

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -88,3 +88,4 @@ Maintain in `docs/prd/README.md`:
 | 0003 | Primary Agent Selection and pi-mohawk Deprecation         | Completed | 2026-04-25 |
 | 0004 | Pi Gremlins Side-Chat Absorption and pi-gizmo Deprecation | Completed | 2026-04-29 |
 | 0005 | Persistent Overlay Side-Chat                            | Completed | 2026-04-30 |
+| 0006 | Active Gremlin Session Steering                         | Active | 2026-04-30 |

--- a/extensions/pi-gremlins/gremlin-runner.test.js
+++ b/extensions/pi-gremlins/gremlin-runner.test.js
@@ -447,4 +447,59 @@ describe("gremlin runner v1 contract", () => {
 		expect(fake.getDisposedCount()).toBe(1);
 		expect(events).toEqual(["abort", "dispose"]);
 	});
+
+	test("registers session before prompt and unregisters exact handle before dispose after prompt rejection", async () => {
+		const { runSingleGremlin } = await import("./gremlin-runner.ts");
+		const events = [];
+		const fake = createFakeSession({
+			onPrompt: async () => {
+				events.push("prompt");
+				throw new Error("prompt rejected");
+			},
+		});
+		const originalDispose = fake.session.dispose;
+		fake.session.dispose = () => {
+			events.push("dispose");
+			originalDispose();
+		};
+		const handle = Symbol("active");
+		const registry = {
+			registerActiveGremlinSession(entry) {
+				events.push(`register:${entry.gremlinId}:${entry.toolCallId}:${entry.agent}:${entry.session === fake.session}`);
+				return handle;
+			},
+			unregisterActiveGremlinSession(receivedHandle) {
+				events.push(`unregister:${receivedHandle === handle}`);
+				return true;
+			},
+			resolveActiveGremlinSession() {
+				return { status: "missing" };
+			},
+			clearActiveGremlinSessions() {},
+		};
+
+		const result = await runSingleGremlin({
+			gremlinId: "g1",
+			toolCallId: "tool-123",
+			activeSessionRegistry: registry,
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
+			definition: {
+				name: "researcher",
+				source: "project",
+				filePath: "/tmp/researcher.md",
+				rawMarkdown: "---\nname: researcher\n---\nraw gremlin body",
+				frontmatter: {},
+			},
+			createSession: async () => fake,
+		});
+
+		expect(result.status).toBe("failed");
+		expect(result.errorMessage).toBe("prompt rejected");
+		expect(events).toEqual([
+			"register:g1:tool-123:researcher:true",
+			"prompt",
+			"unregister:true",
+			"dispose",
+		]);
+	});
 });

--- a/extensions/pi-gremlins/gremlin-runner.ts
+++ b/extensions/pi-gremlins/gremlin-runner.ts
@@ -15,6 +15,10 @@ import type {
 	GremlinRunResult,
 	GremlinUsage,
 } from "./gremlin-schema.js";
+import type {
+	ActiveGremlinSessionHandle,
+	ActiveGremlinSessionRegistry,
+} from "./gremlin-session-registry.js";
 
 export interface GremlinRunnerUpdate {
 	gremlinId: string;
@@ -48,6 +52,7 @@ interface GremlinEvent {
 type GremlinSession = CreateAgentSessionResult["session"] & {
 	subscribe?: (listener: (event: GremlinEvent) => void) => () => void;
 	prompt: (text: string) => Promise<void>;
+	steer: (message: string) => Promise<unknown> | unknown;
 	abort?: () => Promise<void>;
 	dispose: () => void;
 	getContextUsage?: () => { tokens: number | null } | undefined;
@@ -65,6 +70,7 @@ interface TextDeltaPublisher {
 
 export interface RunSingleGremlinOptions {
 	gremlinId: string;
+	toolCallId?: string;
 	request: GremlinRequest;
 	definition: GremlinDefinition;
 	parentModel?: string | Model<any>;
@@ -72,6 +78,7 @@ export interface RunSingleGremlinOptions {
 	modelRegistry?: ModelRegistry;
 	signal?: AbortSignal;
 	onUpdate?: (update: GremlinRunnerUpdate) => void;
+	activeSessionRegistry?: ActiveGremlinSessionRegistry;
 	createSession?: (
 		options: Parameters<typeof createGremlinSession>[0],
 	) => Promise<CreateAgentSessionResult>;
@@ -349,10 +356,12 @@ export async function runSingleGremlin({
 	request,
 	definition,
 	parentModel,
+	toolCallId = "unknown-tool-call",
 	parentThinking,
 	modelRegistry,
 	signal,
 	onUpdate,
+	activeSessionRegistry,
 	createSession = createGremlinSession,
 }: RunSingleGremlinOptions): Promise<GremlinRunResult> {
 	const state = buildBaseResult(gremlinId, request, definition);
@@ -404,6 +413,7 @@ export async function runSingleGremlin({
 	}
 
 	let session: GremlinSession | undefined;
+	let activeSessionHandle: ActiveGremlinSessionHandle | undefined;
 	let unsubscribe: (() => void) | undefined;
 	let abortPromise: Promise<void> | undefined;
 	let abortError: unknown;
@@ -440,6 +450,12 @@ export async function runSingleGremlin({
 			modelRegistry,
 		});
 		session = created.session as GremlinSession;
+		activeSessionHandle = activeSessionRegistry?.registerActiveGremlinSession({
+			gremlinId,
+			toolCallId,
+			agent: request.agent,
+			session,
+		});
 		unsubscribe = session.subscribe?.((event: GremlinEvent) => {
 			projectGremlinEvent(event, state, session, publish, textDeltaPublisher);
 		});
@@ -469,6 +485,10 @@ export async function runSingleGremlin({
 	} finally {
 		signal?.removeEventListener("abort", abortListener);
 		unsubscribe?.();
+		if (activeSessionHandle) {
+			activeSessionRegistry?.unregisterActiveGremlinSession(activeSessionHandle);
+			activeSessionHandle = undefined;
+		}
 		await abortPromise;
 		if (abortError && !state.errorMessage) {
 			publish({

--- a/extensions/pi-gremlins/gremlin-session-registry.test.js
+++ b/extensions/pi-gremlins/gremlin-session-registry.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+function createSession() {
+	return { async steer() {} };
+}
+
+describe("active gremlin session registry", () => {
+	test("registers, resolves case-insensitively, unregisters exactly, and clears", async () => {
+		const { createActiveGremlinSessionRegistry } = await import("./gremlin-session-registry.ts");
+		const registry = createActiveGremlinSessionRegistry();
+		const session = createSession();
+
+		const handle = registry.registerActiveGremlinSession({
+			gremlinId: "g1",
+			toolCallId: "call-a",
+			agent: "researcher",
+			session,
+		});
+
+		expect(registry.resolveActiveGremlinSession("G1")).toMatchObject({
+			status: "active",
+			entry: { gremlinId: "g1", normalizedGremlinId: "g1", toolCallId: "call-a", agent: "researcher", session },
+		});
+		expect(registry.unregisterActiveGremlinSession(handle)).toBe(true);
+		expect(registry.unregisterActiveGremlinSession(handle)).toBe(false);
+		expect(registry.resolveActiveGremlinSession("g1")).toEqual({ status: "missing" });
+
+		registry.registerActiveGremlinSession({ gremlinId: "g2", toolCallId: "call-b", agent: "reviewer", session: createSession() });
+		expect(registry.resolveActiveGremlinSession("g2").status).toBe("active");
+		registry.clearActiveGremlinSessions();
+		expect(registry.resolveActiveGremlinSession("g2")).toEqual({ status: "missing" });
+	});
+
+	test("duplicate display ids are ambiguous and exact unregister leaves the remaining session active", async () => {
+		const { createActiveGremlinSessionRegistry } = await import("./gremlin-session-registry.ts");
+		const registry = createActiveGremlinSessionRegistry();
+		const firstSession = createSession();
+		const secondSession = createSession();
+		const firstHandle = registry.registerActiveGremlinSession({
+			gremlinId: "g1",
+			toolCallId: "call-a",
+			agent: "researcher",
+			session: firstSession,
+		});
+		const secondHandle = registry.registerActiveGremlinSession({
+			gremlinId: "G1",
+			toolCallId: "call-b",
+			agent: "reviewer",
+			session: secondSession,
+		});
+
+		const ambiguous = registry.resolveActiveGremlinSession("g1");
+		expect(ambiguous.status).toBe("ambiguous");
+		expect(ambiguous.matches).toHaveLength(2);
+
+		expect(registry.unregisterActiveGremlinSession(firstHandle)).toBe(true);
+		expect(registry.resolveActiveGremlinSession("g1")).toMatchObject({
+			status: "active",
+			entry: { gremlinId: "G1", toolCallId: "call-b", session: secondSession },
+		});
+		expect(registry.unregisterActiveGremlinSession(secondHandle)).toBe(true);
+		expect(registry.resolveActiveGremlinSession("g1")).toEqual({ status: "missing" });
+	});
+
+	test("unknown and blank ids fail closed", async () => {
+		const { createActiveGremlinSessionRegistry } = await import("./gremlin-session-registry.ts");
+		const registry = createActiveGremlinSessionRegistry();
+		registry.registerActiveGremlinSession({ gremlinId: "g1", toolCallId: "call-a", agent: "researcher", session: createSession() });
+		expect(registry.resolveActiveGremlinSession("g9")).toEqual({ status: "missing" });
+		expect(registry.resolveActiveGremlinSession("   ")).toEqual({ status: "missing" });
+	});
+});

--- a/extensions/pi-gremlins/gremlin-session-registry.ts
+++ b/extensions/pi-gremlins/gremlin-session-registry.ts
@@ -1,0 +1,71 @@
+export interface SteerableGremlinSession {
+	steer(message: string): Promise<unknown> | unknown;
+}
+
+export interface ActiveGremlinSessionEntry {
+	readonly gremlinId: string;
+	readonly normalizedGremlinId: string;
+	readonly toolCallId: string;
+	readonly agent: string;
+	readonly session: SteerableGremlinSession;
+}
+
+export type ActiveGremlinSessionHandle = symbol;
+
+export type ResolveActiveGremlinSessionResult =
+	| { status: "missing" }
+	| { status: "ambiguous"; matches: readonly ActiveGremlinSessionEntry[] }
+	| { status: "active"; entry: ActiveGremlinSessionEntry };
+
+export interface ActiveGremlinSessionRegistry {
+	registerActiveGremlinSession(entry: {
+		gremlinId: string;
+		toolCallId: string;
+		agent: string;
+		session: SteerableGremlinSession;
+	}): ActiveGremlinSessionHandle;
+	unregisterActiveGremlinSession(handle: ActiveGremlinSessionHandle): boolean;
+	resolveActiveGremlinSession(gremlinId: string): ResolveActiveGremlinSessionResult;
+	clearActiveGremlinSessions(): void;
+}
+
+function normalizeGremlinId(gremlinId: string): string {
+	return gremlinId.trim().toLowerCase();
+}
+
+export function createActiveGremlinSessionRegistry(): ActiveGremlinSessionRegistry {
+	const entries = new Map<ActiveGremlinSessionHandle, ActiveGremlinSessionEntry>();
+
+	return {
+		registerActiveGremlinSession(entry) {
+			const handle = Symbol(`pi-gremlins:${entry.toolCallId}:${entry.gremlinId}`);
+			entries.set(handle, {
+				gremlinId: entry.gremlinId,
+				normalizedGremlinId: normalizeGremlinId(entry.gremlinId),
+				toolCallId: entry.toolCallId,
+				agent: entry.agent,
+				session: entry.session,
+			});
+			return handle;
+		},
+
+		unregisterActiveGremlinSession(handle) {
+			return entries.delete(handle);
+		},
+
+		resolveActiveGremlinSession(gremlinId) {
+			const normalizedGremlinId = normalizeGremlinId(gremlinId);
+			if (!normalizedGremlinId) return { status: "missing" };
+			const matches = [...entries.values()].filter(
+				(entry) => entry.normalizedGremlinId === normalizedGremlinId,
+			);
+			if (matches.length === 0) return { status: "missing" };
+			if (matches.length > 1) return { status: "ambiguous", matches };
+			return { status: "active", entry: matches[0]! };
+		},
+
+		clearActiveGremlinSessions() {
+			entries.clear();
+		},
+	};
+}

--- a/extensions/pi-gremlins/gremlin-steer-command.test.js
+++ b/extensions/pi-gremlins/gremlin-steer-command.test.js
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+
+function createCtx() {
+	const notifications = [];
+	return {
+		notifications,
+		ui: {
+			notify(message, type = "info") {
+				notifications.push({ message, type });
+			},
+		},
+	};
+}
+
+function createRegistry(resolveResult) {
+	return {
+		resolveCalls: [],
+		resolveActiveGremlinSession(gremlinId) {
+			this.resolveCalls.push(gremlinId);
+			return typeof resolveResult === "function" ? resolveResult(gremlinId) : resolveResult;
+		},
+		registerActiveGremlinSession() {
+			throw new Error("not used");
+		},
+		unregisterActiveGremlinSession() {
+			throw new Error("not used");
+		},
+		clearActiveGremlinSessions() {},
+	};
+}
+
+describe("gremlin steer command", () => {
+	test("parses string args, first non-empty token as id, and preserves message body", async () => {
+		const { parseGremlinSteerArgs } = await import("./gremlin-steer-command.ts");
+		expect(parseGremlinSteerArgs("  G1   keep investigating auth  flow!  ")).toEqual({
+			ok: true,
+			value: { gremlinId: "G1", message: "keep investigating auth  flow!  " },
+		});
+		expect(parseGremlinSteerArgs("")).toEqual({ ok: false, reason: "missing-id" });
+		expect(parseGremlinSteerArgs("g1   \t  ")).toEqual({ ok: false, reason: "missing-message" });
+	});
+
+	test("missing id and message notify without resolving or steering", async () => {
+		const { createGremlinSteerCommandHandler } = await import("./gremlin-steer-command.ts");
+		const registry = createRegistry({ status: "missing" });
+		const handler = createGremlinSteerCommandHandler(registry);
+		const missingIdCtx = createCtx();
+		await handler("", missingIdCtx);
+		const missingMessageCtx = createCtx();
+		await handler("g1", missingMessageCtx);
+
+		expect(registry.resolveCalls).toEqual([]);
+		expect(missingIdCtx.notifications[0]).toMatchObject({ type: "warning" });
+		expect(missingIdCtx.notifications[0].message).toContain("Usage: /gremlins:steer <G-id> <message>");
+		expect(missingMessageCtx.notifications[0]).toMatchObject({ type: "warning" });
+		expect(missingMessageCtx.notifications[0].message).toContain("steering message");
+	});
+
+	test("unknown and ambiguous ids fail closed without calling steer", async () => {
+		const { createGremlinSteerCommandHandler } = await import("./gremlin-steer-command.ts");
+		let steerCalls = 0;
+		const unknownCtx = createCtx();
+		await createGremlinSteerCommandHandler(createRegistry({ status: "missing" }))("G1 investigate", unknownCtx);
+		expect(unknownCtx.notifications[0]).toMatchObject({ type: "warning" });
+		expect(unknownCtx.notifications[0].message).toContain("No active gremlin found for G1");
+
+		const ambiguousCtx = createCtx();
+		await createGremlinSteerCommandHandler(createRegistry({ status: "ambiguous", matches: [{}, {}] }))("g1 investigate", ambiguousCtx);
+		expect(ambiguousCtx.notifications[0]).toMatchObject({ type: "warning" });
+		expect(ambiguousCtx.notifications[0].message).toContain("Ambiguous active gremlin id g1");
+		expect(steerCalls).toBe(0);
+	});
+
+	test("awaits child session steer exactly once, then notifies success", async () => {
+		const { createGremlinSteerCommandHandler } = await import("./gremlin-steer-command.ts");
+		const order = [];
+		const steerMessages = [];
+		let resolveSteer;
+		const steerPromise = new Promise((resolve) => {
+			resolveSteer = resolve;
+		});
+		const registry = createRegistry({
+			status: "active",
+			entry: {
+				gremlinId: "g1",
+				agent: "researcher",
+				session: {
+					async steer(message) {
+						steerMessages.push(message);
+						order.push("steer-start");
+						await steerPromise;
+						order.push("steer-end");
+					},
+				},
+			},
+		});
+		const ctx = createCtx();
+		const promise = createGremlinSteerCommandHandler(registry)("G1 keep investigating auth flow", ctx);
+		await Promise.resolve();
+		expect(ctx.notifications).toEqual([]);
+		resolveSteer();
+		await promise;
+
+		expect(steerMessages).toEqual(["keep investigating auth flow"]);
+		expect(order).toEqual(["steer-start", "steer-end"]);
+		expect(ctx.notifications).toEqual([{ message: "Steering queued for g1 (researcher).", type: "info" }]);
+	});
+
+	test("steer rejection notifies failure with no success", async () => {
+		const { createGremlinSteerCommandHandler } = await import("./gremlin-steer-command.ts");
+		const registry = createRegistry({
+			status: "active",
+			entry: {
+				gremlinId: "g1",
+				agent: "researcher",
+				session: {
+					async steer() {
+						throw new Error("disposed");
+					},
+				},
+			},
+		});
+		const ctx = createCtx();
+		await createGremlinSteerCommandHandler(registry)("g1 continue", ctx);
+		expect(ctx.notifications).toEqual([{ message: "Failed to steer g1 (researcher): disposed", type: "error" }]);
+	});
+});

--- a/extensions/pi-gremlins/gremlin-steer-command.ts
+++ b/extensions/pi-gremlins/gremlin-steer-command.ts
@@ -1,0 +1,74 @@
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ActiveGremlinSessionRegistry } from "./gremlin-session-registry.js";
+
+export const GREMLIN_STEER_COMMAND = "gremlins:steer";
+
+export interface ParsedGremlinSteerArgs {
+	gremlinId: string;
+	message: string;
+}
+
+export type ParseGremlinSteerArgsResult =
+	| { ok: true; value: ParsedGremlinSteerArgs }
+	| { ok: false; reason: "missing-id" | "missing-message" };
+
+export function parseGremlinSteerArgs(args: string): ParseGremlinSteerArgsResult {
+	const raw = typeof args === "string" ? args : "";
+	const leadingTrimmed = raw.replace(/^\s+/, "");
+	if (!leadingTrimmed) return { ok: false, reason: "missing-id" };
+	const idMatch = /^(\S+)/.exec(leadingTrimmed);
+	const gremlinId = idMatch?.[1] ?? "";
+	if (!gremlinId) return { ok: false, reason: "missing-id" };
+	const remainder = leadingTrimmed.slice(gremlinId.length).replace(/^\s+/, "");
+	if (!remainder.trim()) return { ok: false, reason: "missing-message" };
+	return { ok: true, value: { gremlinId, message: remainder } };
+}
+
+export function createGremlinSteerCommandHandler(
+	registry: ActiveGremlinSessionRegistry,
+): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
+	return async (args, ctx) => {
+		const parsed = parseGremlinSteerArgs(args);
+		if (parsed.ok === false) {
+			const usage = "Usage: /gremlins:steer <G-id> <message>";
+			ctx.ui?.notify?.(
+				parsed.reason === "missing-id"
+					? `${usage}. Provide an active gremlin id such as G1.`
+					: `${usage}. Provide a steering message for the active gremlin.`,
+				"warning",
+			);
+			return;
+		}
+
+		const { gremlinId, message } = parsed.value;
+		const resolved = registry.resolveActiveGremlinSession(gremlinId);
+		if (resolved.status === "missing") {
+			ctx.ui?.notify?.(
+				`No active gremlin found for ${gremlinId}. Completed, canceled, failed, setup-failed, stale, or disposed gremlins cannot be steered.`,
+				"warning",
+			);
+			return;
+		}
+		if (resolved.status === "ambiguous") {
+			ctx.ui?.notify?.(
+				`Ambiguous active gremlin id ${gremlinId}; ${resolved.matches.length} active sessions share that id. Wait for one run to finish, then try again.`,
+				"warning",
+			);
+			return;
+		}
+
+		try {
+			await resolved.entry.session.steer(message);
+			ctx.ui?.notify?.(
+				`Steering queued for ${resolved.entry.gremlinId} (${resolved.entry.agent}).`,
+				"info",
+			);
+		} catch (error) {
+			const messageText = error instanceof Error ? error.message : String(error);
+			ctx.ui?.notify?.(
+				`Failed to steer ${resolved.entry.gremlinId} (${resolved.entry.agent}): ${messageText}`,
+				"error",
+			);
+		}
+	};
+}

--- a/extensions/pi-gremlins/gremlin-tool-execution.ts
+++ b/extensions/pi-gremlins/gremlin-tool-execution.ts
@@ -17,6 +17,7 @@ import type {
 	GremlinRunResult,
 } from "./gremlin-schema.js";
 import { runGremlinBatch } from "./gremlin-scheduler.js";
+import type { ActiveGremlinSessionRegistry } from "./gremlin-session-registry.js";
 import { buildGremlinProgressSummary } from "./gremlin-summary.js";
 
 export type PiGremlinsArgs = { gremlins: GremlinRequest[] };
@@ -25,11 +26,13 @@ type PiGremlinsToolResult = AgentToolResult<GremlinInvocationDetails> & {
 };
 
 export interface ExecutePiGremlinsToolOptions {
+	toolCallId: string;
 	params: PiGremlinsArgs;
 	signal?: AbortSignal;
 	onUpdate?: AgentToolUpdateCallback<GremlinInvocationDetails>;
 	ctx: ExtensionContext;
 	discovery: GremlinDiscoveryCache;
+	activeSessionRegistry?: ActiveGremlinSessionRegistry;
 	notifyDiagnostics: (diagnostics: AgentDiscoveryDiagnostic[]) => void;
 }
 
@@ -128,11 +131,13 @@ function buildModelVisibleContent(
 }
 
 export async function executePiGremlinsTool({
+	toolCallId,
 	params,
 	signal,
 	onUpdate,
 	ctx,
 	discovery,
+	activeSessionRegistry,
 	notifyDiagnostics,
 }: ExecutePiGremlinsToolOptions): Promise<PiGremlinsToolResult> {
 	if (!Array.isArray(params.gremlins) || params.gremlins.length === 0) {
@@ -180,11 +185,13 @@ export async function executePiGremlinsTool({
 
 			return runSingleGremlin({
 				gremlinId,
+				toolCallId,
 				request,
 				definition: gremlin,
 				parentModel: ctx.model,
 				modelRegistry: ctx.modelRegistry,
 				signal: childSignal,
+				activeSessionRegistry,
 				onUpdate: ({ patch }) => publishUpdate?.(patch),
 			});
 		},

--- a/extensions/pi-gremlins/index.execute.test.js
+++ b/extensions/pi-gremlins/index.execute.test.js
@@ -35,18 +35,18 @@ describe("pi-gremlins index execute v1", () => {
 		resetV1ContractHarness();
 	});
 
-	test("registers tool plus primary-agent compatibility command with no legacy viewer or steering commands", () => {
+	test("registers tool plus primary-agent compatibility commands with official steering but no legacy viewer", () => {
 		const { tool, commands, shortcuts } = createExtensionHarness();
 
 		expect(tool.name).toBe("pi-gremlins");
-		expect(commands.size).toBe(5);
+		expect(commands.size).toBe(6);
 		expect(commands.has("gremlins:primary")).toBe(true);
+		expect(commands.has("gremlins:steer")).toBe(true);
 		expect(commands.has("gremlins:chat")).toBe(true);
 		expect(commands.has("gremlins:chat:new")).toBe(true);
 		expect(commands.has("gremlins:tangent")).toBe(true);
 		expect(commands.has("gremlins:tangent:new")).toBe(true);
 		expect(commands.has("gremlins:view")).toBe(false);
-		expect(commands.has("gremlins:steer")).toBe(false);
 		expect(Array.from(shortcuts.keys()).sort()).toEqual(["alt+/", "ctrl+shift+m"]);
 	});
 
@@ -447,5 +447,62 @@ describe("pi-gremlins index execute v1", () => {
 			model: "openai/missing",
 			errorMessage: "Unknown gremlin model: openai/missing",
 		});
+	});
+
+	test("steers only the active child session during its run and rejects stale ids after cleanup", async () => {
+		const workspace = createWorkspace();
+		setMockAgentDir(workspace.userRoot);
+		const { tool, commands, handlers } = createExtensionHarness();
+		writeGremlinFile(workspace.userAgentsDir, "researcher.md", "researcher", "model: openai/gpt-5-mini\n");
+
+		let finishPrompt;
+		const steerMessages = [];
+		setCreateAgentSessionImpl(async () => ({
+			session: {
+				subscribe: () => () => {},
+				async prompt() {
+					await new Promise((resolve) => {
+						finishPrompt = resolve;
+					});
+				},
+				async steer(message) {
+					steerMessages.push(message);
+				},
+				async abort() {},
+				dispose() {},
+			},
+			extensionsResult: {},
+		}));
+
+		const notifications = [];
+		const ctx = createExecutionContext(workspace.repoRoot);
+		ctx.ui.notify = (message, type = "info") => notifications.push({ message, type });
+		const executePromise = tool.execute(
+			"active-steer-run",
+			{ gremlins: [{ intent: "Map auth behavior", agent: "researcher", context: "Find auth flow" }] },
+			undefined,
+			undefined,
+			ctx,
+		);
+		for (let attempts = 0; !finishPrompt && attempts < 50; attempts += 1) {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+		expect(finishPrompt).toBeFunction();
+
+		await commands.get("gremlins:steer").handler("G1 keep investigating auth flow", ctx);
+		expect(steerMessages).toEqual(["keep investigating auth flow"]);
+		expect(notifications).toContainEqual({ message: "Steering queued for g1 (researcher).", type: "info" });
+
+		handlers.get("session_shutdown")();
+		await commands.get("gremlins:steer").handler("G1 after shutdown", ctx);
+		expect(steerMessages).toEqual(["keep investigating auth flow"]);
+		expect(notifications.at(-1)).toMatchObject({ type: "warning" });
+
+		finishPrompt();
+		await executePromise;
+		await commands.get("gremlins:steer").handler("g1 stale message", ctx);
+		expect(steerMessages).toEqual(["keep investigating auth flow"]);
+		expect(notifications.at(-1)).toMatchObject({ type: "warning" });
+		expect(notifications.at(-1).message).toContain("No active gremlin found for g1");
 	});
 });

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -29,6 +29,11 @@ import {
 	normalizeInvocationDetails,
 	type PiGremlinsArgs,
 } from "./gremlin-tool-execution.js";
+import { createActiveGremlinSessionRegistry } from "./gremlin-session-registry.js";
+import {
+	createGremlinSteerCommandHandler,
+	GREMLIN_STEER_COMMAND,
+} from "./gremlin-steer-command.js";
 import {
 	cyclePrimaryAgent,
 	notifyPrimaryAgent,
@@ -101,6 +106,7 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 				userAgentsDir: agentsDir,
 			});
 		let primaryAgentState: PrimaryAgentState = createInitialPrimaryAgentState();
+		const activeSessionRegistry = createActiveGremlinSessionRegistry();
 
 		registerSideChatCommands(pi);
 
@@ -137,6 +143,7 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 		pi.on("session_shutdown", () => {
 			discovery.clear();
 			primaryAgentDiscovery.clear();
+			activeSessionRegistry.clearActiveGremlinSessions();
 		});
 
 		pi.registerCommand("gremlins:primary", {
@@ -150,6 +157,11 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 					args,
 				);
 			},
+		});
+
+		pi.registerCommand(GREMLIN_STEER_COMMAND, {
+			description: "Steer an active gremlin child session",
+			handler: createGremlinSteerCommandHandler(activeSessionRegistry),
 		});
 
 		pi.registerShortcut(PRIMARY_SHORTCUT, {
@@ -206,18 +218,20 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 			},
 
 			async execute(
-				_toolCallId: string,
+				toolCallId: string,
 				params: PiGremlinsArgs,
 				signal: AbortSignal | undefined,
 				onUpdate: AgentToolUpdateCallback<GremlinInvocationDetails> | undefined,
 				ctx: ExtensionContext,
 			) {
 				return executePiGremlinsTool({
+					toolCallId,
 					params,
 					signal,
 					onUpdate,
 					ctx,
 					discovery,
+					activeSessionRegistry,
 					notifyDiagnostics: (diagnostics) =>
 						notifyDiscoveryDiagnostics(ctx, diagnostics),
 				});


### PR DESCRIPTION
## Summary
- Adds `/gremlins:steer <G-id> <message>` through `pi.registerCommand("gremlins:steer", ...)`.
- Tracks active child gremlin sessions in an in-memory registry with case-insensitive id resolution, duplicate-id ambiguity rejection, exact opaque-handle unregister, and shutdown cleanup.
- Calls the target child `AgentSession.steer(message)` directly and awaits/catches failures without parent-message, subprocess/RPC, viewer, or prompt-history fallback paths.
- Updates tests, README, CHANGELOG, PRD-0006, ADR-0006, and related governance docs.

## Verification
- `bun test extensions/pi-gremlins/gremlin-session-registry.test.js extensions/pi-gremlins/gremlin-steer-command.test.js extensions/pi-gremlins/index.execute.test.js extensions/pi-gremlins/gremlin-runner.test.js extensions/pi-gremlins/gremlin-rendering.test.js extensions/pi-gremlins/index.render.test.js extensions/pi-gremlins/gremlin-session-factory.test.js`
- `npm run typecheck`
- `npm test`
- `npm run check`
- Manual forbidden-path grep over `extensions/pi-gremlins README.md CHANGELOG.md docs/prd/0006-active-gremlin-session-steering.md docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md`; hits were docs/tests/bans only, not implementation paths.

## Governance
- PRD-0006: `docs/prd/0006-active-gremlin-session-steering.md`
- ADR-0006: `docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md`

Closes #53
