### PR TITLE
Fix inline sub-agent separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pi-gremlins` maintainability improved by extracting shared cache helpers, tool execution flow, and gremlin runner event projection into smaller focused modules/functions without changing the public tool contract.
 
 ### Fixed
+- **Inline sub-agent separation** (issue #79): collapsed inline gremlin summaries now insert clear gaps between concurrent sub-agent entries and preserve each entry's status/id visibility.
 - **Inline gremlin session metadata** (issue #75): collapsed inline gremlin summaries now show compact model and thinking metadata when available while omitting missing values gracefully.
 - **Sub-agent inline usage cost formatting** (issue #65): gremlin inline usage summaries now render finite costs with a `$` marker and stable precision instead of raw floating-point decimals.
 - **Expanded inline subagent output** (issue #66): expanded gremlin inline details now show the full available subagent output instead of clipping expanded text fields to a short preview.

--- a/extensions/pi-gremlins/rendering/gremlin-rendering.ts
+++ b/extensions/pi-gremlins/rendering/gremlin-rendering.ts
@@ -129,9 +129,10 @@ function buildCollapsedText(details: GremlinInvocationDetails, width?: number): 
 	if (details.gremlins.length === 0) {
 		segments.push(getStaticRenderSegment("No gremlins requested.", width));
 	} else {
-		for (const entry of details.gremlins) {
+		details.gremlins.forEach((entry, index) => {
+			if (index > 0) segments.push("");
 			segments.push(getCollapsedEntrySegment(entry, width));
-		}
+		});
 	}
 	segments.push(getStaticRenderSegment("Ctrl+O expands inline detail.", width));
 	return segments.join("\n");

--- a/extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js
+++ b/extensions/pi-gremlins/test/rendering/gremlin-rendering.test.js
@@ -160,6 +160,45 @@ describe("gremlin rendering v1 contract", () => {
 		}
 	});
 
+	test("keeps collapsed inline entries separated with visible per-entry status and ids", async () => {
+		const {
+			GremlinInlineResultComponent,
+			renderGremlinInvocationText,
+		} = await import("../../rendering/gremlin-rendering.ts");
+
+		const details = {
+			requestedCount: 3,
+			activeCount: 3,
+			completedCount: 0,
+			failedCount: 0,
+			canceledCount: 0,
+			gremlins: Array.from({ length: 3 }, (_value, index) => ({
+				gremlinId: `g${index + 1}`,
+				agent: `worker-${index + 1}`,
+				source: "project",
+				status: "active",
+				intent: `Handle independent task ${index + 1}`,
+				context: `Context line one for worker ${index + 1}\nContext line two for worker ${index + 1}`,
+				currentPhase: "streaming",
+				latestText: `Latest active update for worker ${index + 1}`,
+				revision: index + 1,
+			})),
+			revision: 3,
+		};
+		const text = renderGremlinInvocationText(details, { expanded: false, width: 96 });
+		const lines = text.split("\n");
+
+		expect(lines).toContain("");
+		for (const id of ["g1", "g2", "g3"]) {
+			expect(text).toContain(`[Active] · ${id} worker-${id.slice(1)} [project]`);
+		}
+
+		const rendered = new GremlinInlineResultComponent(text, false).render(96).join("\n");
+		expect(rendered).toContain("[Active] · g1 worker-1 [project]");
+		expect(rendered).toContain("[Active] · g2 worker-2 [project]");
+		expect(rendered).toContain("[Active] · g3 worker-3 [project]");
+	});
+
 	test("keeps multiline collapsed activity previews on one visible line", async () => {
 		const { renderGremlinInvocationText } = await import(
 			"../../rendering/gremlin-rendering.ts"


### PR DESCRIPTION
## Summary
- Adds blank separation between collapsed inline gremlin entries so concurrent sub-agents are easier to scan.
- Covers 3 active inline sub-agents with status/id visibility assertions.
- Updates CHANGELOG.md for issue #79.

## Verification
- npm run check

Closes #79