### PR TITLE
Surface gremlin steering activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pi-gremlins` maintainability improved by extracting shared cache helpers, tool execution flow, and gremlin runner event projection into smaller focused modules/functions without changing the public tool contract.
 
 ### Fixed
+- **Active steering visibility** (issue #63): `/gremlins:steer` now records queued and SDK-rejected steering attempts in the inline gremlin activity stream and documents a live repro plus install-version drift checks.
 - **Inline gremlin render line clamp** (issue #61): collapsed inline sub-agent results now enforce the preview visual-line limit during high-volume output bursts, including narrow-width wrapped lines.
 - **Side-chat overlay UX and realtime rendering** (PRD-0005, ADR-0005, issue #54): overlay now has explicit border/gutters, 80% viewport-height sizing with internal transcript scrolling, reliable Escape close handling, and render invalidation for incoming child-session updates without keyboard input.
 - **Full Gremlin final messages in tool results** (issue #50): parent agents now receive each terminal gremlin's full final output or error text in model-visible tool result content while preserving collapsed inline summary previews.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,17 @@ Behavior:
 - Only currently active gremlin sessions can be steered. Unknown, completed, canceled, failed, setup-failed, stale, or disposed ids are rejected.
 - Concurrent batches can each have a `g1`. If more than one active session shares an id, steering that id fails as ambiguous instead of guessing.
 - Pi SDK queues steering for the target child session after its current child tool calls finish and before its next child LLM call; it does not interrupt a running tool call immediately.
+- Successful active steering is recorded in the inline gremlin activity stream as `steering · steering:queued · queued · <message>` and also emits a transient notification. If the active session rejects steering, the inline activity stream records `steering:rejected` with the failure reason.
 - This is official child-session steering. It does not restore legacy subprocess/RPC steering, parent-message injection, prompt-history injection, popup UI, or `/gremlins:view` viewer controls.
+
+Manual live repro:
+
+1. Start a long-running gremlin task that will make more than one child LLM call, such as a task that asks a gremlin to inspect several files and wait to summarize until all files are read.
+2. While the gremlin row still shows `Active`, run `/gremlins:steer G1 keep investigating before summarizing` in the parent session.
+3. Confirm the notification says `Steering queued for g1 (...)` and expand the gremlin row with Pi's standard tool-row expand control to confirm a `steering:queued` activity line appears.
+4. Confirm the gremlin incorporates the steering before its next LLM response. Steering submitted after completion should warn `No active gremlin found`.
+
+Install/version drift check: because the package version may remain `0.1.0` between unreleased commits, confirm the installed source by checking the Pi package install location or reinstalling from the intended Git commit/branch before testing steering behavior.
 
 See [PRD-0006](docs/prd/0006-active-gremlin-session-steering.md) and [ADR-0006](docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md).
 

--- a/extensions/pi-gremlins/gremlin-render-components.ts
+++ b/extensions/pi-gremlins/gremlin-render-components.ts
@@ -236,6 +236,8 @@ function getActivityLabel(kind: GremlinActivityKind): string {
 			return "latest";
 		case "task":
 			return "task";
+		case "steering":
+			return "steering";
 		case "idle":
 			return "idle";
 	}

--- a/extensions/pi-gremlins/gremlin-runner.test.js
+++ b/extensions/pi-gremlins/gremlin-runner.test.js
@@ -502,4 +502,52 @@ describe("gremlin runner v1 contract", () => {
 			"dispose",
 		]);
 	});
+
+	test("records steering events from the active registry into gremlin activity", async () => {
+		const { runSingleGremlin } = await import("./gremlin-runner.ts");
+		let registeredEntry;
+		const fake = createFakeSession({
+			onPrompt: async () => {
+				registeredEntry.recordSteeringEvent({
+					status: "queued",
+					message: "keep investigating before summarizing",
+				});
+			},
+		});
+		const registry = {
+			registerActiveGremlinSession(entry) {
+				registeredEntry = entry;
+				return Symbol("active");
+			},
+			unregisterActiveGremlinSession() {
+				return true;
+			},
+			resolveActiveGremlinSession() {
+				return { status: "missing" };
+			},
+			clearActiveGremlinSessions() {},
+		};
+
+		const result = await runSingleGremlin({
+			gremlinId: "g1",
+			activeSessionRegistry: registry,
+			request: { intent: "Inspect implementation independently", agent: "researcher", context: "Inspect auth flow" },
+			definition: {
+				name: "researcher",
+				source: "project",
+				filePath: "/tmp/researcher.md",
+				rawMarkdown: "---\nname: researcher\n---\nraw gremlin body",
+				frontmatter: {},
+			},
+			createSession: async () => fake,
+		});
+
+		expect(result.activities).toContainEqual(
+			expect.objectContaining({
+				kind: "steering",
+				phase: "steering:queued",
+				text: "queued · keep investigating before summarizing",
+			}),
+		);
+	});
 });

--- a/extensions/pi-gremlins/gremlin-runner.ts
+++ b/extensions/pi-gremlins/gremlin-runner.ts
@@ -18,6 +18,7 @@ import type {
 import type {
 	ActiveGremlinSessionHandle,
 	ActiveGremlinSessionRegistry,
+	ActiveGremlinSteeringEvent,
 } from "./gremlin-session-registry.js";
 
 export interface GremlinRunnerUpdate {
@@ -455,6 +456,14 @@ export async function runSingleGremlin({
 			toolCallId,
 			agent: request.agent,
 			session,
+			recordSteeringEvent(event: ActiveGremlinSteeringEvent) {
+				const phase = event.status === "queued" ? "steering:queued" : "steering:rejected";
+				const text =
+					event.status === "queued"
+						? `queued · ${event.message}`
+						: `rejected · ${event.errorMessage} · ${event.message}`;
+				publish({}, { kind: "steering", phase, text });
+			},
 		});
 		unsubscribe = session.subscribe?.((event: GremlinEvent) => {
 			projectGremlinEvent(event, state, session, publish, textDeltaPublisher);

--- a/extensions/pi-gremlins/gremlin-schema.ts
+++ b/extensions/pi-gremlins/gremlin-schema.ts
@@ -59,6 +59,7 @@ export type GremlinActivityKind =
 	| "tool-result"
 	| "text"
 	| "task"
+	| "steering"
 	| "idle";
 
 export interface GremlinActivity {

--- a/extensions/pi-gremlins/gremlin-session-registry.ts
+++ b/extensions/pi-gremlins/gremlin-session-registry.ts
@@ -2,12 +2,17 @@ export interface SteerableGremlinSession {
 	steer(message: string): Promise<unknown> | unknown;
 }
 
+export type ActiveGremlinSteeringEvent =
+	| { status: "queued"; message: string }
+	| { status: "rejected"; message: string; errorMessage: string };
+
 export interface ActiveGremlinSessionEntry {
 	readonly gremlinId: string;
 	readonly normalizedGremlinId: string;
 	readonly toolCallId: string;
 	readonly agent: string;
 	readonly session: SteerableGremlinSession;
+	recordSteeringEvent?(event: ActiveGremlinSteeringEvent): void;
 }
 
 export type ActiveGremlinSessionHandle = symbol;
@@ -23,6 +28,7 @@ export interface ActiveGremlinSessionRegistry {
 		toolCallId: string;
 		agent: string;
 		session: SteerableGremlinSession;
+		recordSteeringEvent?(event: ActiveGremlinSteeringEvent): void;
 	}): ActiveGremlinSessionHandle;
 	unregisterActiveGremlinSession(handle: ActiveGremlinSessionHandle): boolean;
 	resolveActiveGremlinSession(gremlinId: string): ResolveActiveGremlinSessionResult;
@@ -45,6 +51,7 @@ export function createActiveGremlinSessionRegistry(): ActiveGremlinSessionRegist
 				toolCallId: entry.toolCallId,
 				agent: entry.agent,
 				session: entry.session,
+				recordSteeringEvent: entry.recordSteeringEvent,
 			});
 			return handle;
 		},

--- a/extensions/pi-gremlins/gremlin-steer-command.test.js
+++ b/extensions/pi-gremlins/gremlin-steer-command.test.js
@@ -71,10 +71,11 @@ describe("gremlin steer command", () => {
 		expect(steerCalls).toBe(0);
 	});
 
-	test("awaits child session steer exactly once, then notifies success", async () => {
+	test("awaits child session steer exactly once, records inline evidence, then notifies success", async () => {
 		const { createGremlinSteerCommandHandler } = await import("./gremlin-steer-command.ts");
 		const order = [];
 		const steerMessages = [];
+		const steeringEvents = [];
 		let resolveSteer;
 		const steerPromise = new Promise((resolve) => {
 			resolveSteer = resolve;
@@ -84,6 +85,9 @@ describe("gremlin steer command", () => {
 			entry: {
 				gremlinId: "g1",
 				agent: "researcher",
+				recordSteeringEvent(event) {
+					steeringEvents.push(event);
+				},
 				session: {
 					async steer(message) {
 						steerMessages.push(message);
@@ -103,16 +107,21 @@ describe("gremlin steer command", () => {
 
 		expect(steerMessages).toEqual(["keep investigating auth flow"]);
 		expect(order).toEqual(["steer-start", "steer-end"]);
+		expect(steeringEvents).toEqual([{ status: "queued", message: "keep investigating auth flow" }]);
 		expect(ctx.notifications).toEqual([{ message: "Steering queued for g1 (researcher).", type: "info" }]);
 	});
 
-	test("steer rejection notifies failure with no success", async () => {
+	test("steer rejection records inline evidence and notifies failure with no success", async () => {
 		const { createGremlinSteerCommandHandler } = await import("./gremlin-steer-command.ts");
+		const steeringEvents = [];
 		const registry = createRegistry({
 			status: "active",
 			entry: {
 				gremlinId: "g1",
 				agent: "researcher",
+				recordSteeringEvent(event) {
+					steeringEvents.push(event);
+				},
 				session: {
 					async steer() {
 						throw new Error("disposed");
@@ -122,6 +131,9 @@ describe("gremlin steer command", () => {
 		});
 		const ctx = createCtx();
 		await createGremlinSteerCommandHandler(registry)("g1 continue", ctx);
+		expect(steeringEvents).toEqual([
+			{ status: "rejected", message: "continue", errorMessage: "disposed" },
+		]);
 		expect(ctx.notifications).toEqual([{ message: "Failed to steer g1 (researcher): disposed", type: "error" }]);
 	});
 });

--- a/extensions/pi-gremlins/gremlin-steer-command.ts
+++ b/extensions/pi-gremlins/gremlin-steer-command.ts
@@ -40,7 +40,7 @@ export function createGremlinSteerCommandHandler(
 			return;
 		}
 
-		const { gremlinId, message } = parsed.value;
+		const { gremlinId, message: steeringMessage } = parsed.value;
 		const resolved = registry.resolveActiveGremlinSession(gremlinId);
 		if (resolved.status === "missing") {
 			ctx.ui?.notify?.(
@@ -58,13 +58,22 @@ export function createGremlinSteerCommandHandler(
 		}
 
 		try {
-			await resolved.entry.session.steer(message);
+			await resolved.entry.session.steer(steeringMessage);
+			resolved.entry.recordSteeringEvent?.({
+				status: "queued",
+				message: steeringMessage,
+			});
 			ctx.ui?.notify?.(
 				`Steering queued for ${resolved.entry.gremlinId} (${resolved.entry.agent}).`,
 				"info",
 			);
 		} catch (error) {
 			const messageText = error instanceof Error ? error.message : String(error);
+			resolved.entry.recordSteeringEvent?.({
+				status: "rejected",
+				message: steeringMessage,
+				errorMessage: messageText,
+			});
 			ctx.ui?.notify?.(
 				`Failed to steer ${resolved.entry.gremlinId} (${resolved.entry.agent}): ${messageText}`,
 				"error",


### PR DESCRIPTION
## Summary
- record queued and SDK-rejected /gremlins:steer attempts in the inline gremlin activity stream
- extend steering tests to cover activity recording from the active runtime registry
- document a live steering repro and install/version drift checks

## Verification
- gh auth status
- git rev-parse --is-inside-work-tree
- gh issue view 63 --json number,title,body,labels,state,url
- npm run typecheck
- npm test
- npm run check

Closes #63