### PR TITLE
Show inline gremlin session metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pi-gremlins` maintainability improved by extracting shared cache helpers, tool execution flow, and gremlin runner event projection into smaller focused modules/functions without changing the public tool contract.
 
 ### Fixed
+- **Inline gremlin session metadata** (issue #75): collapsed inline gremlin summaries now show compact model and thinking metadata when available while omitting missing values gracefully.
 - **Sub-agent inline usage cost formatting** (issue #65): gremlin inline usage summaries now render finite costs with a `$` marker and stable precision instead of raw floating-point decimals.
 - **Expanded inline subagent output** (issue #66): expanded gremlin inline details now show the full available subagent output instead of clipping expanded text fields to a short preview.
 - Side-chat transcript persistence now queues pending chat/tangent questions per mode so overlapping prompts are saved with the correct completed answer.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This is context and resource isolation inside Pi's SDK runtime. It is not an OS-
 
 The tool row uses the label **Gremlins🧌** and can be expanded with Pi's standard `Ctrl+O` affordance.
 
-Collapsed output summarizes source, status, intent/task preview, latest activity, token usage, and errors. Expanded output adds per-gremlin details such as intent, task/context, cwd, model, thinking level, latest text/tool data, usage, errors, and steering activity.
+Collapsed output summarizes source, status, compact model/thinking metadata when available, intent/task preview, latest activity, token usage, and errors. Expanded output adds per-gremlin details such as intent, task/context, cwd, model, thinking level, latest text/tool data, usage, errors, and steering activity.
 
 ## Active gremlin steering
 

--- a/extensions/pi-gremlins/rendering/gremlin-render-components.ts
+++ b/extensions/pi-gremlins/rendering/gremlin-render-components.ts
@@ -80,6 +80,8 @@ export function createEntryCacheKey(
 			String(entry.revision),
 			createBoundedTextCacheToken(entry.currentPhase),
 			createBoundedTextCacheToken(entry.context),
+			createBoundedTextCacheToken(entry.model),
+			createBoundedTextCacheToken(entry.thinking),
 			createBoundedTextCacheToken(entry.latestText),
 			createBoundedTextCacheToken(entry.latestToolCall),
 			createBoundedTextCacheToken(entry.latestToolResult),
@@ -272,6 +274,14 @@ function formatIntentPreviewLine(intent?: string): string | undefined {
 	return preview ? `intent · ${preview}` : undefined;
 }
 
+function formatCompactMetadataLine(entry: GremlinInvocationEntry): string | undefined {
+	const parts = dedupeParts([
+		normalizeText(entry.model) ? `model:${entry.model}` : undefined,
+		normalizeText(entry.thinking) ? `thinking:${entry.thinking}` : undefined,
+	]);
+	return parts.length > 0 ? `meta · ${parts.join(" · ")}` : undefined;
+}
+
 function formatExpandedFieldLines(label: string, value?: string): string[] {
 	const normalized = normalizeText(value);
 	if (!normalized) return [];
@@ -297,6 +307,8 @@ export function formatCollapsedGremlinLines(entry: GremlinInvocationEntry): stri
 	const lines = [`[${formatGremlinStatus(entry.status)}] · ${formatGremlinIdentity(entry)}`];
 	const intentLine = formatIntentPreviewLine(entry.intent);
 	if (intentLine) lines.push(intentLine);
+	const metadataLine = formatCompactMetadataLine(entry);
+	if (metadataLine) lines.push(metadataLine);
 	lines.push(...formatContextPreviewLines(entry.context));
 	lines.push(...getRecentActivityPreviews(entry).map(formatActivityPreviewLine));
 	const usage = formatUsageSummary(entry.usage);

--- a/extensions/pi-gremlins/rendering/gremlin-rendering.ts
+++ b/extensions/pi-gremlins/rendering/gremlin-rendering.ts
@@ -177,6 +177,7 @@ function styleLine(
 	if (line.startsWith("latest · ")) return theme.fg("text", line);
 	if (line.startsWith("error · ")) return theme.fg("error", line);
 	if (line.startsWith("idle · ")) return theme.fg("dim", line);
+	if (line.startsWith("meta · ")) return theme.fg("dim", line);
 	if (line.startsWith("usage · ")) return theme.fg("dim", line);
 	if (
 		line.startsWith("cwd · ") ||

--- a/extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js
+++ b/extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js
@@ -59,6 +59,49 @@ describe("gremlin rendering v1 contract", () => {
 		expect(text).not.toContain("popup");
 	});
 
+	test("renders compact model and thinking metadata in collapsed inline summaries", async () => {
+		const { renderGremlinInvocationText } = await import(
+			"../../rendering/gremlin-rendering.ts"
+		);
+
+		const text = renderGremlinInvocationText(
+			{
+				requestedCount: 2,
+				activeCount: 1,
+				completedCount: 1,
+				failedCount: 0,
+				canceledCount: 0,
+				gremlins: [
+					{
+						gremlinId: "g1",
+						agent: "researcher",
+						source: "project",
+						status: "active",
+						context: "Find auth flow",
+						model: "openai/gpt-5-mini",
+						thinking: "medium",
+						revision: 20,
+					},
+					{
+						gremlinId: "g2",
+						agent: "reviewer",
+						source: "user",
+						status: "completed",
+						context: "Review auth flow",
+						revision: 21,
+					},
+				],
+				revision: 21,
+			},
+			{ expanded: false, width: 120 },
+		);
+
+		expect(text).toContain("meta · model:openai/gpt-5-mini · thinking:medium");
+		expect(text).toContain("[Completed] · g2 reviewer [user]");
+		expect(text).not.toContain("model:undefined");
+		expect(text).not.toContain("thinking:undefined");
+	});
+
 	test("renders narrow collapsed state readably for repeated agent names by keeping stable gremlin ids", async () => {
 		const { renderGremlinInvocationText } = await import(
 			"../../rendering/gremlin-rendering.ts"


### PR DESCRIPTION
## Summary
- Show compact model/thinking metadata in collapsed gremlin inline summaries when available.
- Keep missing metadata omitted gracefully and include metadata in render cache keys.
- Update README and CHANGELOG for issue #75.

## Verification
- npm run check

Closes #75