### PR TITLE
Fix issue #77: add gremlin session overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repaired reliability audit findings for renderer cache uniqueness, same-size agent discovery changes, corrupt primary-agent settings recovery, effective request-cwd discovery, and ambiguous gremlin model reporting.
 
 ### Added
+- **Gremlin session overlay** (issue #77): `/gremlins:open` now opens captured active/completed gremlin transcripts in the side-chat-style overlay, supports active steering through `AgentSession.steer(message)`, and fails closed for missing, ambiguous, or terminal sessions.
 - **Side-chat tool input summaries** (PRD-0009, issue #68): side-chat tool start rows now show safe concise `read` path/file and `bash` command details, with sensitive or long values redacted/truncated before display.
 - **Side-chat skill prompt support** (PRD-0008, ADR-0008, issue #59): `/gremlins:chat` and `/gremlins:tangent` can now load fresh child-session skills and diagnostics through the side-chat child resource-loader boundary, enabling SDK-native skill guidance while keeping parent-loaded skills and legacy side-chat skill paths isolated.
 - **Side-chat SDK default and extension tools** (PRD-0008, ADR-0008, issue #57): `/gremlins:chat` and `/gremlins:tangent` now omit explicit child-session tools so SDK default built-ins apply, while enabled extension custom tools can load through a fresh child resource loader. Side-chat-specific `.pi/settings.json` allowlists/configuration are removed/ignored; overlay persistence and chat/tangent isolation are retained.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Human-facing UI uses the label **Gremlins🧌**. Package installation, extension
 - **Role-aware markdown agents** — discover `agent_type: sub-agent` gremlins and `agent_type: primary` parent roles from user and project directories.
 - **Primary-agent controls** — choose the parent-session role with `/gremlins:primary` or cycle with `Ctrl+Shift+M`.
 - **Active steering** — queue guidance into a running gremlin with `/gremlins:steer <G-id> <message>`.
+- **Gremlin session overlay** — inspect active or completed gremlin transcripts with `/gremlins:open <G-id>` and steer active sessions from the overlay input.
 - **Persistent overlays** — use `/gremlins:chat` for a transcript-aware side conversation or `/gremlins:tangent` for a clean tangent.
 
 ## Install and update
@@ -214,6 +215,24 @@ Behavior:
 - Queued and SDK-rejected steering attempts appear in the inline activity stream.
 
 Related: [PRD-0006](docs/prd/0006-active-gremlin-session-steering.md), [ADR-0006](docs/adr/0006-official-sdk-steering-for-active-gremlin-sessions.md).
+
+## Gremlin session overlay
+
+Use `/gremlins:open <G-id>` to open a side-chat-style overlay for a known gremlin session.
+
+```text
+/gremlins:open G1
+```
+
+Behavior:
+
+- Opens captured transcript rows for active or completed gremlins from the current Pi session.
+- `/gremlins:open` with no id opens the only known gremlin, warns when no sessions are known, and fails closed with a list when multiple sessions require an explicit id.
+- Active sessions append live transcript rows at the bottom when the overlay is not scrolled away from the bottom.
+- Typing in the overlay and pressing `Enter` steers active sessions through the same `AgentSession.steer(message)` path as `/gremlins:steer`.
+- Completed, canceled, failed, stale, missing, or ambiguous sessions remain readable but reject steering in the transcript without closing the overlay.
+- Duplicate local ids across concurrent/repeated batches fail as ambiguous instead of guessing.
+- Tool transcript status rows show tool names only and do not render tool args/results, avoiding secret exposure in the overlay.
 
 ## Side-chat and tangent overlays
 

--- a/extensions/pi-gremlins/gremlins/gremlin-open-command.ts
+++ b/extensions/pi-gremlins/gremlins/gremlin-open-command.ts
@@ -1,0 +1,220 @@
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { OverlayHandle } from "@mariozechner/pi-tui";
+import {
+	SIDE_CHAT_OVERLAY_OPTIONS,
+	SideChatOverlayComponent,
+	type SideChatOverlayController,
+} from "../side-chat/side-chat-overlay.js";
+import type { ActiveGremlinSessionRegistry } from "./gremlin-session-registry.js";
+import type {
+	GremlinSessionTranscriptStore,
+	GremlinTranscriptEntry,
+} from "./gremlin-session-transcript-store.js";
+
+export const GREMLIN_OPEN_COMMAND = "gremlins:open";
+
+interface GremlinOpenRuntime {
+	overlayHandle: OverlayHandle | null;
+	overlayPromise: Promise<void> | null;
+	requestOverlayRender: (() => void) | null;
+	selectedEntry: GremlinTranscriptEntry | null;
+	draft: string;
+	unsubscribeStore: (() => void) | null;
+}
+
+function createRuntime(): GremlinOpenRuntime {
+	return {
+		overlayHandle: null,
+		overlayPromise: null,
+		requestOverlayRender: null,
+		selectedEntry: null,
+		draft: "",
+		unsubscribeStore: null,
+	};
+}
+
+function parseGremlinOpenArgs(args: string): string | undefined {
+	const trimmed = (args ?? "").trim();
+	return trimmed ? trimmed.split(/\s+/, 1)[0] : undefined;
+}
+
+function describeEntry(entry: GremlinTranscriptEntry): string {
+	return `${entry.gremlinId} (${entry.agent}, ${entry.status}, ${entry.toolCallId})`;
+}
+
+function isSteerable(entry: GremlinTranscriptEntry | null): boolean {
+	return entry?.status === "starting" || entry?.status === "active";
+}
+
+export function createGremlinOpenCommandHandler(
+	store: GremlinSessionTranscriptStore,
+	registry: ActiveGremlinSessionRegistry,
+): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
+	const runtime = createRuntime();
+
+	function requestRender(): void {
+		runtime.requestOverlayRender?.();
+	}
+
+	function selectEntry(entry: GremlinTranscriptEntry): void {
+		runtime.selectedEntry = entry;
+		requestRender();
+	}
+
+	function resolveEntry(args: string, ctx: ExtensionCommandContext): GremlinTranscriptEntry | null {
+		const gremlinId = parseGremlinOpenArgs(args);
+		if (!gremlinId) {
+			const known = store.listGremlinTranscripts();
+			if (known.length === 0) {
+				ctx.ui?.notify?.("No known gremlin sessions to open yet.", "warning");
+				return null;
+			}
+			if (known.length === 1) return known[0]!;
+			ctx.ui?.notify?.(
+				`Multiple gremlin sessions are known; use /gremlins:open <G-id>. Known: ${known.map(describeEntry).join(", ")}`,
+				"warning",
+			);
+			return null;
+		}
+
+		const resolved = store.resolveGremlinTranscript(gremlinId);
+		if (resolved.status === "missing") {
+			ctx.ui?.notify?.(`No known gremlin session found for ${gremlinId}.`, "warning");
+			return null;
+		}
+		if (resolved.status === "ambiguous") {
+			ctx.ui?.notify?.(
+				`Ambiguous gremlin id ${gremlinId}; ${resolved.matches.length} sessions share that id: ${resolved.matches.map(describeEntry).join(", ")}`,
+				"warning",
+			);
+			return null;
+		}
+		return resolved.entry;
+	}
+
+	async function submitSteering(ctx: ExtensionCommandContext, message: string): Promise<void> {
+		const entry = runtime.selectedEntry;
+		if (!entry) return;
+		if (!isSteerable(entry)) {
+			store.recordStatus({
+				gremlinId: entry.gremlinId,
+				toolCallId: entry.toolCallId,
+				text: `steering unavailable: gremlin is ${entry.status}`,
+				status: "idle",
+			});
+			requestRender();
+			return;
+		}
+		const resolved = registry.resolveActiveGremlinSession(entry.gremlinId);
+		if (resolved.status === "missing") {
+			store.recordStatus({
+				gremlinId: entry.gremlinId,
+				toolCallId: entry.toolCallId,
+				text: "steering unavailable: active session is gone",
+				status: "idle",
+			});
+			requestRender();
+			return;
+		}
+		if (resolved.status === "ambiguous") {
+			store.recordStatus({
+				gremlinId: entry.gremlinId,
+				toolCallId: entry.toolCallId,
+				text: `steering rejected: ambiguous active gremlin id (${resolved.matches.length} matches)`,
+				status: "idle",
+			});
+			requestRender();
+			return;
+		}
+		try {
+			await resolved.entry.session.steer(message);
+			resolved.entry.recordSteeringEvent?.({ status: "queued", message });
+			store.recordStatus({
+				gremlinId: entry.gremlinId,
+				toolCallId: entry.toolCallId,
+				text: `you steered: ${message}`,
+				status: "thinking",
+			});
+		} catch (error) {
+			const messageText = error instanceof Error ? error.message : String(error);
+			resolved.entry.recordSteeringEvent?.({
+				status: "rejected",
+				message,
+				errorMessage: messageText,
+			});
+			store.recordStatus({
+				gremlinId: entry.gremlinId,
+				toolCallId: entry.toolCallId,
+				text: `steering rejected: ${messageText}`,
+				status: "error",
+			});
+		}
+		requestRender();
+	}
+
+	function ensureOverlay(ctx: ExtensionCommandContext): void {
+		if (!ctx.hasUI || !ctx.ui?.custom) {
+			ctx.ui?.notify?.("Gremlin session overlay requires interactive UI.", "warning");
+			return;
+		}
+		if (runtime.overlayHandle) {
+			runtime.overlayHandle.setHidden(false);
+			runtime.overlayHandle.focus();
+			requestRender();
+			return;
+		}
+		const controller: SideChatOverlayController = {
+			getMode: () => "gremlin",
+			getTranscriptState: () => runtime.selectedEntry?.transcript ?? { rows: [], status: "idle", lastAssistantText: "" },
+			getDraft: () => runtime.draft,
+			setDraft: (value) => {
+				runtime.draft = value;
+			},
+			submitDraft: (value) => {
+				runtime.draft = "";
+				void submitSteering(ctx, value);
+			},
+			close: () => {
+				runtime.overlayHandle?.setHidden(true);
+			},
+			getHeaderText: () => {
+				const entry = runtime.selectedEntry;
+				if (!entry) return "🧌 gremlin │ no session selected │ Esc closes";
+				const steerStatus = isSteerable(entry) ? "steering enabled" : "read-only";
+				return `🧌 ${entry.gremlinId} · ${entry.agent} │ ${entry.status} │ ${steerStatus} │ Enter steers · Esc closes`;
+			},
+			getInputLabel: () => (isSteerable(runtime.selectedEntry) ? "steer ›" : "read-only ›"),
+			getEmptyText: () => "No transcript rows captured for this gremlin yet.",
+		};
+		runtime.unsubscribeStore = store.subscribe(requestRender);
+		runtime.overlayPromise = ctx.ui.custom<void>(
+			(tui, _theme, _keybindings, done) => {
+				runtime.requestOverlayRender = () => tui.requestRender();
+				return new SideChatOverlayComponent(tui, controller, done);
+			},
+			{
+				overlay: true,
+				overlayOptions: SIDE_CHAT_OVERLAY_OPTIONS,
+				onHandle: (handle) => {
+					runtime.overlayHandle = handle;
+					handle.focus();
+				},
+			},
+		);
+		runtime.overlayPromise.finally(() => {
+			runtime.overlayHandle = null;
+			runtime.overlayPromise = null;
+			runtime.requestOverlayRender = null;
+			runtime.unsubscribeStore?.();
+			runtime.unsubscribeStore = null;
+		});
+	}
+
+	return async (args, ctx) => {
+		const entry = resolveEntry(args, ctx);
+		if (!entry) return;
+		selectEntry(entry);
+		ensureOverlay(ctx);
+		requestRender();
+	};
+}

--- a/extensions/pi-gremlins/gremlins/gremlin-runner.ts
+++ b/extensions/pi-gremlins/gremlins/gremlin-runner.ts
@@ -21,6 +21,7 @@ import type {
 	ActiveGremlinSessionRegistry,
 	ActiveGremlinSteeringEvent,
 } from "./gremlin-session-registry.js";
+import type { GremlinSessionTranscriptStore } from "./gremlin-session-transcript-store.js";
 
 export interface GremlinRunnerUpdate {
 	gremlinId: string;
@@ -81,6 +82,7 @@ export interface RunSingleGremlinOptions {
 	signal?: AbortSignal;
 	onUpdate?: (update: GremlinRunnerUpdate) => void;
 	activeSessionRegistry?: ActiveGremlinSessionRegistry;
+	transcriptStore?: GremlinSessionTranscriptStore;
 	createSession?: (
 		options: Parameters<typeof createGremlinSession>[0],
 	) => Promise<CreateAgentSessionResult>;
@@ -186,8 +188,10 @@ function createActivityRecorder(state: GremlinRunResult) {
 
 function createGremlinPublisher(
 	gremlinId: string,
+	toolCallId: string,
 	state: GremlinRunResult,
 	onUpdate?: (update: GremlinRunnerUpdate) => void,
+	transcriptStore?: GremlinSessionTranscriptStore,
 ): PublishGremlinPatch {
 	const addActivity = createActivityRecorder(state);
 	return (patch, activity) => {
@@ -195,6 +199,9 @@ function createGremlinPublisher(
 			? { ...patch, activities: addActivity(activity) }
 			: patch;
 		Object.assign(state, nextPatch, { revision: (state.revision ?? 0) + 1 });
+		if (nextPatch.status) {
+			transcriptStore?.updateSession({ gremlinId, toolCallId, status: nextPatch.status });
+		}
 		onUpdate?.({ gremlinId, patch: { ...nextPatch, revision: state.revision } });
 	};
 }
@@ -351,10 +358,23 @@ export async function runSingleGremlin({
 	signal,
 	onUpdate,
 	activeSessionRegistry,
+	transcriptStore,
 	createSession = createGremlinSession,
 }: RunSingleGremlinOptions): Promise<GremlinRunResult> {
 	const state = buildBaseResult(gremlinId, request, definition);
-	const publish = createGremlinPublisher(gremlinId, state, onUpdate);
+	transcriptStore?.upsertSession({
+		gremlinId,
+		toolCallId,
+		agent: request.agent,
+		status: state.status,
+	});
+	const publish = createGremlinPublisher(
+		gremlinId,
+		toolCallId,
+		state,
+		onUpdate,
+		transcriptStore,
+	);
 	const textDeltaPublisher = createTextDeltaPublisher(state, publish);
 
 	if (signal?.aborted) {
@@ -454,6 +474,7 @@ export async function runSingleGremlin({
 			},
 		});
 		unsubscribe = session.subscribe?.((event: GremlinEvent) => {
+			transcriptStore?.recordEvent({ gremlinId, toolCallId, event });
 			projectGremlinEvent(event, state, session, publish, textDeltaPublisher);
 		});
 		signal?.addEventListener("abort", abortListener, { once: true });

--- a/extensions/pi-gremlins/gremlins/gremlin-session-transcript-store.ts
+++ b/extensions/pi-gremlins/gremlins/gremlin-session-transcript-store.ts
@@ -1,0 +1,238 @@
+import type { SideChatTranscriptRow, SideChatTranscriptState } from "../side-chat/side-chat-transcript-state.js";
+import { extractTextFromContent } from "../shared/gremlin-content-utils.js";
+import type { GremlinStatus } from "../shared/gremlin-schema.js";
+
+export interface GremlinTranscriptEvent {
+	type?: string;
+	assistantMessageEvent?: { type?: string; delta?: unknown };
+	message?: { role?: unknown; content?: unknown };
+	toolName?: unknown;
+	isError?: boolean;
+}
+
+export interface GremlinTranscriptEntry {
+	readonly key: string;
+	readonly gremlinId: string;
+	readonly normalizedGremlinId: string;
+	readonly toolCallId: string;
+	readonly agent: string;
+	readonly createdAt: number;
+	status: GremlinStatus;
+	transcript: SideChatTranscriptState;
+}
+
+export type ResolveGremlinTranscriptResult =
+	| { status: "missing" }
+	| { status: "ambiguous"; matches: readonly GremlinTranscriptEntry[] }
+	| { status: "found"; entry: GremlinTranscriptEntry };
+
+export interface GremlinSessionTranscriptStore {
+	upsertSession(input: {
+		gremlinId: string;
+		toolCallId: string;
+		agent: string;
+		status?: GremlinStatus;
+	}): GremlinTranscriptEntry;
+	updateSession(input: {
+		gremlinId: string;
+		toolCallId: string;
+		status?: GremlinStatus;
+	}): GremlinTranscriptEntry | undefined;
+	recordEvent(input: {
+		gremlinId: string;
+		toolCallId: string;
+		event: GremlinTranscriptEvent;
+	}): GremlinTranscriptEntry | undefined;
+	recordStatus(input: {
+		gremlinId: string;
+		toolCallId: string;
+		text: string;
+		status?: SideChatTranscriptState["status"];
+	}): GremlinTranscriptEntry | undefined;
+	resolveGremlinTranscript(gremlinId: string): ResolveGremlinTranscriptResult;
+	listGremlinTranscripts(): readonly GremlinTranscriptEntry[];
+	subscribe(listener: () => void): () => void;
+	clearGremlinTranscripts(): void;
+}
+
+function normalizeGremlinId(gremlinId: string): string {
+	return gremlinId.trim().toLowerCase();
+}
+
+function createKey(toolCallId: string, gremlinId: string): string {
+	return `${toolCallId}:${normalizeGremlinId(gremlinId)}`;
+}
+
+function createTranscriptState(rows: SideChatTranscriptRow[] = []): SideChatTranscriptState {
+	return { rows, status: "idle", lastAssistantText: "" };
+}
+
+function normalizeToolName(toolName: unknown): string {
+	return typeof toolName === "string" && toolName.trim() ? toolName.trim() : "tool";
+}
+
+function reduceGremlinTranscriptEvent(
+	state: SideChatTranscriptState,
+	event: GremlinTranscriptEvent,
+): SideChatTranscriptState {
+	if (!event || typeof event !== "object") return state;
+	switch (event.type) {
+		case "turn_start":
+			return {
+				...state,
+				status: "thinking",
+				error: undefined,
+				rows: [...state.rows, { type: "turn-boundary", phase: "start" }],
+			};
+		case "turn_end":
+			return {
+				...state,
+				status: "idle",
+				rows: [...state.rows, { type: "turn-boundary", phase: "end" }],
+			};
+		case "message_start":
+			return {
+				...state,
+				status: "replying",
+				lastAssistantText: "",
+				rows: [...state.rows, { type: "assistant-text", text: "", streaming: true }],
+			};
+		case "message_update": {
+			if (event.assistantMessageEvent?.type !== "text_delta") return state;
+			const delta = event.assistantMessageEvent.delta;
+			if (typeof delta !== "string" || delta.length === 0) return state;
+			const rows = [...state.rows];
+			const last = rows[rows.length - 1];
+			if (last?.type === "assistant-text" && last.streaming) {
+				rows[rows.length - 1] = { ...last, text: last.text + delta };
+			} else {
+				rows.push({ type: "assistant-text", text: delta, streaming: true });
+			}
+			return {
+				...state,
+				status: "replying",
+				lastAssistantText: state.lastAssistantText + delta,
+				rows,
+			};
+		}
+		case "message_end": {
+			const text = extractTextFromContent(event.message?.content).trim();
+			const finalText = text || state.lastAssistantText;
+			const rows = [...state.rows];
+			const last = rows[rows.length - 1];
+			if (last?.type === "assistant-text") {
+				rows[rows.length - 1] = { ...last, text: finalText || last.text, streaming: false };
+			} else if (finalText) {
+				rows.push({ type: "assistant-text", text: finalText, streaming: false });
+			}
+			return { ...state, status: "idle", lastAssistantText: finalText, rows };
+		}
+		case "tool_execution_start":
+			return {
+				...state,
+				status: "tool",
+				rows: [...state.rows, { type: "status", text: `running tool: ${normalizeToolName(event.toolName)}` }],
+			};
+		case "tool_execution_end":
+			return {
+				...state,
+				status: event.isError ? "error" : "replying",
+				rows: [...state.rows, { type: "status", text: `${normalizeToolName(event.toolName)} ${event.isError ? "failed" : "finished"}` }],
+			};
+		default:
+			return state;
+	}
+}
+
+export function createGremlinSessionTranscriptStore(): GremlinSessionTranscriptStore {
+	const entries = new Map<string, GremlinTranscriptEntry>();
+	const listeners = new Set<() => void>();
+
+	function notify(): void {
+		for (const listener of listeners) listener();
+	}
+
+	function get(gremlinId: string, toolCallId: string): GremlinTranscriptEntry | undefined {
+		return entries.get(createKey(toolCallId, gremlinId));
+	}
+
+	return {
+		upsertSession(input) {
+			const key = createKey(input.toolCallId, input.gremlinId);
+			let entry = entries.get(key);
+			if (!entry) {
+				entry = {
+					key,
+					gremlinId: input.gremlinId,
+					normalizedGremlinId: normalizeGremlinId(input.gremlinId),
+					toolCallId: input.toolCallId,
+					agent: input.agent,
+					status: input.status ?? "starting",
+					createdAt: Date.now(),
+					transcript: createTranscriptState([{ type: "status", text: `opened ${input.gremlinId} (${input.agent})` }]),
+				};
+				entries.set(key, entry);
+			} else {
+				entry.status = input.status ?? entry.status;
+			}
+			notify();
+			return entry;
+		},
+
+		updateSession(input) {
+			const entry = get(input.gremlinId, input.toolCallId);
+			if (entry && input.status) {
+				entry.status = input.status;
+				notify();
+			}
+			return entry;
+		},
+
+		recordEvent(input) {
+			const entry = get(input.gremlinId, input.toolCallId);
+			if (!entry) return undefined;
+			entry.transcript = reduceGremlinTranscriptEvent(entry.transcript, input.event);
+			notify();
+			return entry;
+		},
+
+		recordStatus(input) {
+			const entry = get(input.gremlinId, input.toolCallId);
+			if (!entry) return undefined;
+			entry.transcript = {
+				...entry.transcript,
+				status: input.status ?? entry.transcript.status,
+				rows: [...entry.transcript.rows, { type: "status", text: input.text }],
+			};
+			notify();
+			return entry;
+		},
+
+		resolveGremlinTranscript(gremlinId) {
+			const normalizedGremlinId = normalizeGremlinId(gremlinId);
+			if (!normalizedGremlinId) return { status: "missing" };
+			const matches = [...entries.values()].filter(
+				(entry) => entry.normalizedGremlinId === normalizedGremlinId,
+			);
+			if (matches.length === 0) return { status: "missing" };
+			if (matches.length > 1) return { status: "ambiguous", matches };
+			return { status: "found", entry: matches[0]! };
+		},
+
+		listGremlinTranscripts() {
+			return [...entries.values()].sort((left, right) => right.createdAt - left.createdAt);
+		},
+
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+
+		clearGremlinTranscripts() {
+			entries.clear();
+			notify();
+		},
+	};
+}

--- a/extensions/pi-gremlins/gremlins/gremlin-tool-execution.ts
+++ b/extensions/pi-gremlins/gremlins/gremlin-tool-execution.ts
@@ -18,6 +18,7 @@ import type {
 } from "../shared/gremlin-schema.js";
 import { runGremlinBatch } from "./gremlin-scheduler.js";
 import type { ActiveGremlinSessionRegistry } from "./gremlin-session-registry.js";
+import type { GremlinSessionTranscriptStore } from "./gremlin-session-transcript-store.js";
 import { buildGremlinProgressSummary } from "./gremlin-summary.js";
 
 export type PiGremlinsArgs = { gremlins: GremlinRequest[] };
@@ -33,6 +34,7 @@ export interface ExecutePiGremlinsToolOptions {
 	ctx: ExtensionContext;
 	discovery: GremlinDiscoveryCache;
 	activeSessionRegistry?: ActiveGremlinSessionRegistry;
+	transcriptStore?: GremlinSessionTranscriptStore;
 	notifyDiagnostics: (diagnostics: AgentDiscoveryDiagnostic[]) => void;
 }
 
@@ -138,6 +140,7 @@ export async function executePiGremlinsTool({
 	ctx,
 	discovery,
 	activeSessionRegistry,
+	transcriptStore,
 	notifyDiagnostics,
 }: ExecutePiGremlinsToolOptions): Promise<PiGremlinsToolResult> {
 	if (!Array.isArray(params.gremlins) || params.gremlins.length === 0) {
@@ -192,6 +195,7 @@ export async function executePiGremlinsTool({
 				modelRegistry: ctx.modelRegistry,
 				signal: childSignal,
 				activeSessionRegistry,
+				transcriptStore,
 				onUpdate: ({ patch }) => publishUpdate?.(patch),
 			});
 		},

--- a/extensions/pi-gremlins/index.ts
+++ b/extensions/pi-gremlins/index.ts
@@ -32,6 +32,11 @@ import {
 } from "./gremlins/gremlin-tool-execution.js";
 import { createActiveGremlinSessionRegistry } from "./gremlins/gremlin-session-registry.js";
 import {
+	createGremlinOpenCommandHandler,
+	GREMLIN_OPEN_COMMAND,
+} from "./gremlins/gremlin-open-command.js";
+import { createGremlinSessionTranscriptStore } from "./gremlins/gremlin-session-transcript-store.js";
+import {
 	createGremlinSteerCommandHandler,
 	GREMLIN_STEER_COMMAND,
 } from "./gremlins/gremlin-steer-command.js";
@@ -108,6 +113,7 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 			});
 		let primaryAgentState: PrimaryAgentState = createInitialPrimaryAgentState();
 		const activeSessionRegistry = createActiveGremlinSessionRegistry();
+		const transcriptStore = createGremlinSessionTranscriptStore();
 
 		registerSideChatCommands(pi);
 
@@ -145,6 +151,7 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 			discovery.clear();
 			primaryAgentDiscovery.clear();
 			activeSessionRegistry.clearActiveGremlinSessions();
+			transcriptStore.clearGremlinTranscripts();
 		});
 
 		pi.registerCommand("gremlins:primary", {
@@ -163,6 +170,11 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 		pi.registerCommand(GREMLIN_STEER_COMMAND, {
 			description: "Steer an active gremlin child session",
 			handler: createGremlinSteerCommandHandler(activeSessionRegistry),
+		});
+
+		pi.registerCommand(GREMLIN_OPEN_COMMAND, {
+			description: "Open an overlay for an active or completed gremlin session transcript",
+			handler: createGremlinOpenCommandHandler(transcriptStore, activeSessionRegistry),
 		});
 
 		pi.registerShortcut(PRIMARY_SHORTCUT, {
@@ -237,6 +249,7 @@ export function createPiGremlinsExtension(options: PiGremlinsExtensionOptions = 
 					ctx,
 					discovery,
 					activeSessionRegistry,
+					transcriptStore,
 					notifyDiagnostics: (diagnostics) =>
 						notifyDiscoveryDiagnostics(ctx, diagnostics),
 				});

--- a/extensions/pi-gremlins/side-chat/side-chat-overlay.ts
+++ b/extensions/pi-gremlins/side-chat/side-chat-overlay.ts
@@ -34,12 +34,15 @@ export const SIDE_CHAT_OVERLAY_OPTIONS: OverlayOptions = {
 };
 
 export interface SideChatOverlayController {
-	getMode(): SideChatMode;
+	getMode(): SideChatMode | "gremlin";
 	getTranscriptState(): SideChatTranscriptState;
 	getDraft(): string;
 	setDraft(value: string): void;
 	submitDraft(value: string): void;
 	close(): void;
+	getHeaderText?(): string;
+	getInputLabel?(): string;
+	getEmptyText?(): string;
 }
 
 export class SideChatOverlayComponent implements Component {
@@ -67,13 +70,15 @@ export class SideChatOverlayComponent implements Component {
 			innerWidth,
 			bodyHeight,
 		);
+		const headerText = this.controller.getHeaderText?.() ?? `${mode === "chat" ? "💬 chat" : mode === "tangent" ? "🧭 tangent" : "🧌 gremlin"} │ ${formatStatus(state.status)} │ Enter submits · Esc closes · Alt+/ focuses`;
+		const inputLabel = this.controller.getInputLabel?.() ?? "›";
 		const contentLines = [
 			"",
-			`${mode === "chat" ? "💬 chat" : "🧭 tangent"} │ ${formatStatus(state.status)} │ Enter submits · Esc closes · Alt+/ focuses`,
+			headerText,
 			"─".repeat(innerWidth),
 			...bodyLines,
 			"",
-			`› ${draft}${this.focused ? CURSOR_MARKER : ""}`,
+			`${inputLabel} ${draft}${this.focused ? CURSOR_MARKER : ""}`,
 			"Scroll: ↑/↓ PgUp/PgDn Home/End",
 			"",
 		];
@@ -155,7 +160,7 @@ export class SideChatOverlayComponent implements Component {
 		height: number,
 	): string[] {
 		const transcriptLines = rows.length === 0
-			? new Text("No side-chat messages yet.", 0, 0).render(width)
+			? new Text(this.controller.getEmptyText?.() ?? "No side-chat messages yet.", 0, 0).render(width)
 			: rows.flatMap((row) => this.renderRow(row, width));
 		const maxOffset = Math.max(0, transcriptLines.length - height);
 		const offset = Math.min(this.scrollOffset, maxOffset);

--- a/extensions/pi-gremlins/test/gremlins/gremlin-open-command.test.js
+++ b/extensions/pi-gremlins/test/gremlins/gremlin-open-command.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import "../fixtures/v1-contract-harness.js";
+
+function createRegistry(resolveResult) {
+	return {
+		resolveCalls: [],
+		resolveActiveGremlinSession(gremlinId) {
+			this.resolveCalls.push(gremlinId);
+			return typeof resolveResult === "function" ? resolveResult(gremlinId) : resolveResult;
+		},
+		registerActiveGremlinSession() { throw new Error("not used"); },
+		unregisterActiveGremlinSession() { throw new Error("not used"); },
+		clearActiveGremlinSessions() {},
+	};
+}
+
+function createCtx() {
+	const notifications = [];
+	const handles = [];
+	const components = [];
+	return {
+		notifications,
+		handles,
+		components,
+		hasUI: true,
+		ui: {
+			notify(message, type = "info") { notifications.push({ message, type }); },
+			custom(factory, options) {
+				const handle = {
+					hidden: false,
+					focused: false,
+					setHidden(value) { this.hidden = value; },
+					focus() { this.focused = true; },
+					isFocused() { return this.focused; },
+					unfocus() { this.focused = false; },
+					hide() { this.hidden = true; },
+				};
+				options.onHandle(handle);
+				handles.push(handle);
+				components.push(factory({ requestRender() {}, terminal: { rows: 30 } }, {}, {}, () => {}));
+				return new Promise(() => {});
+			},
+		},
+	};
+}
+
+describe("gremlin open command", () => {
+	test("opens the only known gremlin when no id is supplied", async () => {
+		const { createGremlinOpenCommandHandler } = await import("../../gremlins/gremlin-open-command.ts");
+		const { createGremlinSessionTranscriptStore } = await import("../../gremlins/gremlin-session-transcript-store.ts");
+		const store = createGremlinSessionTranscriptStore();
+		store.upsertSession({ gremlinId: "g1", toolCallId: "tool-a", agent: "researcher", status: "completed" });
+		store.recordStatus({ gremlinId: "g1", toolCallId: "tool-a", text: "done" });
+		const ctx = createCtx();
+		await createGremlinOpenCommandHandler(store, createRegistry({ status: "missing" }))("", ctx);
+
+		expect(ctx.notifications).toEqual([]);
+		expect(ctx.handles[0].focused).toBe(true);
+		const rendered = ctx.components[0].render(90).join("\n");
+		expect(rendered).toContain("g1 · researcher");
+		expect(rendered).toContain("read-only");
+		expect(rendered).toContain("done");
+	});
+
+	test("no-arg open warns instead of guessing when multiple gremlins are known", async () => {
+		const { createGremlinOpenCommandHandler } = await import("../../gremlins/gremlin-open-command.ts");
+		const { createGremlinSessionTranscriptStore } = await import("../../gremlins/gremlin-session-transcript-store.ts");
+		const store = createGremlinSessionTranscriptStore();
+		store.upsertSession({ gremlinId: "g1", toolCallId: "tool-a", agent: "a" });
+		store.upsertSession({ gremlinId: "g2", toolCallId: "tool-a", agent: "b" });
+		const ctx = createCtx();
+		await createGremlinOpenCommandHandler(store, createRegistry({ status: "missing" }))("", ctx);
+		expect(ctx.notifications[0]).toMatchObject({ type: "warning" });
+		expect(ctx.notifications[0].message).toContain("Multiple gremlin sessions are known");
+		expect(ctx.handles).toEqual([]);
+	});
+
+	test("enter in active overlay steers through active session and records visible status", async () => {
+		const { createGremlinOpenCommandHandler } = await import("../../gremlins/gremlin-open-command.ts");
+		const { createGremlinSessionTranscriptStore } = await import("../../gremlins/gremlin-session-transcript-store.ts");
+		const store = createGremlinSessionTranscriptStore();
+		store.upsertSession({ gremlinId: "g1", toolCallId: "tool-a", agent: "researcher", status: "active" });
+		const steerMessages = [];
+		const steeringEvents = [];
+		const registry = createRegistry({
+			status: "active",
+			entry: {
+				gremlinId: "g1",
+				agent: "researcher",
+				session: { steer(message) { steerMessages.push(message); } },
+				recordSteeringEvent(event) { steeringEvents.push(event); },
+			},
+		});
+		const ctx = createCtx();
+		await createGremlinOpenCommandHandler(store, registry)("g1", ctx);
+		ctx.components[0].handleInput("g");
+		ctx.components[0].handleInput("o");
+		ctx.components[0].handleInput("\r");
+		await Promise.resolve();
+
+		expect(steerMessages).toEqual(["go"]);
+		expect(steeringEvents).toEqual([{ status: "queued", message: "go" }]);
+		expect(store.resolveGremlinTranscript("g1").entry.transcript.rows.at(-1)).toMatchObject({ text: "you steered: go" });
+	});
+});

--- a/extensions/pi-gremlins/test/gremlins/gremlin-session-transcript-store.test.js
+++ b/extensions/pi-gremlins/test/gremlins/gremlin-session-transcript-store.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+describe("gremlin session transcript store", () => {
+	test("captures full streaming transcript rows beyond activity-tail semantics", async () => {
+		const { createGremlinSessionTranscriptStore } = await import("../../gremlins/gremlin-session-transcript-store.ts");
+		const store = createGremlinSessionTranscriptStore();
+		store.upsertSession({ gremlinId: "g1", toolCallId: "tool-a", agent: "researcher" });
+		for (let index = 0; index < 15; index += 1) {
+			store.recordEvent({ gremlinId: "g1", toolCallId: "tool-a", event: { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: `chunk-${index} ` } } });
+		}
+		store.recordEvent({ gremlinId: "g1", toolCallId: "tool-a", event: { type: "message_end", message: { content: [{ type: "text", text: "final answer" }] } } });
+		store.updateSession({ gremlinId: "g1", toolCallId: "tool-a", status: "completed" });
+
+		const resolved = store.resolveGremlinTranscript("G1");
+		expect(resolved.status).toBe("found");
+		expect(resolved.entry.status).toBe("completed");
+		expect(resolved.entry.transcript.rows.at(-1)).toMatchObject({ type: "assistant-text", text: "final answer", streaming: false });
+	});
+
+	test("rejects duplicate local gremlin ids as ambiguous instead of guessing", async () => {
+		const { createGremlinSessionTranscriptStore } = await import("../../gremlins/gremlin-session-transcript-store.ts");
+		const store = createGremlinSessionTranscriptStore();
+		store.upsertSession({ gremlinId: "g1", toolCallId: "tool-a", agent: "a" });
+		store.upsertSession({ gremlinId: "G1", toolCallId: "tool-b", agent: "b" });
+		expect(store.resolveGremlinTranscript("g1")).toMatchObject({ status: "ambiguous" });
+	});
+
+	test("tool transcript status omits args so sensitive values are not rendered", async () => {
+		const { createGremlinSessionTranscriptStore } = await import("../../gremlins/gremlin-session-transcript-store.ts");
+		const store = createGremlinSessionTranscriptStore();
+		store.upsertSession({ gremlinId: "g1", toolCallId: "tool-a", agent: "researcher" });
+		store.recordEvent({ gremlinId: "g1", toolCallId: "tool-a", event: { type: "tool_execution_start", toolName: "bash", args: { command: "echo token=secret123" } } });
+		const text = store.resolveGremlinTranscript("g1").entry.transcript.rows.map((row) => row.text ?? "").join("\n");
+		expect(text).toContain("running tool: bash");
+		expect(text).not.toContain("secret123");
+	});
+});

--- a/extensions/pi-gremlins/test/rendering/index.execute.test.js
+++ b/extensions/pi-gremlins/test/rendering/index.execute.test.js
@@ -35,13 +35,14 @@ describe("pi-gremlins index execute v1", () => {
 		resetV1ContractHarness();
 	});
 
-	test("registers tool plus primary-agent compatibility commands with official steering but no legacy viewer", () => {
+	test("registers tool plus primary-agent compatibility commands with official steering and session open but no legacy viewer", () => {
 		const { tool, commands, shortcuts } = createExtensionHarness();
 
 		expect(tool.name).toBe("pi-gremlins");
-		expect(commands.size).toBe(6);
+		expect(commands.size).toBe(7);
 		expect(commands.has("gremlins:primary")).toBe(true);
 		expect(commands.has("gremlins:steer")).toBe(true);
+		expect(commands.has("gremlins:open")).toBe(true);
 		expect(commands.has("gremlins:chat")).toBe(true);
 		expect(commands.has("gremlins:chat:new")).toBe(true);
 		expect(commands.has("gremlins:tangent")).toBe(true);


### PR DESCRIPTION
## Summary
- Adds /gremlins:open to inspect captured active or completed gremlin session transcripts in the side-chat-style overlay.
- Captures full in-memory gremlin transcript rows during runner execution and live-invalidates the overlay.
- Steers active gremlins from the overlay via AgentSession.steer(message), with visible rejection/status rows for terminal, stale, or ambiguous sessions.
- Updates README, CHANGELOG, and focused command/store tests.

## Verification
- npm run typecheck
- npm test
- npm run check

Closes #77