### PR TITLE
Fix primary-agent settings path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Primary-agent settings path** (issue #67): primary-agent selection now reads and writes nearest project `.pi/agents/settings.json`, creates `.pi/agents/` when needed, and safely migrates/falls back from legacy `.pi/settings.json` selections without writing new primary-agent state to the old path.
 - `extensions/pi-gremlins` source and test files are reorganized into feature folders (`agents`, `gremlins`, `primary`, `rendering`, `shared`, `side-chat`, and `test`) while preserving the package entry point at `./extensions/pi-gremlins`.
 - **Persistent overlay side-chat** (PRD-0005, ADR-0005, issue #49): `/gremlins:chat` and `/gremlins:tangent` now open persistent multi-turn overlays instead of inline one-shot responses; `:new` variants reset only the selected mode while preserving chat/tangent isolation.
 - **`/mohawk` renamed to `/gremlins:primary`** (issue #45): the `/mohawk` slash command is replaced by `/gremlins:primary`, consolidating primary-agent selection under the `pi-gremlins` tool namespace; all underlying behavior, shortcut cycling, and session state are preserved.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ Controls:
 
 Session behavior:
 
-- selection is restored from nearest project `.pi/settings.json` under `pi-gremlins.primaryAgent`; project-local storage avoids surprising cross-project primary-agent injection.
+- selection is restored from nearest project `.pi/agents/settings.json` under `pi-gremlins.primaryAgent`; project-local storage avoids surprising cross-project primary-agent injection.
+- existing primary-agent selections in legacy `.pi/settings.json` are safely migrated or used as fallback when the new agents settings file has no primary-agent selection.
 - current-branch session entries still take precedence when present.
 - `/gremlins:primary <name>`, picker selection, `Ctrl+Shift+M`, and `/gremlins:primary none` persist selected name, source, and file path only.
 - new session entries are also appended as `pi-gremlins-primary-agent` for branch history compatibility.

--- a/docs/plans/issue-67-primary-agent-settings-path.md
+++ b/docs/plans/issue-67-primary-agent-settings-path.md
@@ -1,0 +1,200 @@
+# Issue 67 Plan: Move Primary-Agent Settings to `.pi/agents/settings.json`
+
+## Objective
+Fix GitHub issue #67 end-to-end using the provided `git-issue-fix` workflow: move primary-agent selection persistence from project `.pi/settings.json` to project `.pi/agents/settings.json`, preserve safe migration/fallback for existing users, update tests/docs/changelog, then commit, push, and open a PR that closes #67.
+
+## Scope
+- In scope: primary-agent persistence path resolution, read/write behavior, scoped migration/fallback of only `pi-gremlins.primaryAgent`, tests for new path and legacy fallback/migration, README/CHANGELOG updates, verification, commit/push/PR sequence.
+- Out of scope: moving unrelated settings, changing side-chat settings behavior, PRD/ADR creation, broad persistence architecture changes, or altering primary-agent discovery/prompt injection semantics.
+
+## Observed Context
+- Issue #67 is open and requests `~/.pi/agents/settings.json`; issue body notes a typo `settings.jso` and assumes `settings.json`.
+- Current primary-agent persistence is in `extensions/pi-gremlins/primary/primary-agent-persistence.ts`.
+- Current implementation resolves nearest project `.pi` and reads/writes `.pi/settings.json` under `pi-gremlins.primaryAgent`.
+- Existing primary-agent tests in `extensions/pi-gremlins/test/primary/primary-agent.test.js` assert `.pi/settings.json` behavior and corrupt legacy-file handling.
+- `README.md` documents primary-agent restore from nearest project `.pi/settings.json`.
+- `CHANGELOG.md` has an Unreleased section with prior primary-agent persistence notes.
+
+## Required Implementation Decisions
+1. **Migration vs fallback:** Implement safe migration on read/write when legacy `.pi/settings.json` contains a valid `pi-gremlins.primaryAgent` and new `.pi/agents/settings.json` does not already contain one. Copy only that key into the new file; do not move or delete unrelated legacy settings.
+2. **Conflict precedence:** If both files contain `pi-gremlins.primaryAgent`, prefer the new `.pi/agents/settings.json` value and do not overwrite it from legacy.
+3. **New writes:** All writes and clears must target `.pi/agents/settings.json`; the old `.pi/settings.json` must not be modified for new primary-agent persistence after migration/fallback.
+4. **Corrupt new-path precedence boundary:** `.pi/agents/settings.json` is authoritative when it exists. If it exists but is unreadable or corrupt, warn and return None; do not consult legacy `.pi/settings.json`, do not migrate from legacy, and do not overwrite or repair the corrupt new file during startup/read.
+5. **Legacy fallback/migration boundary:** Consult or migrate from legacy `.pi/settings.json` only when the new file is absent, or when the new file is valid JSON but lacks `pi-gremlins.primaryAgent`. Corrupt legacy settings should only warn if legacy fallback/migration is actually attempted and cannot be read; do not let legacy corruption break valid new-path reads.
+6. **Path wording:** Although the issue says `~/.pi/...`, this repo currently uses the nearest project `.pi`; keep the existing project-local resolution and move the file under that `.pi/agents/` directory unless product direction explicitly changes.
+
+## Task 1 — Inspect and confirm persistence call sites
+### What
+Before coding, inspect all primary-agent persistence imports/usages and related tests/docs so the change remains scoped to the persistence module and direct expectations.
+
+### References
+- `extensions/pi-gremlins/primary/primary-agent-persistence.ts`
+- `extensions/pi-gremlins/index.ts`
+- `extensions/pi-gremlins/primary/*.ts`
+- `extensions/pi-gremlins/test/primary/primary-agent.test.js`
+- `README.md`
+- `CHANGELOG.md`
+
+### Acceptance Criteria
+- All call sites of `getPrimaryAgentSettingsPath`, `readPersistedPrimaryAgentSelection*`, `writePersistedPrimaryAgentSelection`, and `clearPersistedPrimaryAgentSelection` are identified.
+- No unrelated settings subsystem is included in the implementation scope.
+- Implementation notes confirm project-local `.pi` behavior is intentionally preserved.
+
+### Guardrails
+- Do not edit code during this inspection task except as part of later implementation tasks.
+- Do not change side-chat settings behavior or side-chat tests.
+
+### Verification
+- Run/search commands during implementation:
+  - `grep -R "getPrimaryAgentSettingsPath\|readPersistedPrimaryAgentSelection\|writePersistedPrimaryAgentSelection\|clearPersistedPrimaryAgentSelection" -n extensions/pi-gremlins`
+  - `grep -R "\.pi/settings.json\|settings.json\|primaryAgent" -n README.md CHANGELOG.md extensions/pi-gremlins/test/primary extensions/pi-gremlins/primary`
+
+## Task 2 — Add failing tests for new path and legacy migration/fallback first
+### What
+Update primary-agent tests to assert the issue #67 behavior before implementing the production change.
+
+### References
+- `extensions/pi-gremlins/test/primary/primary-agent.test.js`
+- `extensions/pi-gremlins/test/helpers/test-helpers.js`
+
+### Acceptance Criteria
+- Existing persistence test now expects writes at `path.join(workspace.repoRoot, ".pi", "agents", "settings.json")`.
+- Test asserts `.pi/agents/` is created automatically when selecting or clearing a primary agent.
+- Test asserts persisted selection restores from `.pi/agents/settings.json` in a new session.
+- Test asserts legacy `.pi/settings.json` containing only `pi-gremlins.primaryAgent` is safely migrated/fallen back into `.pi/agents/settings.json` and restored.
+- Test asserts unrelated keys in legacy `.pi/settings.json` remain in the old file and are not copied wholesale into the new file.
+- Test asserts when both legacy and new files contain primary-agent selections, the new file wins.
+- Test asserts after migration or command writes, legacy `.pi/settings.json` is not modified for new primary-agent writes.
+- Test asserts if `.pi/agents/settings.json` exists but is corrupt/unreadable while legacy `.pi/settings.json` contains a valid primary-agent selection, startup/read warns and returns None, does not read/fallback to legacy, does not migrate, and leaves the corrupt new file untouched.
+- Test asserts legacy fallback/migration happens only when `.pi/agents/settings.json` is absent or valid JSON without `pi-gremlins.primaryAgent`.
+- Test asserts when valid `.pi/agents/settings.json` lacks `pi-gremlins.primaryAgent` but contains unrelated keys, migration preserves those unrelated new-path keys while adding only `pi-gremlins.primaryAgent` from legacy.
+- Existing corrupt-settings tests are updated or split to cover authoritative corrupt new-path behavior and corrupt legacy fallback behavior.
+
+### Guardrails
+- Add focused tests in the existing primary-agent test file; do not create broad integration fixtures unless necessary.
+- Do not weaken existing assertions that raw markdown is not persisted.
+- Keep tests deterministic with temp workspaces; no real home directory access.
+
+### Verification
+- Run the focused test before production changes and confirm expected failure:
+  - `bun test extensions/pi-gremlins/test/primary/primary-agent.test.js`
+- Expected pre-fix failure: tests still find writes/reads at old `.pi/settings.json` or missing `.pi/agents/settings.json`.
+
+## Task 3 — Implement new path resolution and scoped migration/fallback
+### What
+Change primary-agent persistence to read/write `.pi/agents/settings.json`, create the agents directory as needed, and safely migrate/fallback a valid legacy `pi-gremlins.primaryAgent` value when the new file lacks that key.
+
+### References
+- `extensions/pi-gremlins/primary/primary-agent-persistence.ts`
+
+### Acceptance Criteria
+- `getPrimaryAgentSettingsPath(cwd)` returns nearest project `.pi/agents/settings.json` or `path.resolve(cwd)/.pi/agents/settings.json` when no `.pi` exists.
+- `writePersistedPrimaryAgentSelection` reads/merges only the new settings file, then writes only `.pi/agents/settings.json`.
+- `clearPersistedPrimaryAgentSelection` writes `NONE_SELECTION` only to `.pi/agents/settings.json`.
+- `readPersistedPrimaryAgentSelectionWithDiagnostics` reads from new path first and treats an existing new settings file as the precedence boundary.
+- If `.pi/agents/settings.json` exists but cannot be parsed/read, the function warns and returns None without checking legacy `.pi/settings.json`, without migrating, and without writing to either file during startup/read.
+- If `.pi/agents/settings.json` is absent, legacy `.pi/settings.json` is checked for a valid `pi-gremlins.primaryAgent`.
+- If `.pi/agents/settings.json` is valid JSON but lacks `pi-gremlins.primaryAgent`, legacy `.pi/settings.json` is checked for a valid `pi-gremlins.primaryAgent`.
+- If a valid legacy primary-agent selection is found and new settings do not already define one, it is copied to `.pi/agents/settings.json` while preserving any unrelated keys already present in the valid new file and copying only `pi-gremlins.primaryAgent` from legacy.
+- Legacy `.pi/settings.json` is not deleted, not modified, and unrelated legacy keys are not copied to the new file.
+- Invalid/missing legacy values produce no crash and return None unless a diagnostic is warranted for an unreadable/corrupt file during an allowed legacy fallback/migration attempt.
+- No `as any`, `@ts-ignore`, or `@ts-expect-error` are introduced.
+
+### Guardrails
+- Keep the migration scoped to the `pi-gremlins.primaryAgent` key only.
+- Do not change serialized `PrimaryAgentSessionEntryData` shape.
+- Do not migrate side-chat or any other package settings.
+- Do not write to the legacy path in any code path.
+- Preserve current behavior for corrupt new settings: startup does not crash and warning diagnostics remain visible.
+- Do not mask corrupt new settings with legacy fallback; corrupt `.pi/agents/settings.json` must remain user-actionable and untouched.
+
+### Verification
+- Re-read the modified persistence file.
+- Run focused tests:
+  - `bun test extensions/pi-gremlins/test/primary/primary-agent.test.js`
+
+## Task 4 — Update README and CHANGELOG
+### What
+Update user-facing documentation to describe the new primary-agent settings location and add the issue #67 changelog entry.
+
+### References
+- `README.md`
+- `CHANGELOG.md`
+
+### Acceptance Criteria
+- README primary-agent persistence text references nearest project `.pi/agents/settings.json` under `pi-gremlins.primaryAgent`.
+- README notes existing `.pi/settings.json` primary-agent selections are safely migrated or used as fallback.
+- CHANGELOG Unreleased section includes a concise issue #67 entry mentioning new path, agents-directory creation, and legacy migration/fallback.
+- Existing side-chat note that it does not read side-chat-specific `.pi/settings.json` remains accurate and is not rewritten as primary-agent behavior.
+
+### Guardrails
+- Do not add PRD/ADR documents for this narrow persistence-location change.
+- Do not over-document internal migration mechanics beyond user-relevant behavior.
+
+### Verification
+- `grep -n "primary-agent\|primary agent\|\.pi/agents/settings.json\|\.pi/settings.json" README.md CHANGELOG.md`
+
+## Task 5 — Run full verification and inspect diff
+### What
+Run the repository verification expected by the issue workflow and inspect the final diff for scope control.
+
+### References
+- `package.json`
+- All modified files
+
+### Acceptance Criteria
+- Focused primary-agent tests pass.
+- Full test suite passes.
+- Typecheck passes.
+- `npm run check` passes because it is available and combines typecheck/test.
+- Diff only includes expected changes to persistence, primary-agent tests, README, CHANGELOG, and this plan file unless implementation reveals a necessary direct dependency.
+
+### Guardrails
+- Do not hide type errors.
+- Do not skip failing tests without documenting the blocker.
+- Do not include generated/cache/node_modules changes.
+
+### Verification
+Run:
+- `bun test extensions/pi-gremlins/test/primary/primary-agent.test.js`
+- `npm test`
+- `npm run typecheck`
+- `npm run check`
+- `git status --short`
+- `git diff --check`
+- `git diff -- extensions/pi-gremlins/primary/primary-agent-persistence.ts extensions/pi-gremlins/test/primary/primary-agent.test.js README.md CHANGELOG.md docs/plans/issue-67-primary-agent-settings-path.md`
+
+## Task 6 — Commit, push, and open PR via git-issue-fix workflow
+### What
+After implementation and verification pass, follow the provided `git-issue-fix` release workflow: commit, push branch `issue-67`, and open a PR that closes issue #67.
+
+### References
+- Branch: `issue-67`
+- Remote: `git@github.com:magimetal/pi-gremlins.git`
+- Issue: `https://github.com/magimetal/pi-gremlins/issues/67`
+
+### Acceptance Criteria
+- Commit includes only scoped issue #67 changes.
+- Commit message references issue #67, e.g. `Fix primary-agent settings path (#67)`.
+- Branch `issue-67` is pushed to origin.
+- PR is opened against the repository default branch with body including `Closes #67` and verification commands/results.
+
+### Guardrails
+- Do not commit or push until all verification is passing, or explicitly document any blocker in the PR if instructed to proceed despite failure.
+- Do not squash unrelated local changes into the commit.
+- Do not close the issue manually outside the PR flow.
+
+### Verification
+Run:
+- `git status --short`
+- `git diff --check`
+- `git add extensions/pi-gremlins/primary/primary-agent-persistence.ts extensions/pi-gremlins/test/primary/primary-agent.test.js README.md CHANGELOG.md docs/plans/issue-67-primary-agent-settings-path.md`
+- `git commit -m "Fix primary-agent settings path (#67)"`
+- `git push -u origin issue-67`
+- `gh pr create --fill --body-file <prepared-pr-body-with-Closes-67-and-verification>`
+- `gh pr view --web` or `gh pr view --json url,title,body`
+
+## Open Risks / Unknowns
+- **Observed:** Current code uses nearest project `.pi`, while issue wording says `~/.pi`; this plan preserves existing project-local semantics because README and tests already frame persistence that way.
+- **Inferred:** Migration-on-read is preferable to pure fallback because it satisfies “old location not used for new writes after migration” and makes subsequent reads independent of legacy state.
+- **Unknown:** Exact desired warning behavior for corrupt legacy file when new settings are absent; keep diagnostics useful but avoid warning if valid new settings already exist.

--- a/extensions/pi-gremlins/primary/primary-agent-persistence.ts
+++ b/extensions/pi-gremlins/primary/primary-agent-persistence.ts
@@ -17,6 +17,7 @@ interface PrimaryAgentSettingsRoot {
 
 interface PrimaryAgentSettingsReadResult {
 	settings: PrimaryAgentSettingsRoot;
+	exists: boolean;
 	diagnostic?: string;
 }
 
@@ -35,9 +36,16 @@ function findNearestPiDir(cwd: string): string | null {
 	}
 }
 
-export function getPrimaryAgentSettingsPath(cwd: string): string {
-	const nearestPiDir = findNearestPiDir(cwd);
-	return path.join(nearestPiDir ?? path.join(path.resolve(cwd), ".pi"), "settings.json");
+function getPrimaryAgentPiDir(cwd: string): string {
+	return findNearestPiDir(cwd) ?? path.join(path.resolve(cwd), ".pi");
+}
+
+function getPrimaryAgentSettingsPath(cwd: string): string {
+	return path.join(getPrimaryAgentPiDir(cwd), "agents", "settings.json");
+}
+
+function getLegacyPrimaryAgentSettingsPath(cwd: string): string {
+	return path.join(getPrimaryAgentPiDir(cwd), "settings.json");
 }
 
 function formatSettingsReadError(settingsPath: string, error: unknown): string {
@@ -45,34 +53,95 @@ function formatSettingsReadError(settingsPath: string, error: unknown): string {
 	return `Could not read primary-agent settings at ${settingsPath}: ${message}`;
 }
 
-function readSettingsFile(settingsPath: string): PrimaryAgentSettingsReadResult {
-	try {
-		return {
-			settings: JSON.parse(fs.readFileSync(settingsPath, "utf-8")) as PrimaryAgentSettingsRoot,
-		};
-	} catch (error) {
-		if (
-			error &&
+function isMissingFileError(error: unknown): boolean {
+	return Boolean(
+		error &&
 			typeof error === "object" &&
 			"code" in error &&
 			error.code === "ENOENT"
-		) {
-			return { settings: {} };
+	);
+}
+
+function isSettingsRoot(value: unknown): value is PrimaryAgentSettingsRoot {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readSettingsFile(settingsPath: string): PrimaryAgentSettingsReadResult {
+	try {
+		const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+		return { settings: isSettingsRoot(parsed) ? parsed : {}, exists: true };
+	} catch (error) {
+		if (isMissingFileError(error)) {
+			return { settings: {}, exists: false };
 		}
-		return { settings: {}, diagnostic: formatSettingsReadError(settingsPath, error) };
+		return {
+			settings: {},
+			exists: true,
+			diagnostic: formatSettingsReadError(settingsPath, error),
+		};
 	}
+}
+
+function getPrimaryAgentSelection(settings: PrimaryAgentSettingsRoot): PrimaryAgentSessionEntryData | null {
+	const value = settings[PRIMARY_AGENT_SETTINGS_NAMESPACE]?.[PRIMARY_AGENT_SETTINGS_KEY];
+	return isPrimaryAgentSessionEntryData(value) ? value : null;
+}
+
+function settingsDefinesPrimaryAgent(settings: PrimaryAgentSettingsRoot): boolean {
+	return Object.prototype.hasOwnProperty.call(
+		settings[PRIMARY_AGENT_SETTINGS_NAMESPACE] ?? {},
+		PRIMARY_AGENT_SETTINGS_KEY,
+	);
+}
+
+function withPrimaryAgentSelection(
+	settings: PrimaryAgentSettingsRoot,
+	selection: PrimaryAgentSessionEntryData,
+): PrimaryAgentSettingsRoot {
+	const namespace = settings[PRIMARY_AGENT_SETTINGS_NAMESPACE];
+	settings[PRIMARY_AGENT_SETTINGS_NAMESPACE] = {
+		...(namespace && typeof namespace === "object" ? namespace : {}),
+		[PRIMARY_AGENT_SETTINGS_KEY]: selection,
+	};
+	return settings;
+}
+
+function writeSettingsFile(settingsPath: string, settings: PrimaryAgentSettingsRoot): void {
+	fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+	fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8");
 }
 
 export function readPersistedPrimaryAgentSelectionWithDiagnostics(cwd: string): {
 	selection: PrimaryAgentSessionEntryData | null;
 	diagnostic?: string;
 } {
-	const { settings, diagnostic } = readSettingsFile(getPrimaryAgentSettingsPath(cwd));
-	const value = settings[PRIMARY_AGENT_SETTINGS_NAMESPACE]?.[PRIMARY_AGENT_SETTINGS_KEY];
-	return {
-		selection: isPrimaryAgentSessionEntryData(value) ? value : null,
-		diagnostic,
-	};
+	const settingsPath = getPrimaryAgentSettingsPath(cwd);
+	const newRead = readSettingsFile(settingsPath);
+	if (newRead.diagnostic) {
+		return { selection: null, diagnostic: newRead.diagnostic };
+	}
+
+	const newSelection = getPrimaryAgentSelection(newRead.settings);
+	if (newSelection) {
+		return { selection: newSelection };
+	}
+
+	if (newRead.exists && settingsDefinesPrimaryAgent(newRead.settings)) {
+		return { selection: null };
+	}
+
+	const legacyRead = readSettingsFile(getLegacyPrimaryAgentSettingsPath(cwd));
+	if (legacyRead.diagnostic) {
+		return { selection: null, diagnostic: legacyRead.diagnostic };
+	}
+
+	const legacySelection = getPrimaryAgentSelection(legacyRead.settings);
+	if (!legacySelection) {
+		return { selection: null };
+	}
+
+	writeSettingsFile(settingsPath, withPrimaryAgentSelection(newRead.settings, legacySelection));
+	return { selection: legacySelection };
 }
 
 export function readPersistedPrimaryAgentSelection(
@@ -87,12 +156,7 @@ export function writePersistedPrimaryAgentSelection(
 ): void {
 	const settingsPath = getPrimaryAgentSettingsPath(cwd);
 	const { settings } = readSettingsFile(settingsPath);
-	settings[PRIMARY_AGENT_SETTINGS_NAMESPACE] = {
-		...(settings[PRIMARY_AGENT_SETTINGS_NAMESPACE] ?? {}),
-		[PRIMARY_AGENT_SETTINGS_KEY]: selection,
-	};
-	fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-	fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8");
+	writeSettingsFile(settingsPath, withPrimaryAgentSelection(settings, selection));
 }
 
 export function clearPersistedPrimaryAgentSelection(cwd: string): void {

--- a/extensions/pi-gremlins/test/primary/primary-agent.test.js
+++ b/extensions/pi-gremlins/test/primary/primary-agent.test.js
@@ -193,7 +193,7 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
 	});
 
-	test("selection persists to project settings and restores in a new session without raw markdown", async () => {
+	test("selection persists to project agents settings and restores in a new session without raw markdown", async () => {
 		const { createPrimaryAgentDiscoveryCache } = await import("../../gremlins/gremlin-discovery.ts");
 		const { createPiGremlinsExtension } = await import("../../index.ts");
 		const workspace = createWorkspace();
@@ -207,7 +207,10 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		await firstPi.handler("session_start")({ type: "session_start", reason: "startup" }, firstCtx);
 		await firstPi.commands.get("gremlins:primary").handler("Alpha", firstCtx);
 
-		const settingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const legacySettingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "agents", "settings.json");
+		expect(fs.existsSync(path.dirname(settingsPath))).toBe(true);
+		expect(fs.existsSync(legacySettingsPath)).toBe(false);
 		const settingsContent = fs.readFileSync(settingsPath, "utf-8");
 		expect(settingsContent).toContain('"selectedName": "Alpha"');
 		expect(settingsContent).toContain('"source": "project"');
@@ -222,41 +225,131 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		expect(injected.systemPrompt).toContain("alpha prompt");
 	});
 
-	test("corrupt project settings does not crash startup and reports warning", async () => {
-		const { createPrimaryAgentDiscoveryCache } = await import("../../gremlins/gremlin-discovery.ts");
-		const { createPiGremlinsExtension } = await import("../../index.ts");
-		const workspace = createWorkspace();
-		workspaceRoot = workspace.root;
-		fs.mkdirSync(path.join(workspace.repoRoot, ".pi"), { recursive: true });
-		fs.writeFileSync(path.join(workspace.repoRoot, ".pi", "settings.json"), "{not json", "utf-8");
-		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
-		const pi = createMockPi();
-		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(pi);
-		const ctx = createMockContext(workspace);
-
-		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
-
-		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
-		expect(ctx.ui.notifications.at(-1)).toMatchObject({ type: "warning" });
-		expect(ctx.ui.notifications.at(-1).message).toContain("Could not read primary-agent settings");
-	});
-
-	test("selection replaces corrupt project settings with valid persisted primary", async () => {
+	test("legacy project settings migrate only primary-agent selection when new settings are absent", async () => {
 		const { createPrimaryAgentDiscoveryCache } = await import("../../gremlins/gremlin-discovery.ts");
 		const { createPiGremlinsExtension } = await import("../../index.ts");
 		const workspace = createWorkspace();
 		workspaceRoot = workspace.root;
 		writePrimaryFile(workspace.projectAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
-		const settingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const legacySettingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "agents", "settings.json");
+		fs.writeFileSync(legacySettingsPath, JSON.stringify({
+			"pi-gremlins": { primaryAgent: { selectedName: "Alpha", source: "project", filePath: path.join(workspace.projectAgentsDir, "alpha.md") }, other: true },
+			unrelated: "legacy",
+		}, null, 2), "utf-8");
+		const legacyBefore = fs.readFileSync(legacySettingsPath, "utf-8");
+
+		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const pi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(pi);
+		const ctx = createMockContext(workspace);
+		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
+
+		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: Alpha" });
+		expect(fs.readFileSync(legacySettingsPath, "utf-8")).toBe(legacyBefore);
+		const migrated = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+		expect(migrated).toEqual({ "pi-gremlins": { primaryAgent: { selectedName: "Alpha", source: "project", filePath: path.join(workspace.projectAgentsDir, "alpha.md") } } });
+	});
+
+	test("new primary-agent settings win over legacy and legacy is not rewritten", async () => {
+		const { createPrimaryAgentDiscoveryCache } = await import("../../gremlins/gremlin-discovery.ts");
+		const { createPiGremlinsExtension } = await import("../../index.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.projectAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
+		writePrimaryFile(workspace.projectAgentsDir, "beta.md", "---\nname: Beta\nagent_type: primary\n---\nbeta prompt");
+		const legacySettingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "agents", "settings.json");
+		fs.writeFileSync(legacySettingsPath, JSON.stringify({ "pi-gremlins": { primaryAgent: { selectedName: "Alpha", source: "project", filePath: path.join(workspace.projectAgentsDir, "alpha.md") } } }, null, 2), "utf-8");
+		fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+		fs.writeFileSync(settingsPath, JSON.stringify({ preserved: true, "pi-gremlins": { primaryAgent: { selectedName: "Beta", source: "project", filePath: path.join(workspace.projectAgentsDir, "beta.md") } } }, null, 2), "utf-8");
+		const legacyBefore = fs.readFileSync(legacySettingsPath, "utf-8");
+
+		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const pi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(pi);
+		const ctx = createMockContext(workspace);
+		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
+		await pi.commands.get("gremlins:primary").handler("Alpha", ctx);
+
+		expect(ctx.ui.statuses.at(-2)).toEqual({ key: "pi-gremlins-primary", text: "Primary: Beta" });
+		expect(fs.readFileSync(legacySettingsPath, "utf-8")).toBe(legacyBefore);
+		const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+		expect(settings.preserved).toBe(true);
+		expect(settings["pi-gremlins"].primaryAgent).toMatchObject({ selectedName: "Alpha", source: "project" });
+	});
+
+	test("legacy migration fills missing new primary-agent key while preserving new settings", async () => {
+		const { createPrimaryAgentDiscoveryCache } = await import("../../gremlins/gremlin-discovery.ts");
+		const { createPiGremlinsExtension } = await import("../../index.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.projectAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
+		const legacySettingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "agents", "settings.json");
+		fs.writeFileSync(legacySettingsPath, JSON.stringify({ "pi-gremlins": { primaryAgent: { selectedName: "Alpha", source: "project", filePath: path.join(workspace.projectAgentsDir, "alpha.md") }, legacyOnly: true }, copiedNever: true }, null, 2), "utf-8");
+		fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+		fs.writeFileSync(settingsPath, JSON.stringify({ preserved: true, "pi-gremlins": { newOnly: true } }, null, 2), "utf-8");
+
+		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const pi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(pi);
+		const ctx = createMockContext(workspace);
+		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
+
+		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: Alpha" });
+		const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+		expect(settings).toEqual({ preserved: true, "pi-gremlins": { newOnly: true, primaryAgent: { selectedName: "Alpha", source: "project", filePath: path.join(workspace.projectAgentsDir, "alpha.md") } } });
+	});
+
+	test("corrupt new primary-agent settings are authoritative and block legacy fallback", async () => {
+		const { createPrimaryAgentDiscoveryCache } = await import("../../gremlins/gremlin-discovery.ts");
+		const { createPiGremlinsExtension } = await import("../../index.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.projectAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
+		const legacySettingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "agents", "settings.json");
+		fs.writeFileSync(legacySettingsPath, JSON.stringify({ "pi-gremlins": { primaryAgent: { selectedName: "Alpha", source: "project", filePath: path.join(workspace.projectAgentsDir, "alpha.md") } } }, null, 2), "utf-8");
+		fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
 		fs.writeFileSync(settingsPath, "{not json", "utf-8");
+		const legacyBefore = fs.readFileSync(legacySettingsPath, "utf-8");
+
+		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
+		const pi = createMockPi();
+		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(pi);
+		const ctx = createMockContext(workspace);
+		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
+
+		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
+		expect(ctx.ui.notifications.at(-1)).toMatchObject({ type: "warning" });
+		expect(ctx.ui.notifications.at(-1).message).toContain(".pi/agents/settings.json");
+		expect(fs.readFileSync(settingsPath, "utf-8")).toBe("{not json");
+		expect(fs.readFileSync(legacySettingsPath, "utf-8")).toBe(legacyBefore);
+	});
+
+	test("corrupt legacy settings warn only during allowed fallback and command writes new path", async () => {
+		const { createPrimaryAgentDiscoveryCache } = await import("../../gremlins/gremlin-discovery.ts");
+		const { createPiGremlinsExtension } = await import("../../index.ts");
+		const workspace = createWorkspace();
+		workspaceRoot = workspace.root;
+		writePrimaryFile(workspace.projectAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
+		const legacySettingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "agents", "settings.json");
+		fs.writeFileSync(legacySettingsPath, "{not json", "utf-8");
+		const legacyBefore = fs.readFileSync(legacySettingsPath, "utf-8");
 		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
 		const pi = createMockPi();
 		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(pi);
 		const ctx = createMockContext(workspace);
 
 		await pi.handler("session_start")({ type: "session_start", reason: "startup" }, ctx);
-		await pi.commands.get("gremlins:primary").handler("Alpha", ctx);
+		expect(ctx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
+		expect(ctx.ui.notifications.at(-1)).toMatchObject({ type: "warning" });
+		expect(ctx.ui.notifications.at(-1).message).toContain(".pi/settings.json");
 
+		await pi.commands.get("gremlins:primary").handler("Alpha", ctx);
+		expect(fs.readFileSync(legacySettingsPath, "utf-8")).toBe(legacyBefore);
 		const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
 		expect(settings["pi-gremlins"].primaryAgent).toMatchObject({ selectedName: "Alpha", source: "project" });
 	});
@@ -268,7 +361,8 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		workspaceRoot = workspace.root;
 		writePrimaryFile(workspace.projectAgentsDir, "alpha.md", "---\nname: Alpha\nagent_type: primary\n---\nalpha prompt");
 		const discovery = createPrimaryAgentDiscoveryCache({ userAgentsDir: workspace.userAgentsDir });
-		const settingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const legacySettingsPath = path.join(workspace.repoRoot, ".pi", "settings.json");
+		const settingsPath = path.join(workspace.repoRoot, ".pi", "agents", "settings.json");
 
 		const firstPi = createMockPi();
 		createPiGremlinsExtension({ primaryAgentDiscoveryCache: discovery })(firstPi);
@@ -276,6 +370,8 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		await firstPi.handler("session_start")({ type: "session_start", reason: "startup" }, firstCtx);
 		await firstPi.commands.get("gremlins:primary").handler("Alpha", firstCtx);
 		await firstPi.commands.get("gremlins:primary").handler("none", firstCtx);
+		expect(fs.existsSync(path.dirname(settingsPath))).toBe(true);
+		expect(fs.existsSync(legacySettingsPath)).toBe(false);
 		expect(fs.readFileSync(settingsPath, "utf-8")).toContain('"selectedName": null');
 
 		const clearedPi = createMockPi();
@@ -291,6 +387,8 @@ describe("primary-agent state, controls, and prompt injection", () => {
 		await missingPi.handler("session_start")({ type: "session_start", reason: "startup" }, missingCtx);
 		expect(missingCtx.ui.statuses.at(-1)).toEqual({ key: "pi-gremlins-primary", text: "Primary: None" });
 		expect(missingCtx.ui.notifications.at(-1)).toEqual({ message: "Primary agent unavailable, reset to None: Missing", type: "warning" });
+		expect(fs.existsSync(path.dirname(settingsPath))).toBe(true);
+		expect(fs.existsSync(legacySettingsPath)).toBe(false);
 		expect(fs.readFileSync(settingsPath, "utf-8")).toContain('"selectedName": null');
 		const injected = await missingPi.handler("before_agent_start")({ type: "before_agent_start", systemPrompt: "system", prompt: "go", systemPromptOptions: {} }, missingCtx);
 		expect(injected).toBeUndefined();


### PR DESCRIPTION
## Summary
- Move primary-agent persistence to nearest project `.pi/agents/settings.json`.
- Create `.pi/agents/` for new writes and clears.
- Safely migrate/fallback legacy `.pi/settings.json` primary-agent selections without copying unrelated legacy settings or writing new state to the old path.
- Update tests, README, CHANGELOG, and implementation plan artifact.

## Verification
- `git diff --check` — passed
- `npm test` — passed (107 pass, 0 fail)
- `npm run typecheck` — passed
- `npm run check` — passed (typecheck + tests: 107 pass, 0 fail)
- `git status --short` — clean after commit

Closes #67
