### PR TITLE
Fix sub-agent inline usage cost formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pi-gremlins` maintainability improved by extracting shared cache helpers, tool execution flow, and gremlin runner event projection into smaller focused modules/functions without changing the public tool contract.
 
 ### Fixed
+- **Sub-agent inline usage cost formatting** (issue #65): gremlin inline usage summaries now render finite costs with a `$` marker and stable precision instead of raw floating-point decimals.
 - **Expanded inline subagent output** (issue #66): expanded gremlin inline details now show the full available subagent output instead of clipping expanded text fields to a short preview.
 - Side-chat transcript persistence now queues pending chat/tangent questions per mode so overlapping prompts are saved with the correct completed answer.
 - **Active steering visibility** (issue #63): `/gremlins:steer` now records queued and SDK-rejected steering attempts in the inline gremlin activity stream and documents a live repro plus install-version drift checks.

--- a/extensions/pi-gremlins/rendering/gremlin-render-components.ts
+++ b/extensions/pi-gremlins/rendering/gremlin-render-components.ts
@@ -138,6 +138,15 @@ export function formatGremlinStatus(status: GremlinInvocationEntry["status"]): s
 	}
 }
 
+function formatUsageCost(cost: number): string {
+	if (cost === 0) return "$0.00";
+	const absoluteCost = Math.abs(cost);
+	const sign = cost < 0 ? "-" : "";
+	if (absoluteCost < 0.000001) return `${sign}<$0.000001`;
+	if (absoluteCost < 0.01) return `${sign}$${absoluteCost.toFixed(6)}`;
+	return `${sign}$${absoluteCost.toFixed(2)}`;
+}
+
 export function formatUsageSummary(usage?: GremlinUsage): string {
 	if (!usage) return "";
 	const parts = [
@@ -150,7 +159,9 @@ export function formatUsageSummary(usage?: GremlinUsage): string {
 		parts.push(`cacheWrite:${usage.cacheWrite}`);
 	}
 	if (typeof usage.contextTokens === "number") parts.push(`context:${usage.contextTokens}`);
-	if (typeof usage.cost === "number") parts.push(`cost:${usage.cost}`);
+	if (typeof usage.cost === "number" && Number.isFinite(usage.cost)) {
+		parts.push(`cost:${formatUsageCost(usage.cost)}`);
+	}
 	return parts.join(" · ");
 }
 

--- a/extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js
+++ b/extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js
@@ -233,6 +233,56 @@ describe("gremlin rendering v1 contract", () => {
 		expect(text).toContain("read apps/web/src/main.ts");
 	});
 
+	test("formats usage cost in collapsed and expanded inline summaries", async () => {
+		const { renderGremlinInvocationText } = await import(
+			"../../rendering/gremlin-rendering.ts"
+		);
+		const details = {
+			requestedCount: 1,
+			activeCount: 0,
+			completedCount: 1,
+			failedCount: 0,
+			canceledCount: 0,
+			gremlins: [
+				{
+					gremlinId: "g1",
+					agent: "researcher",
+					source: "project",
+					status: "completed",
+					context: "Find auth flow",
+					usage: { turns: 2, input: 20, output: 8, cost: 0.000123456 },
+					revision: 14,
+				},
+			],
+			revision: 14,
+		};
+
+		const collapsed = renderGremlinInvocationText(details, { expanded: false, width: 120 });
+		const expanded = renderGremlinInvocationText(details, { expanded: true, width: 120 });
+
+		expect(collapsed).toContain("usage · turns:2 · input:20 · output:8 · cost:$0.000123");
+		expect(expanded).toContain("usage · turns:2 · input:20 · output:8 · cost:$0.000123");
+		expect(collapsed).not.toContain("0.000123456");
+		expect(expanded).not.toContain("0.000123456");
+	});
+
+	test("formats zero tiny and normal usage costs predictably and omits non-finite costs", async () => {
+		const { formatUsageSummary } = await import("../../rendering/gremlin-render-components.ts");
+
+		expect(formatUsageSummary({ turns: 0, input: 0, output: 0, cost: 0 })).toBe(
+			"turns:0 · input:0 · output:0 · cost:$0.00",
+		);
+		expect(formatUsageSummary({ turns: 1, input: 2, output: 3, cost: 0.0000004 })).toBe(
+			"turns:1 · input:2 · output:3 · cost:<$0.000001",
+		);
+		expect(formatUsageSummary({ turns: 1, input: 2, output: 3, cost: 1.234 })).toBe(
+			"turns:1 · input:2 · output:3 · cost:$1.23",
+		);
+		expect(formatUsageSummary({ turns: 1, input: 2, output: 3, cost: Number.NaN })).toBe(
+			"turns:1 · input:2 · output:3",
+		);
+	});
+
 	test("renders expanded inline detail with task model usage and no popup chrome", async () => {
 		const { renderGremlinInvocationText } = await import(
 			"../../rendering/gremlin-rendering.ts"


### PR DESCRIPTION
## Summary
- Format finite sub-agent inline usage costs with a dollar marker and stable precision.
- Omit non-finite usage costs from summaries.
- Add rendering contract coverage for collapsed, expanded, zero, tiny, normal, and NaN cost values.

Closes #65

## Verification
- git diff --check
- npm run check