### PR TITLE
Fix expanded inline subagent output truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pi SDK/runtime deps now target `0.69.0`, package/tool schemas now import `typebox` 1.x instead of `@sinclair/typebox`, and tool registration includes a localized TS inference workaround until upstream typings stop triggering `TS2589` deep-instantiation errors.
 - Gremlin runner usage now reports current context-window token usage from Pi SDK session context instead of summing cumulative per-turn `totalTokens`, preventing inflated `contextTokens` in multi-turn runs.
 - Runtime cache hot paths now use compact render cache keys, per-entry render segment reuse, memoized discovery directory listings, reused file fingerprints, in-flight discovery sharing, coalesced streaming text updates, and truncated activity previews to reduce repeated string, filesystem, and UI churn during active gremlin runs.
-- Gremlin batch scheduling and discovery file processing now use bounded internal concurrency, expanded inline rendering clamps large multiline fields, and shared helper modules reduce duplicated text/cache handling without changing the public tool contract.
+- Gremlin batch scheduling and discovery file processing now use bounded internal concurrency, collapsed inline rendering keeps preview output bounded, and shared helper modules reduce duplicated text/cache handling without changing the public tool contract.
 - `pi-gremlins` maintainability improved by extracting shared cache helpers, tool execution flow, and gremlin runner event projection into smaller focused modules/functions without changing the public tool contract.
 
 ### Fixed
+- **Expanded inline subagent output** (issue #66): expanded gremlin inline details now show the full available subagent output instead of clipping expanded text fields to a short preview.
 - Side-chat transcript persistence now queues pending chat/tangent questions per mode so overlapping prompts are saved with the correct completed answer.
 - **Active steering visibility** (issue #63): `/gremlins:steer` now records queued and SDK-rejected steering attempts in the inline gremlin activity stream and documents a live repro plus install-version drift checks.
 - **Inline gremlin render line clamp** (issue #61): collapsed inline sub-agent results now enforce the preview visual-line limit during high-volume output bursts, including narrow-width wrapped lines.

--- a/extensions/pi-gremlins/rendering/gremlin-render-components.ts
+++ b/extensions/pi-gremlins/rendering/gremlin-render-components.ts
@@ -11,8 +11,6 @@ const ENTRY_CACHE_LIMIT = 256;
 const COLLAPSED_PREVIEW_LIMIT = 96;
 const COLLAPSED_CONTEXT_LINE_LIMIT = 3;
 const COLLAPSED_ACTIVITY_LINE_LIMIT = 3;
-const EXPANDED_FIELD_LINE_LIMIT = 4;
-const EXPANDED_FIELD_CHAR_LIMIT = 120;
 const collapsedLinesCache = new Map<string, string[]>();
 const expandedLinesCache = new Map<string, string[]>();
 
@@ -263,23 +261,10 @@ function formatIntentPreviewLine(intent?: string): string | undefined {
 	return preview ? `intent · ${preview}` : undefined;
 }
 
-function boundExpandedLine(line: string): string {
-	if (line.length <= EXPANDED_FIELD_CHAR_LIMIT) return line;
-	return `${line.slice(0, EXPANDED_FIELD_CHAR_LIMIT - 1).trimEnd()}…`;
-}
-
 function formatExpandedFieldLines(label: string, value?: string): string[] {
 	const normalized = normalizeText(value);
 	if (!normalized) return [];
-	const sourceLines = normalized.split(/\r?\n/);
-	const visibleLines = sourceLines
-		.slice(0, EXPANDED_FIELD_LINE_LIMIT)
-		.map((line) => `${label} · ${boundExpandedLine(line)}`);
-	const omittedLines = sourceLines.length - visibleLines.length;
-	if (omittedLines > 0) {
-		visibleLines.push(`${label} · … ${omittedLines} lines omitted`);
-	}
-	return visibleLines;
+	return normalized.split(/\r?\n/).map((line) => `${label} · ${line}`);
 }
 
 export function formatBatchHeadline(details: GremlinInvocationDetails): string {

--- a/extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js
+++ b/extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js
@@ -423,7 +423,36 @@ describe("gremlin rendering v1 contract", () => {
 		expect(text.split("\n").length).toBeGreaterThan(INLINE_RESULT_PREVIEW_LINES);
 	});
 
-	test("bounds expanded render output for large multiline fields", async () => {
+	test("renders full expanded subagent output without field clipping", async () => {
+		const { renderGremlinInvocationText } = await import("../../rendering/gremlin-rendering.ts");
+		const fullOutput = Array.from({ length: 8 }, (_value, index) => `full output line ${index + 1}`).join("\n");
+
+		const text = renderGremlinInvocationText(
+			{
+				requestedCount: 1,
+				activeCount: 0,
+				completedCount: 1,
+				failedCount: 0,
+				canceledCount: 0,
+				gremlins: [{
+					gremlinId: "g1",
+					agent: "researcher",
+					source: "project",
+					status: "completed",
+					latestText: fullOutput,
+					revision: 66,
+				}],
+				revision: 66,
+			},
+			{ expanded: true },
+		);
+
+		expect(text).toContain("latest · full output line 1");
+		expect(text).toContain("latest · full output line 8");
+		expect(text).not.toContain("omitted");
+	});
+
+	test("wraps expanded render output to width without omitting available fields", async () => {
 		const { renderGremlinInvocationText } = await import("../../rendering/gremlin-rendering.ts");
 		const hugeLines = Array.from({ length: 80 }, (_value, index) => `expanded line ${index + 1} ${"x".repeat(180)}`).join("\n");
 		const details = {
@@ -449,8 +478,9 @@ describe("gremlin rendering v1 contract", () => {
 
 		const lines = renderGremlinInvocationText(details, { expanded: true, width: 140 }).split("\n");
 
-		expect(lines.length).toBeLessThanOrEqual(38);
-		expect(lines.some((line) => line.includes("omitted"))).toBe(true);
+		expect(lines.length).toBeGreaterThanOrEqual(403);
+		expect(lines).toContain(`latest · expanded line 80 ${"x".repeat(180)}`.slice(0, 139) + "…");
+		expect(lines.some((line) => line.includes("omitted"))).toBe(false);
 		for (const line of lines) {
 			expect(line.length).toBeLessThanOrEqual(140);
 		}


### PR DESCRIPTION
## Summary
- Show full available gremlin subagent output in expanded inline details instead of clipping expanded fields to preview text.
- Preserve collapsed preview truncation behavior.
- Add rendering coverage for full expanded output and wide expanded wrapping.

Closes #66

## Verification
- bun test extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js (passed: 13/13)
- npm run check (passed: typecheck + 105 tests)
- git diff --check (clean)

## Risks
- Expanded inline views can now render substantially more text by design; collapsed output remains bounded.