### PR TITLE
Fix side-chat overlay UX and realtime rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pi-gremlins` maintainability improved by extracting shared cache helpers, tool execution flow, and gremlin runner event projection into smaller focused modules/functions without changing the public tool contract.
 
 ### Fixed
+- **Side-chat overlay UX and realtime rendering** (PRD-0005, ADR-0005, issue #54): overlay now has explicit border/gutters, 80% viewport-height sizing with internal transcript scrolling, reliable Escape close handling, and render invalidation for incoming child-session updates without keyboard input.
 - **Full Gremlin final messages in tool results** (issue #50): parent agents now receive each terminal gremlin's full final output or error text in model-visible tool result content while preserving collapsed inline summary previews.
 - **Primary-agent selection persistence** (PRD-0003, ADR-0003, issue #42): `/mohawk` selections, shortcut cycling, and cleared primary-agent state now persist in project-local `.pi/settings.json`, restore in fresh Pi sessions, and reset with a warning if the saved primary agent disappears.
 - **Gremlin child prompt isolation** (PRD-0002, ADR-0002, ADR-0003, issue #41): child sessions now use selected sub-agent markdown as their system prompt and no longer receive parent prompt snapshots, primary-agent prompt blocks, active primary-agent markdown, or orchestration rules.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ See [PRD-0006](docs/prd/0006-active-gremlin-session-steering.md) and [ADR-0006](
 ## Side-chat overlay: `/gremlins:chat` and `/gremlins:tangent`
 
 Side-chat support now uses persistent Pi overlays (PRD-0005, ADR-0005,
-issue #49). The older PRD-0004/ADR-0004 inline one-shot behavior has been
+issues #49 and #54). The older PRD-0004/ADR-0004 inline one-shot behavior has been
 superseded for side-chat UX, while its isolation rules remain: zero tools,
 no tangent parent transcript, and no per-side-chat model/thinking override.
 

--- a/docs/prd/0005-persistent-overlay-side-chat.md
+++ b/docs/prd/0005-persistent-overlay-side-chat.md
@@ -3,7 +3,7 @@
 - **Status:** Completed
 - **Date:** 2026-04-30
 - **Author:** Magi Metal
-- **Related:** GitHub issue [#49](https://github.com/magimetal/pi-gremlins/issues/49), [PRD-0004](0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md), [ADR-0005](../adr/0005-persistent-overlay-side-chat.md), [ADR-0004](../adr/0004-side-chat-absorption-from-pi-gizmo.md), [ADR-0003](../adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md)
+- **Related:** GitHub issues [#49](https://github.com/magimetal/pi-gremlins/issues/49), [#54](https://github.com/magimetal/pi-gremlins/issues/54), [PRD-0004](0004-pi-gremlins-side-chat-absorption-and-pi-gizmo-deprecation.md), [ADR-0005](../adr/0005-persistent-overlay-side-chat.md), [ADR-0004](../adr/0004-side-chat-absorption-from-pi-gizmo.md), [ADR-0003](../adr/0003-unified-agent-discovery-and-primary-agent-prompt-injection-in-pi-gremlins.md)
 - **Supersedes:** PRD-0004 side-chat UX decisions for fresh-per-invocation inline side-chat.
 
 ## Problem Statement
@@ -60,7 +60,7 @@ Issue #49 requests the inverse UX: persistent multi-turn side-chat threads, surf
 - [x] `/gremlins:chat:new` appends a chat reset marker, clears only chat state, and opens overlay.
 - [x] `/gremlins:tangent` opens overlay and resumes tangent thread or creates a new thread.
 - [x] `/gremlins:tangent:new` appends a tangent reset marker, clears only tangent state, and opens overlay.
-- [x] Overlay uses Pi `ctx.ui.custom(..., { overlay: true })` with top-center, 78% width/max-height, margin, and non-capturing options.
+- [x] Overlay uses Pi `ctx.ui.custom(..., { overlay: true })` with a visible border, viewport gutters, 78% width, about 80% viewport height, and non-capturing options.
 - [x] Overlay renders mode label, transcript rows, status, draft input, submit/close controls, and scroll keys.
 - [x] Completed exchanges persist through `pi.appendEntry("pi-gremlins:side-chat-thread", ...)`.
 - [x] `:new` writes `pi-gremlins:side-chat-reset` and restore ignores older entries for that mode only.
@@ -82,3 +82,4 @@ Issue #49 requests the inverse UX: persistent multi-turn side-chat threads, surf
 ## Revision History
 
 - 2026-04-30 — Created and completed with issue #49 implementation.
+- 2026-04-30 — Amended overlay UX acceptance for issue #54: border/gutters, 80% viewport height, Escape close, and realtime render invalidation.

--- a/extensions/pi-gremlins/side-chat-command.test.js
+++ b/extensions/pi-gremlins/side-chat-command.test.js
@@ -26,6 +26,7 @@ function createFakeCtx({ branchEntries = [], hasUI = true, model } = {}) {
 	const notifications = [];
 	const customCalls = [];
 	let customComponent;
+	let renderRequests = 0;
 	return {
 		cwd: "/tmp",
 		hasUI,
@@ -36,7 +37,10 @@ function createFakeCtx({ branchEntries = [], hasUI = true, model } = {}) {
 			custom(factory, _options) {
 				customCalls.push(_options);
 				customComponent = factory(
-					{ requestRender() {} },
+					{
+						requestRender() { renderRequests += 1; },
+						terminal: { rows: 24 },
+					},
 					{},
 					{},
 					() => {},
@@ -56,6 +60,9 @@ function createFakeCtx({ branchEntries = [], hasUI = true, model } = {}) {
 		customCalls,
 		get customComponent() {
 			return customComponent;
+		},
+		get renderRequests() {
+			return renderRequests;
 		},
 		sessionManager: {
 			getBranch() {
@@ -145,6 +152,21 @@ describe("side-chat overlay command contract", () => {
 		expect(factory.calls[0].mode).toBe("tangent");
 		expect(factory.calls[0].sessionConfig.tools).toEqual([]);
 		expect(pi.entries.some((entry) => entry.customType === "pi-gremlins:side-chat-thread")).toBe(true);
+	});
+
+	test("realtime transcript events request overlay render without keyboard input", async () => {
+		const { registerSideChatCommands } = await loadCommandModule();
+		const factory = createFakeSessionFactory({
+			events: [
+				{ type: "message_start", message: { role: "assistant" } },
+				{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "live answer" } },
+			],
+		});
+		registerSideChatCommands(pi, { createSideChatSession: factory.impl });
+		const ctx = createFakeCtx();
+		await pi.commands.get("gremlins:chat").handler("question", ctx);
+		expect(ctx.renderRequests).toBeGreaterThan(0);
+		expect(ctx.customComponent.render(72).join("\n")).toContain("live answer");
 	});
 
 	test(":new appends reset and only resets requested mode", async () => {

--- a/extensions/pi-gremlins/side-chat-command.ts
+++ b/extensions/pi-gremlins/side-chat-command.ts
@@ -76,6 +76,7 @@ interface SideChatRuntime {
 	overlayHandle: OverlayHandle | null;
 	overlayPromise: Promise<void> | null;
 	overlayDraft: string;
+	requestOverlayRender: (() => void) | null;
 	transcriptState: SideChatTranscriptState;
 	subscriptions: Set<() => void>;
 	lastSubmittedQuestion: string | null;
@@ -90,6 +91,7 @@ function createRuntime(): SideChatRuntime {
 		overlayHandle: null,
 		overlayPromise: null,
 		overlayDraft: "",
+		requestOverlayRender: null,
 		transcriptState: createInitialSideChatTranscriptState(),
 		subscriptions: new Set(),
 		lastSubmittedQuestion: null,
@@ -145,6 +147,7 @@ export function registerSideChatCommands(
 		runtime.transcriptState = createInitialSideChatTranscriptState(
 			sideChatRowsFromThread(runtime.threads[runtime.activeMode].exchanges),
 		);
+		requestOverlayRender(runtime);
 	}
 
 	pi.on("session_start", (_event, ctx) => {
@@ -161,6 +164,7 @@ export function registerSideChatCommands(
 		runtime.overlayHandle?.hide();
 		runtime.overlayHandle = null;
 		runtime.overlayPromise = null;
+		runtime.requestOverlayRender = null;
 	});
 	pi.on("context", (event) => {
 		return { messages: filterSideChatMessagesFromContext(event.messages) };
@@ -218,6 +222,7 @@ export function registerSideChatCommands(
 				sideChatRowsFromThread(runtime.threads[mode].exchanges),
 			);
 			ensureOverlay(ctx);
+			requestOverlayRender(runtime);
 			if (parsed.userPrompt) {
 				await submitSideChatPrompt(ctx, parsed.userPrompt);
 			}
@@ -250,8 +255,10 @@ export function registerSideChatCommands(
 			},
 		};
 		runtime.overlayPromise = ctx.ui.custom<void>(
-			(tui, _theme, _keybindings, done) =>
-				new SideChatOverlayComponent(tui, controller, done),
+			(tui, _theme, _keybindings, done) => {
+				runtime.requestOverlayRender = () => tui.requestRender();
+				return new SideChatOverlayComponent(tui, controller, done);
+			},
 			{
 				overlay: true,
 				overlayOptions: SIDE_CHAT_OVERLAY_OPTIONS,
@@ -264,6 +271,7 @@ export function registerSideChatCommands(
 		runtime.overlayPromise.finally(() => {
 			runtime.overlayHandle = null;
 			runtime.overlayPromise = null;
+			runtime.requestOverlayRender = null;
 		});
 	}
 
@@ -278,6 +286,7 @@ export function registerSideChatCommands(
 			runtime.transcriptState,
 			userPrompt,
 		);
+		requestOverlayRender(runtime);
 		let session = runtime.activeSession;
 		if (!session || runtime.activeSessionMode !== mode) {
 			resetActiveSession(runtime);
@@ -310,11 +319,13 @@ export function registerSideChatCommands(
 						event,
 					);
 					if (event.type === "turn_end") finalizeExchange(pi, runtime, mode);
+					requestOverlayRender(runtime);
 				});
 				if (unsubscribe) runtime.subscriptions.add(unsubscribe);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				runtime.transcriptState = appendSideChatError(runtime.transcriptState, message);
+				requestOverlayRender(runtime);
 				ctx.ui?.notify?.(`Side-chat failed to start: ${message}`, "error");
 				return;
 			}
@@ -334,9 +345,14 @@ export function registerSideChatCommands(
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			runtime.transcriptState = appendSideChatError(runtime.transcriptState, message);
+			requestOverlayRender(runtime);
 			ctx.ui?.notify?.(`Side-chat prompt failed: ${message}`, "error");
 		}
 	}
+}
+
+function requestOverlayRender(runtime: SideChatRuntime): void {
+	runtime.requestOverlayRender?.();
 }
 
 function finalizeExchange(

--- a/extensions/pi-gremlins/side-chat-overlay.test.js
+++ b/extensions/pi-gremlins/side-chat-overlay.test.js
@@ -9,8 +9,12 @@ describe("side-chat overlay component", () => {
 		let submitted = "";
 		let closed = false;
 		let done = false;
+		let renderRequests = 0;
 		const component = new SideChatOverlayComponent(
-			{ requestRender() {} },
+			{
+				requestRender() { renderRequests += 1; },
+				terminal: { rows: 30 },
+			},
 			{
 				getMode: () => "chat",
 				getTranscriptState: () => createInitialSideChatTranscriptState(),
@@ -29,5 +33,26 @@ describe("side-chat overlay component", () => {
 		component.handleInput("\u001b");
 		expect(closed).toBe(true);
 		expect(done).toBe(true);
+		expect(renderRequests).toBeGreaterThan(0);
+	});
+
+	test("renders bordered 80vh-height overlay with internal transcript space", () => {
+		const component = new SideChatOverlayComponent(
+			{ requestRender() {}, terminal: { rows: 30 } },
+			{
+				getMode: () => "chat",
+				getTranscriptState: () => createInitialSideChatTranscriptState(),
+				getDraft: () => "",
+				setDraft: () => {},
+				submitDraft: () => {},
+				close: () => {},
+			},
+			() => {},
+		);
+		const lines = component.render(72);
+		expect(lines.length).toBe(24);
+		expect(lines[0]).toStartWith("┌");
+		expect(lines.at(-1)).toStartWith("└");
+		expect(lines.join("\n")).toContain("No side-chat messages yet.");
 	});
 });

--- a/extensions/pi-gremlins/side-chat-overlay.ts
+++ b/extensions/pi-gremlins/side-chat-overlay.ts
@@ -1,15 +1,15 @@
 import {
-	Container,
+	Key,
 	Markdown,
-	Spacer,
 	Text,
+	matchesKey,
+	truncateToWidth,
+	visibleWidth,
 	type Component,
 	type MarkdownTheme,
 	type OverlayOptions,
 	type TUI,
 } from "@mariozechner/pi-tui";
-
-const CURSOR_MARKER = "\u001b_pi:c\u0007";
 import { getMarkdownTheme } from "@mariozechner/pi-coding-agent";
 import type { SideChatMode } from "./side-chat-session-factory.js";
 import type {
@@ -17,12 +17,19 @@ import type {
 	SideChatTranscriptState,
 } from "./side-chat-transcript-state.js";
 
+const CURSOR_MARKER = "\u001b_pi:c\u0007";
+const OVERLAY_HEIGHT_RATIO = 0.8;
+const FALLBACK_TERM_HEIGHT = 24;
+const MIN_OVERLAY_HEIGHT = 10;
+const BOX_HORIZONTAL_CHROME = 4;
+const FIXED_BOX_LINES = 9;
+
 export const SIDE_CHAT_OVERLAY_OPTIONS: OverlayOptions = {
-	anchor: "top-center",
+	anchor: "center",
 	width: "78%",
 	minWidth: 72,
-	maxHeight: "78%",
-	margin: { top: 1, left: 2, right: 2 },
+	maxHeight: "80%",
+	margin: { top: 2, right: 4, bottom: 2, left: 4 },
 	nonCapturing: true,
 };
 
@@ -37,7 +44,7 @@ export interface SideChatOverlayController {
 
 export class SideChatOverlayComponent implements Component {
 	private scrollOffset = 0;
-	private focused = true;
+	focused = true;
 
 	constructor(
 		private readonly tui: TUI | undefined,
@@ -48,83 +55,80 @@ export class SideChatOverlayComponent implements Component {
 	invalidate(): void {}
 
 	render(width: number): string[] {
+		const safeWidth = Math.max(8, width);
+		const innerWidth = Math.max(1, safeWidth - BOX_HORIZONTAL_CHROME);
+		const targetHeight = this.getTargetHeight();
+		const bodyHeight = Math.max(1, targetHeight - FIXED_BOX_LINES);
 		const mode = this.controller.getMode();
 		const state = this.controller.getTranscriptState();
 		const draft = this.controller.getDraft();
-		const container = new Container();
-		container.addChild(
-			new Text(
-				`${mode === "chat" ? "💬 chat" : "🧭 tangent"} │ ${formatStatus(state.status)} │ Enter submits · Esc closes · Alt+/ focuses`,
-				1,
-				0,
-			),
+		const bodyLines = this.getVisibleTranscriptLines(
+			state.rows,
+			innerWidth,
+			bodyHeight,
 		);
-		container.addChild(new Text("─".repeat(Math.max(8, width - 2)), 1, 0));
-		const body = new Container();
-		const visibleRows = this.getVisibleRows(state.rows, 18);
-		if (visibleRows.length === 0) {
-			body.addChild(new Text("No side-chat messages yet.", 1, 0));
-		} else {
-			for (const row of visibleRows) body.addChild(this.renderRow(row));
-		}
-		container.addChild(body);
-		container.addChild(new Spacer(1));
-		container.addChild(
-			new Text(
-				`› ${draft}${this.focused ? CURSOR_MARKER : ""}`,
-				1,
-				0,
-			),
-		);
-		container.addChild(new Text("Scroll: ↑/↓ PgUp/PgDn Home/End", 1, 0));
-		return container.render(width);
+		const contentLines = [
+			"",
+			`${mode === "chat" ? "💬 chat" : "🧭 tangent"} │ ${formatStatus(state.status)} │ Enter submits · Esc closes · Alt+/ focuses`,
+			"─".repeat(innerWidth),
+			...bodyLines,
+			"",
+			`› ${draft}${this.focused ? CURSOR_MARKER : ""}`,
+			"Scroll: ↑/↓ PgUp/PgDn Home/End",
+			"",
+		];
+		return [
+			`┌${"─".repeat(Math.max(0, safeWidth - 2))}┐`,
+			...contentLines.map((line) => boxLine(line, innerWidth)),
+			`└${"─".repeat(Math.max(0, safeWidth - 2))}┘`,
+		];
 	}
 
 	handleInput(data: string): void {
-		if (data === "\u001b") {
+		if (isEscape(data)) {
 			this.controller.close();
 			this.done();
 			this.tui?.requestRender();
 			return;
 		}
-		if (data === "\r" || data === "\n") {
+		if (isEnter(data)) {
 			const draft = this.controller.getDraft().trim();
 			if (draft) this.controller.submitDraft(draft);
 			this.tui?.requestRender();
 			return;
 		}
-		if (data === "\u007f" || data === "\b") {
+		if (isBackspace(data)) {
 			const draft = this.controller.getDraft();
 			this.controller.setDraft(draft.slice(0, -1));
 			this.tui?.requestRender();
 			return;
 		}
-		if (data === "\u001b[A") {
+		if (isUp(data)) {
 			this.scrollOffset += 1;
 			this.tui?.requestRender();
 			return;
 		}
-		if (data === "\u001b[B") {
+		if (isDown(data)) {
 			this.scrollOffset = Math.max(0, this.scrollOffset - 1);
 			this.tui?.requestRender();
 			return;
 		}
-		if (data === "\u001b[5~") {
+		if (isPageUp(data)) {
 			this.scrollOffset += 8;
 			this.tui?.requestRender();
 			return;
 		}
-		if (data === "\u001b[6~") {
+		if (isPageDown(data)) {
 			this.scrollOffset = Math.max(0, this.scrollOffset - 8);
 			this.tui?.requestRender();
 			return;
 		}
-		if (data === "\u001b[H") {
+		if (isHome(data)) {
 			this.scrollOffset = Number.MAX_SAFE_INTEGER;
 			this.tui?.requestRender();
 			return;
 		}
-		if (data === "\u001b[F") {
+		if (isEnd(data)) {
 			this.scrollOffset = 0;
 			this.tui?.requestRender();
 			return;
@@ -135,21 +139,37 @@ export class SideChatOverlayComponent implements Component {
 		}
 	}
 
-	setFocused(focused: boolean): void {
-		this.focused = focused;
+	private getTargetHeight(): number {
+		const termHeight = this.tui?.terminal?.rows ?? FALLBACK_TERM_HEIGHT;
+		const availableHeight = Math.max(1, termHeight - 4);
+		const ratioHeight = Math.floor(termHeight * OVERLAY_HEIGHT_RATIO);
+		return Math.max(
+			Math.min(MIN_OVERLAY_HEIGHT, availableHeight),
+			Math.min(ratioHeight, availableHeight),
+		);
 	}
 
-	private getVisibleRows(
+	private getVisibleTranscriptLines(
 		rows: SideChatTranscriptRow[],
-		maxRows: number,
-	): SideChatTranscriptRow[] {
-		const maxOffset = Math.max(0, rows.length - maxRows);
+		width: number,
+		height: number,
+	): string[] {
+		const transcriptLines = rows.length === 0
+			? new Text("No side-chat messages yet.", 0, 0).render(width)
+			: rows.flatMap((row) => this.renderRow(row, width));
+		const maxOffset = Math.max(0, transcriptLines.length - height);
 		const offset = Math.min(this.scrollOffset, maxOffset);
-		const end = rows.length - offset;
-		return rows.slice(Math.max(0, end - maxRows), end);
+		const end = transcriptLines.length - offset;
+		const visible = transcriptLines.slice(Math.max(0, end - height), end);
+		while (visible.length < height) visible.push("");
+		return visible;
 	}
 
-	private renderRow(row: SideChatTranscriptRow): Component {
+	private renderRow(row: SideChatTranscriptRow, width: number): string[] {
+		return this.renderRowComponent(row).render(width);
+	}
+
+	private renderRowComponent(row: SideChatTranscriptRow): Component {
 		switch (row.type) {
 			case "user-message":
 				return new Text(`you: ${row.text}`, 0, 0);
@@ -166,6 +186,48 @@ export class SideChatOverlayComponent implements Component {
 				return new Text(row.text, 0, 0);
 		}
 	}
+}
+
+function boxLine(line: string, innerWidth: number): string {
+	const truncated = truncateToWidth(line, innerWidth, "…");
+	const padding = Math.max(0, innerWidth - visibleWidth(truncated));
+	return `│ ${truncated}${" ".repeat(padding)} │`;
+}
+
+function isEscape(data: string): boolean {
+	return data === "\u001b" || matchesKey(data, Key.escape);
+}
+
+function isEnter(data: string): boolean {
+	return data === "\r" || data === "\n" || matchesKey(data, Key.enter);
+}
+
+function isBackspace(data: string): boolean {
+	return data === "\u007f" || data === "\b" || matchesKey(data, Key.backspace);
+}
+
+function isUp(data: string): boolean {
+	return data === "\u001b[A" || matchesKey(data, Key.up);
+}
+
+function isDown(data: string): boolean {
+	return data === "\u001b[B" || matchesKey(data, Key.down);
+}
+
+function isPageUp(data: string): boolean {
+	return data === "\u001b[5~" || matchesKey(data, Key.pageUp);
+}
+
+function isPageDown(data: string): boolean {
+	return data === "\u001b[6~" || matchesKey(data, Key.pageDown);
+}
+
+function isHome(data: string): boolean {
+	return data === "\u001b[H" || matchesKey(data, Key.home);
+}
+
+function isEnd(data: string): boolean {
+	return data === "\u001b[F" || matchesKey(data, Key.end);
 }
 
 function isPrintable(data: string): boolean {

--- a/extensions/pi-gremlins/test-helpers.js
+++ b/extensions/pi-gremlins/test-helpers.js
@@ -53,6 +53,12 @@ export class MockContainer {
 	addChild(child) {
 		this.children.push(child);
 	}
+
+	render(width) {
+		return this.children.flatMap((child) => child.render?.(width) ?? []);
+	}
+
+	invalidate() {}
 }
 
 export class MockText {
@@ -63,17 +69,35 @@ export class MockText {
 	setText(text) {
 		this.text = text;
 	}
+
+	render() {
+		return String(this.text).split("\n");
+	}
+
+	invalidate() {}
 }
 
 export class MockSpacer {
 	constructor(lines = 1) {
 		this.lines = lines;
 	}
+
+	render() {
+		return Array.from({ length: this.lines }, () => "");
+	}
+
+	invalidate() {}
 }
 
 export class MockMarkdown {
 	constructor(text) {
 		this.text = text;
 	}
+
+	render() {
+		return String(this.text).split("\n");
+	}
+
+	invalidate() {}
 }
 


### PR DESCRIPTION
## Summary
- Fix Gremlins side-chat overlay rendering so child-session realtime events request a TUI render without waiting for keyboard input
- Add visible overlay border, wider viewport gutters, and 80% viewport-height sizing with internal transcript scrolling
- Harden Escape/keyboard handling and add targeted regression coverage
- Update README, CHANGELOG, and PRD-0005 issue references

## Verification
- npm run check

Closes #54